### PR TITLE
request: fix map serialization

### DIFF
--- a/request.go
+++ b/request.go
@@ -564,8 +564,7 @@ func prepareMap(prefix string, params *url.Values, m interface{}) error {
 		default:
 			return fmt.Errorf("Only map[string]string are supported (XXX)")
 		}
-		params.Set(fmt.Sprintf("%s[%d].key", prefix, i), keyName)
-		params.Set(fmt.Sprintf("%s[%d].vaue", prefix, i), keyValue)
+		params.Set(fmt.Sprintf("%s[%d].%s", prefix, i, keyName), keyValue)
 	}
 	return nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -85,10 +85,9 @@ func TestPrepareValues(t *testing.T) {
 		t.Errorf("expected tags to be serialized as foo, got %#v", v)
 	}
 
-	k := params.Get("map[0].key")
-	v = params.Get("map[0].value")
-	if k != "foo" && v != "bar" {
-		t.Errorf("expected map to be serialized as \"foo\" => \"bar\", got %#v => %#v", k, v)
+	v = params.Get("map[0].foo")
+	if v != "bar" {
+		t.Errorf("expected map to be serialized as .foo => \"bar\", got .foo => %#v", v)
 	}
 
 	v = params.Get("is_great")


### PR DESCRIPTION
Details are serialized this way, after all.

> Template details in key/value pairs using format `details[i].keyname=keyvalue`. Example: `details[0].hypervisortoolsversion=xenserver61`
>
> https://github.com/apache/cloudstack/blob/87ef8137534fa798101f65c6691fcf71513ac978/api/src/org/apache/cloudstack/api/command/user/template/CreateTemplateCmd.java#L123

it impacts other calls like UpdateVM