### PR TITLE
security_groups: deletion returns success as a string

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -75,7 +75,7 @@ func (*DisassociateIPAddress) name() string {
 	return "disassociateIpAddress"
 }
 func (*DisassociateIPAddress) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // UpdateIPAddress (Async) represents the IP modification

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -24,7 +24,7 @@ func TestDisassociateIPAddress(t *testing.T) {
 	if req.name() != "disassociateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestListPublicIPAddresses(t *testing.T) {

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -90,7 +90,7 @@ func (req *DeleteAffinityGroup) name() string {
 }
 
 func (req *DeleteAffinityGroup) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ListAffinityGroups represents an (anti-)affinity groups search

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -25,7 +25,7 @@ func TestDeleteAffinityGroup(t *testing.T) {
 	if req.name() != "deleteAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestListAffinityGroups(t *testing.T) {

--- a/keypairs.go
+++ b/keypairs.go
@@ -48,7 +48,7 @@ func (req *DeleteSSHKeyPair) name() string {
 }
 
 func (req *DeleteSSHKeyPair) response() interface{} {
-	return new(BooleanResponse)
+	return new(booleanResponse)
 }
 
 // RegisterSSHKeyPair represents a new registration of a public key in a keypair

--- a/keypairs.go
+++ b/keypairs.go
@@ -48,7 +48,7 @@ func (req *DeleteSSHKeyPair) name() string {
 }
 
 func (req *DeleteSSHKeyPair) response() interface{} {
-	return new(booleanResponse)
+	return new(booleanSyncResponse)
 }
 
 // RegisterSSHKeyPair represents a new registration of a public key in a keypair

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -41,7 +41,7 @@ func TestDeleteSSHKeyPair(t *testing.T) {
 	if req.name() != "deleteSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*booleanResponse)
+	_ = req.response().(*booleanSyncResponse)
 }
 
 func TestListSSHKeyPairs(t *testing.T) {

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -41,7 +41,7 @@ func TestDeleteSSHKeyPair(t *testing.T) {
 	if req.name() != "deleteSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*BooleanResponse)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestListSSHKeyPairs(t *testing.T) {

--- a/networks.go
+++ b/networks.go
@@ -181,7 +181,7 @@ func (req *DeleteNetwork) name() string {
 }
 
 func (req *DeleteNetwork) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ListNetworks represents a query to a network

--- a/networks_test.go
+++ b/networks_test.go
@@ -49,5 +49,5 @@ func TestDeleteNetwork(t *testing.T) {
 	if req.name() != "deleteNetwork" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }

--- a/nics.go
+++ b/nics.go
@@ -83,7 +83,7 @@ func (req *RemoveIPFromNic) name() string {
 }
 
 func (req *RemoveIPFromNic) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ListNics lists the NIC of a VM

--- a/nics_test.go
+++ b/nics_test.go
@@ -23,7 +23,7 @@ func TestRemoveIPFromNic(t *testing.T) {
 	if req.name() != "removeIpFromNic" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestListNics(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -80,27 +80,27 @@ func (e *ErrorResponse) Error() string {
 	return fmt.Sprintf("API error %d (internal code: %d): %s", e.ErrorCode, e.CsErrorCode, e.ErrorText)
 }
 
-// BooleanResponse represents a boolean response (usually after a deletion)
-type BooleanResponse struct {
+// booleanAsyncResponse represents a boolean response (usually after a deletion)
+type booleanAsyncResponse struct {
 	Success     bool   `json:"success"`
 	DisplayText string `json:"diplaytext,omitempty"`
 }
 
 // Error formats a CloudStack job response into a standard error
-func (e *BooleanResponse) Error() error {
+func (e *booleanAsyncResponse) Error() error {
 	if e.Success {
 		return nil
 	}
 	return fmt.Errorf("API error: %s", e.DisplayText)
 }
 
-// XXX HACK Sync boolean call returns success as a string
-type booleanResponse struct {
+// booleanAsyncResponse represents a boolean response for sync calls
+type booleanSyncResponse struct {
 	Success     string `json:"success"`
 	DisplayText string `json:"displaytext,omitempty"`
 }
 
-func (e *booleanResponse) Error() error {
+func (e *booleanSyncResponse) Error() error {
 	if e.Success == "true" {
 		return nil
 	}
@@ -243,7 +243,7 @@ func (exo *Client) BooleanRequest(req Command) error {
 		return err
 	}
 
-	return resp.(*booleanResponse).Error()
+	return resp.(*booleanSyncResponse).Error()
 }
 
 // BooleanAsyncRequest performs a sync request on a boolean call
@@ -253,7 +253,7 @@ func (exo *Client) BooleanAsyncRequest(req AsyncCommand, async AsyncInfo) error 
 		return err
 	}
 
-	return resp.(*BooleanResponse).Error()
+	return resp.(*booleanAsyncResponse).Error()
 }
 
 // Request performs a sync request on a generic command

--- a/request.go
+++ b/request.go
@@ -76,8 +76,8 @@ type ErrorResponse struct {
 }
 
 // Error formats a CloudStack error into a standard error
-func (e *ErrorResponse) Error() error {
-	return fmt.Errorf("API error %d (internal code: %d): %s", e.ErrorCode, e.CsErrorCode, e.ErrorText)
+func (e *ErrorResponse) Error() string {
+	return fmt.Sprintf("API error %d (internal code: %d): %s", e.ErrorCode, e.CsErrorCode, e.ErrorText)
 }
 
 // BooleanResponse represents a boolean response (usually after a deletion)
@@ -155,7 +155,7 @@ func (exo *Client) parseResponse(resp *http.Response) (json.RawMessage, error) {
 		if err := json.Unmarshal(b, &e); err != nil {
 			return nil, err
 		}
-		return b, e.Error()
+		return b, &e
 	}
 	return b, nil
 }
@@ -205,7 +205,7 @@ func (exo *Client) AsyncRequest(req AsyncCommand, async AsyncInfo) (interface{},
 		if err := json.Unmarshal(*result.JobResult, &errorResponse); err != nil {
 			return nil, err
 		}
-		return errorResponse, errorResponse.Error()
+		return errorResponse, errorResponse
 	}
 
 	if result.JobStatus == PENDING {
@@ -216,7 +216,7 @@ func (exo *Client) AsyncRequest(req AsyncCommand, async AsyncInfo) (interface{},
 		if err := json.Unmarshal(*result.JobResult, errorResponse); err != nil {
 			return nil, err
 		}
-		return errorResponse, errorResponse.Error()
+		return errorResponse, errorResponse
 	}
 
 	return resp, nil
@@ -253,7 +253,7 @@ func (exo *Client) Request(req Command) (interface{}, error) {
 	if err := json.Unmarshal(body, resp); err != nil {
 		r := new(ErrorResponse)
 		if e := json.Unmarshal(body, &r); e != nil {
-			return r, r.Error()
+			return nil, r
 		}
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (exo *Client) Request(req Request, v interface{}) error {
 	if err := json.Unmarshal(resp, v); err != nil {
 		var r ErrorResponse
 		if e := json.Unmarshal(resp, &r); e == nil {
-			return r.Error()
+			return r
 		}
 		return err
 	}

--- a/request.go
+++ b/request.go
@@ -94,6 +94,20 @@ func (e *BooleanResponse) Error() error {
 	return fmt.Errorf("API error: %s", e.DisplayText)
 }
 
+// XXX HACK Sync boolean call returns success as a string
+type booleanResponse struct {
+	Success     string `json:"success"`
+	DisplayText string `json:"displaytext,omitempty"`
+}
+
+func (e *booleanResponse) Error() error {
+	if e.Success == "true" {
+		return nil
+	}
+
+	return fmt.Errorf("API error: %s", e.DisplayText)
+}
+
 // AsyncInfo represents the details for any async call
 //
 // It retries at most Retries time and waits for Delay between each retry
@@ -229,7 +243,7 @@ func (exo *Client) BooleanRequest(req Command) error {
 		return err
 	}
 
-	return resp.(*BooleanResponse).Error()
+	return resp.(*booleanResponse).Error()
 }
 
 // BooleanAsyncRequest performs a sync request on a boolean call

--- a/security_groups.go
+++ b/security_groups.go
@@ -92,7 +92,7 @@ func (req *DeleteSecurityGroup) name() string {
 }
 
 func (req *DeleteSecurityGroup) response() interface{} {
-	return new(booleanResponse)
+	return new(booleanSyncResponse)
 }
 
 // AuthorizeSecurityGroupIngress (Async) represents the ingress rule creation
@@ -168,7 +168,7 @@ func (req *RevokeSecurityGroupIngress) name() string {
 }
 
 func (req *RevokeSecurityGroupIngress) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // RevokeSecurityGroupEgress (Async) represents the ingress/egress rule deletion
@@ -183,7 +183,7 @@ func (req *RevokeSecurityGroupEgress) name() string {
 }
 
 func (req *RevokeSecurityGroupEgress) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ListSecurityGroups represents a search for security groups

--- a/security_groups.go
+++ b/security_groups.go
@@ -92,13 +92,7 @@ func (req *DeleteSecurityGroup) name() string {
 }
 
 func (req *DeleteSecurityGroup) response() interface{} {
-	return new(DeleteSecurityGroupResponse)
-}
-
-// DeleteSecurityGroupResponse fixes the fact that it serializes the bool as a string...
-type DeleteSecurityGroupResponse struct {
-	Success     string `json:"success"`
-	DisplayText string `json:"displaytext,omitempty"`
+	return new(booleanResponse)
 }
 
 // AuthorizeSecurityGroupIngress (Async) represents the ingress rule creation

--- a/security_groups.go
+++ b/security_groups.go
@@ -92,7 +92,13 @@ func (req *DeleteSecurityGroup) name() string {
 }
 
 func (req *DeleteSecurityGroup) response() interface{} {
-	return new(BooleanResponse)
+	return new(DeleteSecurityGroupResponse)
+}
+
+// DeleteSecurityGroupResponse fixes the fact that it serializes the bool as a string...
+type DeleteSecurityGroupResponse struct {
+	Success     string `json:"success"`
+	DisplayText string `json:"displaytext,omitempty"`
 }
 
 // AuthorizeSecurityGroupIngress (Async) represents the ingress rule creation

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -45,7 +45,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 	if req.name() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*BooleanResponse)
+	_ = req.response().(*DeleteSecurityGroupResponse)
 }
 
 func TestListSecurityGroups(t *testing.T) {

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -45,7 +45,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 	if req.name() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*booleanResponse)
+	_ = req.response().(*booleanSyncResponse)
 }
 
 func TestListSecurityGroups(t *testing.T) {
@@ -61,7 +61,7 @@ func TestRevokeSecurityGroupEgress(t *testing.T) {
 	if req.name() != "revokeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestRevokeSecurityGroupIngress(t *testing.T) {
@@ -69,5 +69,5 @@ func TestRevokeSecurityGroupIngress(t *testing.T) {
 	if req.name() != "revokeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -45,7 +45,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 	if req.name() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*DeleteSecurityGroupResponse)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestListSecurityGroups(t *testing.T) {

--- a/snapshots.go
+++ b/snapshots.go
@@ -96,7 +96,7 @@ func (req *DeleteSnapshot) name() string {
 }
 
 func (req *DeleteSnapshot) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // RevertSnapshot revert a volume snapshot
@@ -111,5 +111,5 @@ func (req *RevertSnapshot) name() string {
 }
 
 func (req *RevertSnapshot) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -32,7 +32,7 @@ func TestDeleteSnapshot(t *testing.T) {
 	if req.name() != "deleteSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestRevertSnapshot(t *testing.T) {
@@ -40,5 +40,5 @@ func TestRevertSnapshot(t *testing.T) {
 	if req.name() != "revertSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }

--- a/tags.go
+++ b/tags.go
@@ -31,7 +31,7 @@ func (req *CreateTags) name() string {
 }
 
 func (req *CreateTags) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // DeleteTags (Async) deletes the resource tag(s)
@@ -48,7 +48,7 @@ func (req *DeleteTags) name() string {
 }
 
 func (req *DeleteTags) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ListTags list resource tag(s)

--- a/tags_test.go
+++ b/tags_test.go
@@ -15,7 +15,7 @@ func TestCreateTags(t *testing.T) {
 	if req.name() != "createTags" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestDeleteTags(t *testing.T) {
@@ -23,7 +23,7 @@ func TestDeleteTags(t *testing.T) {
 	if req.name() != "deleteTags" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestListTags(t *testing.T) {

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -285,7 +285,7 @@ func (req *ExpungeVirtualMachine) name() string {
 }
 
 func (req *ExpungeVirtualMachine) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ScaleVirtualMachine (Async) represents the scaling of a VM
@@ -305,7 +305,7 @@ func (req *ScaleVirtualMachine) name() string {
 }
 
 func (req *ScaleVirtualMachine) asyncResponse() interface{} {
-	return new(BooleanResponse)
+	return new(booleanAsyncResponse)
 }
 
 // ChangeServiceForVirtualMachine represents the scaling of a VM

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -117,7 +117,7 @@ func TestScaleVirtualMachine(t *testing.T) {
 	if req.name() != "scaleVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestRecoverVirtualMachine(t *testing.T) {
@@ -133,7 +133,7 @@ func TestExpungeVirtualMachine(t *testing.T) {
 	if req.name() != "expungeVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*BooleanResponse)
+	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
 func TestAddNicToVirtualMachine(t *testing.T) {


### PR DESCRIPTION
...and better handling of the errors (will be used by TF)

**edit:** in fact, all the sync boolean response do so, e.g. `deleteSSHKeyPair`

> This code is needed because the response field is different for sync and async calls :(
>
> https://github.com/xanzy/go-cloudstack/blob/master/generate/generate.go#L1274