### PR TITLE
request: use POST

### DIFF
--- a/request.go
+++ b/request.go
@@ -155,9 +155,10 @@ func (exo *Client) request(command string, params url.Values) (json.RawMessage, 
 	mac.Write([]byte(sign_string))
 	signature := csEncode(base64.StdEncoding.EncodeToString(mac.Sum(nil)))
 	query := params.Encode()
-	url := fmt.Sprintf("%s?%s&signature=%s", exo.endpoint, csQuotePlus(query), signature)
+	reader := strings.NewReader(fmt.Sprintf("%s&signature=%s", csQuotePlus(query), signature))
 
-	resp, err := exo.client.Get(url)
+	// Use PostForm?
+	resp, err := exo.client.Post(exo.endpoint, "application/x-www-form-urlencoded", reader)
 	if err != nil {
 		return nil, err
 	}

--- a/types.go
+++ b/types.go
@@ -38,7 +38,7 @@ type VirtualMachineProfile struct {
 	DiskSize        uint64
 	SecurityGroups  []string
 	Keypair         string
-	Userdata        string
+	UserData        string
 	ServiceOffering string
 	Template        string
 	Zone            string

--- a/vm.go
+++ b/vm.go
@@ -24,8 +24,8 @@ func (exo *Client) DeployVirtualMachine(p VirtualMachineProfile, async AsyncInfo
 	}
 
 	params.Set("displayname", p.Name)
-	if len(p.Userdata) > 0 {
-		params.Set("userdata", base64.StdEncoding.EncodeToString([]byte(p.Userdata)))
+	if len(p.UserData) > 0 {
+		params.Set("userdata", base64.StdEncoding.EncodeToString([]byte(p.UserData)))
 	}
 	if len(p.Keypair) > 0 {
 		params.Set("keypair", p.Keypair)


### PR DESCRIPTION
Sending large cloud-init  files is easier in POST.