### PR TITLE
global: make CS API command name public

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -83,7 +83,8 @@ type ListAccounts struct {
 	State             string `json:"state,omitempty"`
 }
 
-func (*ListAccounts) name() string {
+// APIName returns the CloudStack API command name
+func (*ListAccounts) APIName() string {
 	return "listAccounts"
 }
 

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -10,7 +10,7 @@ func TestAccounts(t *testing.T) {
 
 func TestListAccounts(t *testing.T) {
 	req := &ListAccounts{}
-	if req.name() != "listAccounts" {
+	if req.APIName() != "listAccounts" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAccountsResponse)

--- a/addresses.go
+++ b/addresses.go
@@ -58,7 +58,8 @@ type AssociateIPAddress struct {
 	ZoneID     string `json:"zoneid,omitempty"`
 }
 
-func (*AssociateIPAddress) name() string {
+// APIName returns the CloudStack API command name
+func (*AssociateIPAddress) APIName() string {
 	return "associateIpAddress"
 }
 
@@ -78,7 +79,8 @@ type DisassociateIPAddress struct {
 	ID string `json:"id"`
 }
 
-func (*DisassociateIPAddress) name() string {
+// APIName returns the CloudStack API command name
+func (*DisassociateIPAddress) APIName() string {
 	return "disassociateIpAddress"
 }
 func (*DisassociateIPAddress) asyncResponse() interface{} {
@@ -94,7 +96,8 @@ type UpdateIPAddress struct {
 	ForDisplay *bool  `json:"fordisplay,omitempty"`
 }
 
-func (*UpdateIPAddress) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateIPAddress) APIName() string {
 	return "updateIpAddress"
 }
 func (*UpdateIPAddress) asyncResponse() interface{} {
@@ -133,7 +136,8 @@ type ListPublicIPAddresses struct {
 	ZoneID             string        `json:"zoneid,omitempty"`
 }
 
-func (*ListPublicIPAddresses) name() string {
+// APIName returns the CloudStack API command name
+func (*ListPublicIPAddresses) APIName() string {
 	return "listPublicIpAddresses"
 }
 

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -21,7 +21,7 @@ func TestIPAddress(t *testing.T) {
 
 func TestAssociateIPAddress(t *testing.T) {
 	req := &AssociateIPAddress{}
-	if req.name() != "associateIpAddress" {
+	if req.APIName() != "associateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AssociateIPAddressResponse)
@@ -29,7 +29,7 @@ func TestAssociateIPAddress(t *testing.T) {
 
 func TestDisassociateIPAddress(t *testing.T) {
 	req := &DisassociateIPAddress{}
-	if req.name() != "disassociateIpAddress" {
+	if req.APIName() != "disassociateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -37,7 +37,7 @@ func TestDisassociateIPAddress(t *testing.T) {
 
 func TestListPublicIPAddresses(t *testing.T) {
 	req := &ListPublicIPAddresses{}
-	if req.name() != "listPublicIpAddresses" {
+	if req.APIName() != "listPublicIpAddresses" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListPublicIPAddressesResponse)
@@ -45,7 +45,7 @@ func TestListPublicIPAddresses(t *testing.T) {
 
 func TestUpdateIPAddress(t *testing.T) {
 	req := &UpdateIPAddress{}
-	if req.name() != "updateIpAddress" {
+	if req.APIName() != "updateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateIPAddressResponse)

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -32,7 +32,8 @@ type CreateAffinityGroup struct {
 	DomainID    string `json:"domainid,omitempty"`
 }
 
-func (*CreateAffinityGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateAffinityGroup) APIName() string {
 	return "createAffinityGroup"
 }
 
@@ -54,7 +55,8 @@ type UpdateVMAffinityGroup struct {
 	AffinityGroupNames []string `json:"affinitygroupnames,omitempty"` // mutually exclusive with ids
 }
 
-func (*UpdateVMAffinityGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateVMAffinityGroup) APIName() string {
 	return "updateVMAffinityGroup"
 }
 
@@ -85,7 +87,8 @@ type DeleteAffinityGroup struct {
 	DomainID    string `json:"domainid,omitempty"`
 }
 
-func (*DeleteAffinityGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteAffinityGroup) APIName() string {
 	return "deleteAffinityGroup"
 }
 
@@ -110,7 +113,8 @@ type ListAffinityGroups struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-func (*ListAffinityGroups) name() string {
+// APIName returns the CloudStack API command name
+func (*ListAffinityGroups) APIName() string {
 	return "listAffinityGroups"
 }
 
@@ -127,7 +131,8 @@ type ListAffinityGroupTypes struct {
 	PageSize int    `json:"pagesize,omitempty"`
 }
 
-func (*ListAffinityGroupTypes) name() string {
+// APIName returns the CloudStack API command name
+func (*ListAffinityGroupTypes) APIName() string {
 	return "listAffinityGroupTypes"
 }
 

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -14,7 +14,7 @@ func TestAffinityGroups(t *testing.T) {
 
 func TestCreateAffinityGroup(t *testing.T) {
 	req := &CreateAffinityGroup{}
-	if req.name() != "createAffinityGroup" {
+	if req.APIName() != "createAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*CreateAffinityGroupResponse)
@@ -22,7 +22,7 @@ func TestCreateAffinityGroup(t *testing.T) {
 
 func TestDeleteAffinityGroup(t *testing.T) {
 	req := &DeleteAffinityGroup{}
-	if req.name() != "deleteAffinityGroup" {
+	if req.APIName() != "deleteAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -30,7 +30,7 @@ func TestDeleteAffinityGroup(t *testing.T) {
 
 func TestListAffinityGroups(t *testing.T) {
 	req := &ListAffinityGroups{}
-	if req.name() != "listAffinityGroups" {
+	if req.APIName() != "listAffinityGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAffinityGroupsResponse)
@@ -38,7 +38,7 @@ func TestListAffinityGroups(t *testing.T) {
 
 func TestListAffinityGroupTypes(t *testing.T) {
 	req := &ListAffinityGroupTypes{}
-	if req.name() != "listAffinityGroupTypes" {
+	if req.APIName() != "listAffinityGroupTypes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAffinityGroupTypesResponse)
@@ -46,7 +46,7 @@ func TestListAffinityGroupTypes(t *testing.T) {
 
 func TestUpdateVMAffinityGroup(t *testing.T) {
 	req := &UpdateVMAffinityGroup{}
-	if req.name() != "updateVMAffinityGroup" {
+	if req.APIName() != "updateVMAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateVMAffinityGroupResponse)

--- a/apis.go
+++ b/apis.go
@@ -37,7 +37,8 @@ type ListAPIs struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (*ListAPIs) name() string {
+// APIName returns the CloudStack API command name
+func (*ListAPIs) APIName() string {
 	return "listApis"
 }
 

--- a/apis_test.go
+++ b/apis_test.go
@@ -10,7 +10,7 @@ func TestApis(t *testing.T) {
 
 func TestListAPIs(t *testing.T) {
 	req := &ListAPIs{}
-	if req.name() != "listApis" {
+	if req.APIName() != "listApis" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAPIsResponse)

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -27,7 +27,8 @@ type QueryAsyncJobResult struct {
 	JobID string `json:"jobid"`
 }
 
-func (*QueryAsyncJobResult) name() string {
+// APIName returns the CloudStack API command name
+func (*QueryAsyncJobResult) APIName() string {
 	return "queryAsyncJobResult"
 }
 
@@ -51,7 +52,8 @@ type ListAsyncJobs struct {
 	StartDate   string `json:"startdate,omitempty"`
 }
 
-func (*ListAsyncJobs) name() string {
+// APIName returns the CloudStack API command name
+func (*ListAsyncJobs) APIName() string {
 	return "listAsyncJobs"
 }
 

--- a/async_jobs_test.go
+++ b/async_jobs_test.go
@@ -11,7 +11,7 @@ func TestAsyncJobs(t *testing.T) {
 
 func TestQueryAsyncJobResult(t *testing.T) {
 	req := &QueryAsyncJobResult{}
-	if req.name() != "queryAsyncJobResult" {
+	if req.APIName() != "queryAsyncJobResult" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*QueryAsyncJobResultResponse)
@@ -19,7 +19,7 @@ func TestQueryAsyncJobResult(t *testing.T) {
 
 func TestListAsyncJobs(t *testing.T) {
 	req := &ListAsyncJobs{}
-	if req.name() != "listAsyncJobs" {
+	if req.APIName() != "listAsyncJobs" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAsyncJobsResponse)

--- a/events.go
+++ b/events.go
@@ -43,7 +43,8 @@ type ListEvents struct {
 	Type        string `json:"type,omitempty"`
 }
 
-func (*ListEvents) name() string {
+// APIName returns the CloudStack API command name
+func (*ListEvents) APIName() string {
 	return "listEvents"
 }
 
@@ -62,7 +63,8 @@ type ListEventsResponse struct {
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/listEventTypes.html
 type ListEventTypes struct{}
 
-func (*ListEventTypes) name() string {
+// APIName returns the CloudStack API command name
+func (*ListEventTypes) APIName() string {
 	return "listEventTypes"
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -11,7 +11,7 @@ func TestEvents(t *testing.T) {
 
 func TestListEvents(t *testing.T) {
 	req := &ListEvents{}
-	if req.name() != "listEvents" {
+	if req.APIName() != "listEvents" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListEventsResponse)
@@ -19,7 +19,7 @@ func TestListEvents(t *testing.T) {
 
 func TestListEventTypes(t *testing.T) {
 	req := &ListEventTypes{}
-	if req.name() != "listEventTypes" {
+	if req.APIName() != "listEventTypes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListEventTypesResponse)

--- a/keypairs.go
+++ b/keypairs.go
@@ -20,7 +20,8 @@ type CreateSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*CreateSSHKeyPair) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateSSHKeyPair) APIName() string {
 	return "createSSHKeyPair"
 }
 
@@ -43,7 +44,8 @@ type DeleteSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*DeleteSSHKeyPair) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteSSHKeyPair) APIName() string {
 	return "deleteSSHKeyPair"
 }
 
@@ -62,7 +64,8 @@ type RegisterSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*RegisterSSHKeyPair) name() string {
+// APIName returns the CloudStack API command name
+func (*RegisterSSHKeyPair) APIName() string {
 	return "registerSSHKeyPair"
 }
 
@@ -91,7 +94,8 @@ type ListSSHKeyPairs struct {
 	ProjectID   string `json:"projectid,omitempty"`
 }
 
-func (*ListSSHKeyPairs) name() string {
+// APIName returns the CloudStack API command name
+func (*ListSSHKeyPairs) APIName() string {
 	return "listSSHKeyPairs"
 }
 
@@ -116,7 +120,8 @@ type ResetSSHKeyForVirtualMachine struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*ResetSSHKeyForVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*ResetSSHKeyForVirtualMachine) APIName() string {
 	return "resetSSHKeyForVirtualMachine"
 }
 

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -14,7 +14,7 @@ func TestSSHKeyPairs(t *testing.T) {
 
 func TestResetSSHKeyForVirtualMachine(t *testing.T) {
 	req := &ResetSSHKeyForVirtualMachine{}
-	if req.name() != "resetSSHKeyForVirtualMachine" {
+	if req.APIName() != "resetSSHKeyForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResetSSHKeyForVirtualMachineResponse)
@@ -22,7 +22,7 @@ func TestResetSSHKeyForVirtualMachine(t *testing.T) {
 
 func TestRegisterSSHKeyPair(t *testing.T) {
 	req := &RegisterSSHKeyPair{}
-	if req.name() != "registerSSHKeyPair" {
+	if req.APIName() != "registerSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RegisterSSHKeyPairResponse)
@@ -30,7 +30,7 @@ func TestRegisterSSHKeyPair(t *testing.T) {
 
 func TestCreateSSHKeyPair(t *testing.T) {
 	req := &CreateSSHKeyPair{}
-	if req.name() != "createSSHKeyPair" {
+	if req.APIName() != "createSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateSSHKeyPairResponse)
@@ -38,7 +38,7 @@ func TestCreateSSHKeyPair(t *testing.T) {
 
 func TestDeleteSSHKeyPair(t *testing.T) {
 	req := &DeleteSSHKeyPair{}
-	if req.name() != "deleteSSHKeyPair" {
+	if req.APIName() != "deleteSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)
@@ -46,7 +46,7 @@ func TestDeleteSSHKeyPair(t *testing.T) {
 
 func TestListSSHKeyPairs(t *testing.T) {
 	req := &ListSSHKeyPairs{}
-	if req.name() != "listSSHKeyPairs" {
+	if req.APIName() != "listSSHKeyPairs" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSSHKeyPairsResponse)

--- a/limits.go
+++ b/limits.go
@@ -79,7 +79,8 @@ type ListResourceLimits struct {
 	ResourceTypeName ResourceTypeName `json:"resourcetypename,omitempty"`
 }
 
-func (*ListResourceLimits) name() string {
+// APIName returns the CloudStack API command name
+func (*ListResourceLimits) APIName() string {
 	return "listResourceLimits"
 }
 

--- a/limits_test.go
+++ b/limits_test.go
@@ -10,7 +10,7 @@ func TestResourceLimits(t *testing.T) {
 
 func TestListResourceLimits(t *testing.T) {
 	req := &ListResourceLimits{}
-	if req.name() != "listResourceLimits" {
+	if req.APIName() != "listResourceLimits" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListResourceLimitsResponse)

--- a/network_offerings.go
+++ b/network_offerings.go
@@ -53,7 +53,8 @@ type ListNetworkOfferings struct {
 	ZoneID             string        `json:"zoneid,omitempty"`
 }
 
-func (*ListNetworkOfferings) name() string {
+// APIName returns the CloudStack API command name
+func (*ListNetworkOfferings) APIName() string {
 	return "listNetworkOfferings"
 }
 

--- a/network_offerings_test.go
+++ b/network_offerings_test.go
@@ -10,7 +10,7 @@ func TestNetworkOfferings(t *testing.T) {
 
 func TestListNetworkOfferings(t *testing.T) {
 	req := &ListNetworkOfferings{}
-	if req.name() != "listNetworkOfferings" {
+	if req.APIName() != "listNetworkOfferings" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNetworkOfferingsResponse)

--- a/networks.go
+++ b/networks.go
@@ -120,7 +120,8 @@ type CreateNetwork struct {
 	VpcID             string `json:"vpcid,omitempty"`
 }
 
-func (*CreateNetwork) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateNetwork) APIName() string {
 	return "createNetwork"
 }
 
@@ -159,7 +160,8 @@ type UpdateNetwork struct {
 	UpdateInSequence  *bool  `json:"updateinsequence,omitempty"`
 }
 
-func (*UpdateNetwork) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateNetwork) APIName() string {
 	return "updateNetwork"
 }
 
@@ -178,7 +180,8 @@ type RestartNetwork struct {
 	Cleanup *bool  `json:"cleanup,omitempty"`
 }
 
-func (*RestartNetwork) name() string {
+// APIName returns the CloudStack API command name
+func (*RestartNetwork) APIName() string {
 	return "restartNetwork"
 }
 
@@ -197,7 +200,8 @@ type DeleteNetwork struct {
 	Forced *bool  `json:"forced,omitempty"`
 }
 
-func (*DeleteNetwork) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteNetwork) APIName() string {
 	return "deleteNetwork"
 }
 
@@ -234,7 +238,8 @@ type ListNetworks struct {
 	ZoneID            string        `json:"zoneid,omitempty"`
 }
 
-func (*ListNetworks) name() string {
+// APIName returns the CloudStack API command name
+func (*ListNetworks) APIName() string {
 	return "listNetworks"
 }
 

--- a/networks_test.go
+++ b/networks_test.go
@@ -22,7 +22,7 @@ func TestNetwork(t *testing.T) {
 
 func TestListNetworks(t *testing.T) {
 	req := &ListNetworks{}
-	if req.name() != "listNetworks" {
+	if req.APIName() != "listNetworks" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNetworksResponse)
@@ -30,7 +30,7 @@ func TestListNetworks(t *testing.T) {
 
 func TestCreateNetwork(t *testing.T) {
 	req := &CreateNetwork{}
-	if req.name() != "createNetwork" {
+	if req.APIName() != "createNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateNetworkResponse)
@@ -38,7 +38,7 @@ func TestCreateNetwork(t *testing.T) {
 
 func TestRestartNetwork(t *testing.T) {
 	req := &RestartNetwork{}
-	if req.name() != "restartNetwork" {
+	if req.APIName() != "restartNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RestartNetworkResponse)
@@ -46,7 +46,7 @@ func TestRestartNetwork(t *testing.T) {
 
 func TestUpdateNetwork(t *testing.T) {
 	req := &UpdateNetwork{}
-	if req.name() != "updateNetwork" {
+	if req.APIName() != "updateNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateNetworkResponse)
@@ -54,7 +54,7 @@ func TestUpdateNetwork(t *testing.T) {
 
 func TestDeleteNetwork(t *testing.T) {
 	req := &DeleteNetwork{}
-	if req.name() != "deleteNetwork" {
+	if req.APIName() != "deleteNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/nics.go
+++ b/nics.go
@@ -46,7 +46,8 @@ type ListNics struct {
 	PageSize         int    `json:"pagesize,omitempty"`
 }
 
-func (*ListNics) name() string {
+// APIName returns the CloudStack API command name
+func (*ListNics) APIName() string {
 	return "listNics"
 }
 
@@ -66,7 +67,8 @@ type AddIPToNic struct {
 	IPAddress net.IP `json:"ipaddress"`
 }
 
-func (*AddIPToNic) name() string {
+// APIName returns the CloudStack API command name
+func (*AddIPToNic) APIName() string {
 	return "addIpToNic"
 }
 func (*AddIPToNic) asyncResponse() interface{} {
@@ -83,7 +85,8 @@ type RemoveIPFromNic struct {
 	ID string `json:"id"`
 }
 
-func (*RemoveIPFromNic) name() string {
+// APIName returns the CloudStack API command name
+func (*RemoveIPFromNic) APIName() string {
 	return "removeIpFromNic"
 }
 

--- a/nics_test.go
+++ b/nics_test.go
@@ -12,7 +12,7 @@ func TestNics(t *testing.T) {
 
 func TestAddIPToNic(t *testing.T) {
 	req := &AddIPToNic{}
-	if req.name() != "addIpToNic" {
+	if req.APIName() != "addIpToNic" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AddIPToNicResponse)
@@ -20,7 +20,7 @@ func TestAddIPToNic(t *testing.T) {
 
 func TestRemoveIPFromNic(t *testing.T) {
 	req := &RemoveIPFromNic{}
-	if req.name() != "removeIpFromNic" {
+	if req.APIName() != "removeIpFromNic" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -28,7 +28,7 @@ func TestRemoveIPFromNic(t *testing.T) {
 
 func TestListNics(t *testing.T) {
 	req := &ListNics{}
-	if req.name() != "listNics" {
+	if req.APIName() != "listNics" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNicsResponse)

--- a/request.go
+++ b/request.go
@@ -20,18 +20,24 @@ import (
 	"time"
 )
 
-// Command represent a CloudStack request
+// Command represents a CloudStack request
 type Command interface {
 	// CloudStack API command name
-	name() string
+	APIName() string
+}
+
+// SyncCommand represents a CloudStack synchronous request
+type SyncCommand interface {
+	// CloudStack API command name
+	APIName() string
 	// Response interface to Unmarshal the JSON into
 	response() interface{}
 }
 
-// AsyncCommand represents a async CloudStack request
+// AsyncCommand represents a CloudStack asynchronous request
 type AsyncCommand interface {
 	// CloudStack API command name
-	name() string
+	APIName() string
 	// Response interface to Unmarshal the JSON into
 	asyncResponse() interface{}
 }
@@ -233,7 +239,7 @@ func (exo *Client) processAsyncJob(ctx context.Context, job *asyncJob) {
 	defer close(job.responseChan)
 	defer close(job.errorChan)
 
-	body, err := exo.request(job.command.name(), job.command)
+	body, err := exo.request(job.command.APIName(), job.command)
 	if err != nil {
 		job.errorChan <- err
 		return
@@ -337,7 +343,7 @@ func (exo *Client) AsyncRequest(req AsyncCommand, async AsyncInfo) (interface{},
 }
 
 // BooleanRequest performs a sync request on a boolean call
-func (exo *Client) BooleanRequest(req Command) error {
+func (exo *Client) BooleanRequest(req SyncCommand) error {
 	resp, err := exo.Request(req)
 	if err != nil {
 		return err
@@ -357,8 +363,8 @@ func (exo *Client) BooleanAsyncRequest(req AsyncCommand, async AsyncInfo) error 
 }
 
 // Request performs a sync request on a generic command
-func (exo *Client) Request(req Command) (interface{}, error) {
-	body, err := exo.request(req.name(), req)
+func (exo *Client) Request(req SyncCommand) (interface{}, error) {
+	body, err := exo.request(req.APIName(), req)
 	if err != nil {
 		return nil, err
 	}

--- a/security_groups.go
+++ b/security_groups.go
@@ -70,7 +70,8 @@ type CreateSecurityGroup struct {
 	Description string `json:"description,omitempty"`
 }
 
-func (*CreateSecurityGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateSecurityGroup) APIName() string {
 	return "createSecurityGroup"
 }
 
@@ -92,7 +93,8 @@ type DeleteSecurityGroup struct {
 	ProjectID string `json:"project,omitempty"`
 }
 
-func (*DeleteSecurityGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteSecurityGroup) APIName() string {
 	return "deleteSecurityGroup"
 }
 
@@ -119,7 +121,8 @@ type AuthorizeSecurityGroupIngress struct {
 	UserSecurityGroupList []UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
 }
 
-func (*AuthorizeSecurityGroupIngress) name() string {
+// APIName returns the CloudStack API command name
+func (*AuthorizeSecurityGroupIngress) APIName() string {
 	return "authorizeSecurityGroupIngress"
 }
 
@@ -145,7 +148,8 @@ type AuthorizeSecurityGroupIngressResponse SecurityGroupResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/authorizeSecurityGroupEgress.html
 type AuthorizeSecurityGroupEgress AuthorizeSecurityGroupIngress
 
-func (*AuthorizeSecurityGroupEgress) name() string {
+// APIName returns the CloudStack API command name
+func (*AuthorizeSecurityGroupEgress) APIName() string {
 	return "authorizeSecurityGroupEgress"
 }
 
@@ -168,7 +172,8 @@ type RevokeSecurityGroupIngress struct {
 	ID string `json:"id"`
 }
 
-func (*RevokeSecurityGroupIngress) name() string {
+// APIName returns the CloudStack API command name
+func (*RevokeSecurityGroupIngress) APIName() string {
 	return "revokeSecurityGroupIngress"
 }
 
@@ -183,7 +188,8 @@ type RevokeSecurityGroupEgress struct {
 	ID string `json:"id"`
 }
 
-func (*RevokeSecurityGroupEgress) name() string {
+// APIName returns the CloudStack API command name
+func (*RevokeSecurityGroupEgress) APIName() string {
 	return "revokeSecurityGroupEgress"
 }
 
@@ -210,7 +216,8 @@ type ListSecurityGroups struct {
 	VirtualMachineID  string        `json:"virtualmachineid,omitempty"`
 }
 
-func (*ListSecurityGroups) name() string {
+// APIName returns the CloudStack API command name
+func (*ListSecurityGroups) APIName() string {
 	return "listSecurityGroups"
 }
 

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -26,7 +26,7 @@ func TestSecurityGroup(t *testing.T) {
 
 func TestAuthorizeSecurityGroupEgress(t *testing.T) {
 	req := &AuthorizeSecurityGroupEgress{}
-	if req.name() != "authorizeSecurityGroupEgress" {
+	if req.APIName() != "authorizeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AuthorizeSecurityGroupEgressResponse)
@@ -34,7 +34,7 @@ func TestAuthorizeSecurityGroupEgress(t *testing.T) {
 
 func TestAuthorizeSecurityGroupIngress(t *testing.T) {
 	req := &AuthorizeSecurityGroupIngress{}
-	if req.name() != "authorizeSecurityGroupIngress" {
+	if req.APIName() != "authorizeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AuthorizeSecurityGroupIngressResponse)
@@ -42,7 +42,7 @@ func TestAuthorizeSecurityGroupIngress(t *testing.T) {
 
 func TestCreateSecurityGroup(t *testing.T) {
 	req := &CreateSecurityGroup{}
-	if req.name() != "createSecurityGroup" {
+	if req.APIName() != "createSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateSecurityGroupResponse)
@@ -50,7 +50,7 @@ func TestCreateSecurityGroup(t *testing.T) {
 
 func TestDeleteSecurityGroup(t *testing.T) {
 	req := &DeleteSecurityGroup{}
-	if req.name() != "deleteSecurityGroup" {
+	if req.APIName() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)
@@ -58,7 +58,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 
 func TestListSecurityGroups(t *testing.T) {
 	req := &ListSecurityGroups{}
-	if req.name() != "listSecurityGroups" {
+	if req.APIName() != "listSecurityGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSecurityGroupsResponse)
@@ -66,7 +66,7 @@ func TestListSecurityGroups(t *testing.T) {
 
 func TestRevokeSecurityGroupEgress(t *testing.T) {
 	req := &RevokeSecurityGroupEgress{}
-	if req.name() != "revokeSecurityGroupEgress" {
+	if req.APIName() != "revokeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -74,7 +74,7 @@ func TestRevokeSecurityGroupEgress(t *testing.T) {
 
 func TestRevokeSecurityGroupIngress(t *testing.T) {
 	req := &RevokeSecurityGroupIngress{}
-	if req.name() != "revokeSecurityGroupIngress" {
+	if req.APIName() != "revokeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/service_offerings.go
+++ b/service_offerings.go
@@ -50,7 +50,8 @@ type ListServiceOfferings struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-func (*ListServiceOfferings) name() string {
+// APIName returns the CloudStack API command name
+func (*ListServiceOfferings) APIName() string {
 	return "listServiceOfferings"
 }
 

--- a/service_offerings_test.go
+++ b/service_offerings_test.go
@@ -10,7 +10,7 @@ func TestServiceOfferings(t *testing.T) {
 
 func TestListServiceOfferings(t *testing.T) {
 	req := &ListServiceOfferings{}
-	if req.name() != "listServiceOfferings" {
+	if req.APIName() != "listServiceOfferings" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListServiceOfferingsResponse)

--- a/snapshots.go
+++ b/snapshots.go
@@ -41,7 +41,8 @@ type CreateSnapshot struct {
 	QuiesceVM *bool  `json:"quiescevm,omitempty"`
 }
 
-func (*CreateSnapshot) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateSnapshot) APIName() string {
 	return "createSnapshot"
 }
 
@@ -75,7 +76,8 @@ type ListSnapshots struct {
 	ZoneID       string        `json:"zoneid,omitempty"`
 }
 
-func (*ListSnapshots) name() string {
+// APIName returns the CloudStack API command name
+func (*ListSnapshots) APIName() string {
 	return "listSnapshots"
 }
 
@@ -96,7 +98,8 @@ type DeleteSnapshot struct {
 	ID string `json:"id"`
 }
 
-func (*DeleteSnapshot) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteSnapshot) APIName() string {
 	return "deleteSnapshot"
 }
 
@@ -111,7 +114,8 @@ type RevertSnapshot struct {
 	ID string `json:"id"`
 }
 
-func (*RevertSnapshot) name() string {
+// APIName returns the CloudStack API command name
+func (*RevertSnapshot) APIName() string {
 	return "revertSnapshot"
 }
 

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -21,7 +21,7 @@ func TestSnapshot(t *testing.T) {
 
 func TestCreateSnapshot(t *testing.T) {
 	req := &CreateSnapshot{}
-	if req.name() != "createSnapshot" {
+	if req.APIName() != "createSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*CreateSnapshotResponse)
@@ -29,7 +29,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 func TestListSnapshots(t *testing.T) {
 	req := &ListSnapshots{}
-	if req.name() != "listSnapshots" {
+	if req.APIName() != "listSnapshots" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSnapshotsResponse)
@@ -37,7 +37,7 @@ func TestListSnapshots(t *testing.T) {
 
 func TestDeleteSnapshot(t *testing.T) {
 	req := &DeleteSnapshot{}
-	if req.name() != "deleteSnapshot" {
+	if req.APIName() != "deleteSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -45,7 +45,7 @@ func TestDeleteSnapshot(t *testing.T) {
 
 func TestRevertSnapshot(t *testing.T) {
 	req := &RevertSnapshot{}
-	if req.name() != "revertSnapshot" {
+	if req.APIName() != "revertSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/tags.go
+++ b/tags.go
@@ -34,7 +34,8 @@ type CreateTags struct {
 	Customer     string        `json:"customer,omitempty"`
 }
 
-func (*CreateTags) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateTags) APIName() string {
 	return "createTags"
 }
 
@@ -51,7 +52,8 @@ type DeleteTags struct {
 	Tags         []ResourceTag `json:"tags,omitempty"`
 }
 
-func (*DeleteTags) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteTags) APIName() string {
 	return "deleteTags"
 }
 
@@ -78,7 +80,8 @@ type ListTags struct {
 	Value        string `json:"value,omitempty"`
 }
 
-func (*ListTags) name() string {
+// APIName returns the CloudStack API command name
+func (*ListTags) APIName() string {
 	return "listTags"
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,7 +12,7 @@ func TestTags(t *testing.T) {
 
 func TestCreateTags(t *testing.T) {
 	req := &CreateTags{}
-	if req.name() != "createTags" {
+	if req.APIName() != "createTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -20,7 +20,7 @@ func TestCreateTags(t *testing.T) {
 
 func TestDeleteTags(t *testing.T) {
 	req := &DeleteTags{}
-	if req.name() != "deleteTags" {
+	if req.APIName() != "deleteTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -28,7 +28,7 @@ func TestDeleteTags(t *testing.T) {
 
 func TestListTags(t *testing.T) {
 	req := &ListTags{}
-	if req.name() != "listTags" {
+	if req.APIName() != "listTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListTagsResponse)

--- a/templates.go
+++ b/templates.go
@@ -61,7 +61,8 @@ type ListTemplates struct {
 	ZoneID         string        `json:"zoneid,omitempty"`
 }
 
-func (*ListTemplates) name() string {
+// APIName returns the CloudStack API command name
+func (*ListTemplates) APIName() string {
 	return "listTemplates"
 }
 

--- a/templates_test.go
+++ b/templates_test.go
@@ -18,7 +18,7 @@ func TestTemplate(t *testing.T) {
 
 func TestListTemplates(t *testing.T) {
 	req := &ListTemplates{}
-	if req.name() != "listTemplates" {
+	if req.APIName() != "listTemplates" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListTemplatesResponse)

--- a/users.go
+++ b/users.go
@@ -27,7 +27,8 @@ type RegisterUserKeys struct {
 	ID string `json:"id"`
 }
 
-func (*RegisterUserKeys) name() string {
+// APIName returns the CloudStack API command name
+func (*RegisterUserKeys) APIName() string {
 	return "registerUserKeys"
 }
 

--- a/users_test.go
+++ b/users_test.go
@@ -10,7 +10,7 @@ func TestUsers(t *testing.T) {
 
 func TestRegisterUserKeys(t *testing.T) {
 	req := &RegisterUserKeys{}
-	if req.name() != "registerUserKeys" {
+	if req.APIName() != "registerUserKeys" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RegisterUserKeysResponse)

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -179,7 +179,8 @@ type DeployVirtualMachine struct {
 	UserData           string            `json:"userdata,omitempty"` // the client is responsible to base64/gzip it
 }
 
-func (*DeployVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*DeployVirtualMachine) APIName() string {
 	return "deployVirtualMachine"
 }
 
@@ -199,7 +200,8 @@ type StartVirtualMachine struct {
 	HostID            string `json:"hostid,omitempty"`            // root only
 }
 
-func (*StartVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*StartVirtualMachine) APIName() string {
 	return "startVirtualMachine"
 }
 func (*StartVirtualMachine) asyncResponse() interface{} {
@@ -217,7 +219,8 @@ type StopVirtualMachine struct {
 	Forced *bool  `json:"forced,omitempty"`
 }
 
-func (*StopVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*StopVirtualMachine) APIName() string {
 	return "stopVirtualMachine"
 }
 
@@ -235,7 +238,8 @@ type RebootVirtualMachine struct {
 	ID string `json:"id"`
 }
 
-func (*RebootVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*RebootVirtualMachine) APIName() string {
 	return "rebootVirtualMachine"
 }
 
@@ -255,7 +259,8 @@ type RestoreVirtualMachine struct {
 	RootDiskSize     string `json:"rootdisksize,omitempty"` // in GiB, Exoscale specific
 }
 
-func (*RestoreVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*RestoreVirtualMachine) APIName() string {
 	return "restoreVirtualMachine"
 }
 
@@ -273,7 +278,8 @@ type RecoverVirtualMachine struct {
 	ID string `json:"virtualmachineid"`
 }
 
-func (*RecoverVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*RecoverVirtualMachine) APIName() string {
 	return "recoverVirtualMachine"
 }
 
@@ -292,7 +298,8 @@ type DestroyVirtualMachine struct {
 	Expunge *bool  `json:"expunge,omitempty"`
 }
 
-func (*DestroyVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*DestroyVirtualMachine) APIName() string {
 	return "destroyVirtualMachine"
 }
 
@@ -321,7 +328,8 @@ type UpdateVirtualMachine struct {
 	UserData              string            `json:"userdata,omitempty"`
 }
 
-func (*UpdateVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateVirtualMachine) APIName() string {
 	return "updateVirtualMachine"
 }
 
@@ -337,7 +345,8 @@ type ExpungeVirtualMachine struct {
 	ID string `json:"id"`
 }
 
-func (*ExpungeVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*ExpungeVirtualMachine) APIName() string {
 	return "expungeVirtualMachine"
 }
 
@@ -357,7 +366,8 @@ type ScaleVirtualMachine struct {
 	Details           map[string]string `json:"details,omitempty"`
 }
 
-func (*ScaleVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*ScaleVirtualMachine) APIName() string {
 	return "scaleVirtualMachine"
 }
 
@@ -370,7 +380,8 @@ func (*ScaleVirtualMachine) asyncResponse() interface{} {
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/changeServiceForVirtualMachine.html
 type ChangeServiceForVirtualMachine ScaleVirtualMachine
 
-func (*ChangeServiceForVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*ChangeServiceForVirtualMachine) APIName() string {
 	return "changeServiceForVirtualMachine"
 }
 
@@ -386,7 +397,8 @@ type ChangeServiceForVirtualMachineResponse VirtualMachineResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resetPasswordForVirtualMachine.html
 type ResetPasswordForVirtualMachine ScaleVirtualMachine
 
-func (*ResetPasswordForVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*ResetPasswordForVirtualMachine) APIName() string {
 	return "resetPasswordForVirtualMachine"
 }
 
@@ -404,7 +416,8 @@ type GetVMPassword struct {
 	ID string `json:"id"`
 }
 
-func (*GetVMPassword) name() string {
+// APIName returns the CloudStack API command name
+func (*GetVMPassword) APIName() string {
 	return "getVMPassword"
 }
 
@@ -454,7 +467,8 @@ type ListVirtualMachines struct {
 	ZoneID            string            `json:"zoneid,omitempty"`
 }
 
-func (*ListVirtualMachines) name() string {
+// APIName returns the CloudStack API command name
+func (*ListVirtualMachines) APIName() string {
 	return "listVirtualMachines"
 }
 
@@ -477,7 +491,8 @@ type AddNicToVirtualMachine struct {
 	IPAddress        net.IP `json:"ipaddress,omitempty"`
 }
 
-func (*AddNicToVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*AddNicToVirtualMachine) APIName() string {
 	return "addNicToVirtualMachine"
 }
 
@@ -496,7 +511,8 @@ type RemoveNicFromVirtualMachine struct {
 	VirtualMachineID string `json:"virtualmachineid"`
 }
 
-func (*RemoveNicFromVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*RemoveNicFromVirtualMachine) APIName() string {
 	return "removeNicFromVirtualMachine"
 }
 
@@ -516,7 +532,8 @@ type UpdateDefaultNicForVirtualMachine struct {
 	IPAddress        net.IP `json:"ipaddress,omitempty"`
 }
 
-func (*UpdateDefaultNicForVirtualMachine) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateDefaultNicForVirtualMachine) APIName() string {
 	return "updateDefaultNicForVirtualMachine"
 }
 

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -35,7 +35,7 @@ func TestVirtualMachine(t *testing.T) {
 
 func TestDeployVirtualMachine(t *testing.T) {
 	req := &DeployVirtualMachine{}
-	if req.name() != "deployVirtualMachine" {
+	if req.APIName() != "deployVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*DeployVirtualMachineResponse)
@@ -43,7 +43,7 @@ func TestDeployVirtualMachine(t *testing.T) {
 
 func TestDestroyVirtualMachine(t *testing.T) {
 	req := &DestroyVirtualMachine{}
-	if req.name() != "destroyVirtualMachine" {
+	if req.APIName() != "destroyVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*DestroyVirtualMachineResponse)
@@ -51,7 +51,7 @@ func TestDestroyVirtualMachine(t *testing.T) {
 
 func TestRebootVirtualMachine(t *testing.T) {
 	req := &RebootVirtualMachine{}
-	if req.name() != "rebootVirtualMachine" {
+	if req.APIName() != "rebootVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RebootVirtualMachineResponse)
@@ -59,7 +59,7 @@ func TestRebootVirtualMachine(t *testing.T) {
 
 func TestStartVirtualMachine(t *testing.T) {
 	req := &StartVirtualMachine{}
-	if req.name() != "startVirtualMachine" {
+	if req.APIName() != "startVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*StartVirtualMachineResponse)
@@ -67,7 +67,7 @@ func TestStartVirtualMachine(t *testing.T) {
 
 func TestStopVirtualMachine(t *testing.T) {
 	req := &StopVirtualMachine{}
-	if req.name() != "stopVirtualMachine" {
+	if req.APIName() != "stopVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*StopVirtualMachineResponse)
@@ -75,7 +75,7 @@ func TestStopVirtualMachine(t *testing.T) {
 
 func TestResetPasswordForVirtualMachine(t *testing.T) {
 	req := &ResetPasswordForVirtualMachine{}
-	if req.name() != "resetPasswordForVirtualMachine" {
+	if req.APIName() != "resetPasswordForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResetPasswordForVirtualMachineResponse)
@@ -83,7 +83,7 @@ func TestResetPasswordForVirtualMachine(t *testing.T) {
 
 func TestUpdateVirtualMachine(t *testing.T) {
 	req := &UpdateVirtualMachine{}
-	if req.name() != "updateVirtualMachine" {
+	if req.APIName() != "updateVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*UpdateVirtualMachineResponse)
@@ -91,7 +91,7 @@ func TestUpdateVirtualMachine(t *testing.T) {
 
 func TestListVirtualMachines(t *testing.T) {
 	req := &ListVirtualMachines{}
-	if req.name() != "listVirtualMachines" {
+	if req.APIName() != "listVirtualMachines" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListVirtualMachinesResponse)
@@ -99,7 +99,7 @@ func TestListVirtualMachines(t *testing.T) {
 
 func TestGetVMPassword(t *testing.T) {
 	req := &GetVMPassword{}
-	if req.name() != "getVMPassword" {
+	if req.APIName() != "getVMPassword" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*GetVMPasswordResponse)
@@ -107,7 +107,7 @@ func TestGetVMPassword(t *testing.T) {
 
 func TestRestoreVirtualMachine(t *testing.T) {
 	req := &RestoreVirtualMachine{}
-	if req.name() != "restoreVirtualMachine" {
+	if req.APIName() != "restoreVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RestoreVirtualMachineResponse)
@@ -115,7 +115,7 @@ func TestRestoreVirtualMachine(t *testing.T) {
 
 func TestChangeServiceForVirtualMachine(t *testing.T) {
 	req := &ChangeServiceForVirtualMachine{}
-	if req.name() != "changeServiceForVirtualMachine" {
+	if req.APIName() != "changeServiceForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ChangeServiceForVirtualMachineResponse)
@@ -123,7 +123,7 @@ func TestChangeServiceForVirtualMachine(t *testing.T) {
 
 func TestScaleVirtualMachine(t *testing.T) {
 	req := &ScaleVirtualMachine{}
-	if req.name() != "scaleVirtualMachine" {
+	if req.APIName() != "scaleVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -131,7 +131,7 @@ func TestScaleVirtualMachine(t *testing.T) {
 
 func TestRecoverVirtualMachine(t *testing.T) {
 	req := &RecoverVirtualMachine{}
-	if req.name() != "recoverVirtualMachine" {
+	if req.APIName() != "recoverVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RecoverVirtualMachineResponse)
@@ -139,7 +139,7 @@ func TestRecoverVirtualMachine(t *testing.T) {
 
 func TestExpungeVirtualMachine(t *testing.T) {
 	req := &ExpungeVirtualMachine{}
-	if req.name() != "expungeVirtualMachine" {
+	if req.APIName() != "expungeVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -147,7 +147,7 @@ func TestExpungeVirtualMachine(t *testing.T) {
 
 func TestAddNicToVirtualMachine(t *testing.T) {
 	req := &AddNicToVirtualMachine{}
-	if req.name() != "addNicToVirtualMachine" {
+	if req.APIName() != "addNicToVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AddNicToVirtualMachineResponse)
@@ -155,7 +155,7 @@ func TestAddNicToVirtualMachine(t *testing.T) {
 
 func TestRemoveNicFromVirtualMachine(t *testing.T) {
 	req := &RemoveNicFromVirtualMachine{}
-	if req.name() != "removeNicFromVirtualMachine" {
+	if req.APIName() != "removeNicFromVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RemoveNicFromVirtualMachineResponse)
@@ -163,7 +163,7 @@ func TestRemoveNicFromVirtualMachine(t *testing.T) {
 
 func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
 	req := &UpdateDefaultNicForVirtualMachine{}
-	if req.name() != "updateDefaultNicForVirtualMachine" {
+	if req.APIName() != "updateDefaultNicForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateDefaultNicForVirtualMachineResponse)

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -27,7 +27,8 @@ type CreateInstanceGroup struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*CreateInstanceGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*CreateInstanceGroup) APIName() string {
 	return "createInstanceGroup"
 }
 
@@ -46,7 +47,8 @@ type UpdateInstanceGroup struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (*UpdateInstanceGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*UpdateInstanceGroup) APIName() string {
 	return "updateInstanceGroup"
 }
 
@@ -67,7 +69,8 @@ type DeleteInstanceGroup struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (*DeleteInstanceGroup) name() string {
+// APIName returns the CloudStack API command name
+func (*DeleteInstanceGroup) APIName() string {
 	return "deleteInstanceGroup"
 }
 
@@ -91,7 +94,8 @@ type ListInstanceGroups struct {
 	ProjectID   string `json:"projectid,omitempty"`
 }
 
-func (*ListInstanceGroups) name() string {
+// APIName returns the CloudStack API command name
+func (*ListInstanceGroups) APIName() string {
 	return "listInstanceGroups"
 }
 

--- a/vm_groups_test.go
+++ b/vm_groups_test.go
@@ -13,7 +13,7 @@ func TestInstanceGroup(t *testing.T) {
 
 func TestListInstanceGroups(t *testing.T) {
 	req := &ListInstanceGroups{}
-	if req.name() != "listInstanceGroups" {
+	if req.APIName() != "listInstanceGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListInstanceGroupsResponse)
@@ -21,7 +21,7 @@ func TestListInstanceGroups(t *testing.T) {
 
 func TestCreateInstanceGroup(t *testing.T) {
 	req := &CreateInstanceGroup{}
-	if req.name() != "createInstanceGroup" {
+	if req.APIName() != "createInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateInstanceGroupResponse)
@@ -29,7 +29,7 @@ func TestCreateInstanceGroup(t *testing.T) {
 
 func TestUpdateInstanceGroup(t *testing.T) {
 	req := &UpdateInstanceGroup{}
-	if req.name() != "updateInstanceGroup" {
+	if req.APIName() != "updateInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*UpdateInstanceGroupResponse)
@@ -37,7 +37,7 @@ func TestUpdateInstanceGroup(t *testing.T) {
 
 func TestDeleteInstanceGroup(t *testing.T) {
 	req := &DeleteInstanceGroup{}
-	if req.name() != "deleteInstanceGroup" {
+	if req.APIName() != "deleteInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)

--- a/volumes.go
+++ b/volumes.go
@@ -48,7 +48,8 @@ type ResizeVolume struct {
 	Size           int64  `json:"size,omitempty"` // in GiB
 }
 
-func (*ResizeVolume) name() string {
+// APIName returns the CloudStack API command name
+func (*ResizeVolume) APIName() string {
 	return "resizeVolume"
 }
 
@@ -86,7 +87,8 @@ type ListVolumes struct {
 	ZoneID           string        `json:"zoneid,omitempty"`
 }
 
-func (*ListVolumes) name() string {
+// APIName returns the CloudStack API command name
+func (*ListVolumes) APIName() string {
 	return "listVolumes"
 }
 

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -19,7 +19,7 @@ func TestVolume(t *testing.T) {
 
 func TestListVolumes(t *testing.T) {
 	req := &ListVolumes{}
-	if req.name() != "listVolumes" {
+	if req.APIName() != "listVolumes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListVolumesResponse)
@@ -27,7 +27,7 @@ func TestListVolumes(t *testing.T) {
 
 func TestResizeVolume(t *testing.T) {
 	req := &ResizeVolume{}
-	if req.name() != "resizeVolume" {
+	if req.APIName() != "resizeVolume" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResizeVolumeResponse)

--- a/zones.go
+++ b/zones.go
@@ -45,7 +45,8 @@ type ListZones struct {
 	Tags           []ResourceTag `json:"tags,omitempty"`
 }
 
-func (*ListZones) name() string {
+// APIName returns the CloudStack API command name
+func (*ListZones) APIName() string {
 	return "listZones"
 }
 

--- a/zones_test.go
+++ b/zones_test.go
@@ -10,7 +10,7 @@ func TestZones(t *testing.T) {
 
 func TestListZones(t *testing.T) {
 	req := &ListZones{}
-	if req.name() != "listZones" {
+	if req.APIName() != "listZones" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListZonesResponse)


### PR DESCRIPTION
This can be useful to build tools around this library (e.g. a cli)