### PR TITLE
global: use net.IP for IP addresses

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -1,5 +1,7 @@
 package egoscale
 
+import "net"
+
 // IPAddress represents an IP Address
 type IPAddress struct {
 	ID                        string         `json:"id"`
@@ -11,7 +13,7 @@ type IPAddress struct {
 	DomainName                string         `json:"domainname,omitempty"`
 	ForDisplay                bool           `json:"fordisplay,omitempty"`
 	ForVirtualNetwork         bool           `json:"forvirtualnetwork,omitempty"`
-	IPAddress                 string         `json:"ipaddress"`
+	IPAddress                 net.IP         `json:"ipaddress"`
 	IsElastic                 bool           `json:"iselastic,omitempty"`
 	IsPortable                bool           `json:"isportable,omitempty"`
 	IsSourceNat               bool           `json:"issourcenat,omitempty"`
@@ -27,7 +29,7 @@ type IPAddress struct {
 	VirtualMachineName        string         `json:"virtualmachineName,omitempty"`
 	VlanID                    string         `json:"vlanid,omitempty"`
 	VlanName                  string         `json:"vlanname,omitempty"`
-	VMIPAddress               string         `json:"vmipaddress,omitempty"`
+	VMIPAddress               net.IP         `json:"vmipaddress,omitempty"`
 	VpcID                     string         `json:"vpcid,omitempty"`
 	ZoneID                    string         `json:"zoneid,omitempty"`
 	ZoneName                  string         `json:"zonename,omitempty"`
@@ -109,7 +111,7 @@ type ListPublicIPAddresses struct {
 	ForLoadBalancing   bool           `json:"forloadbalancing,omitempty"`
 	ForVirtualNetwork  string         `json:"forvirtualnetwork,omitempty"`
 	ID                 string         `json:"id,omitempty"`
-	IPAddress          string         `json:"ipaddress,omitempty"`
+	IPAddress          net.IP         `json:"ipaddress,omitempty"`
 	IsElastic          bool           `json:"iselastic,omitempty"`
 	IsRecursive        bool           `json:"isrecursive,omitempty"`
 	IsSourceNat        bool           `json:"issourcenat,omitempty"`

--- a/doc.go
+++ b/doc.go
@@ -29,6 +29,10 @@ Elastic IPs
 
 See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/networking_and_traffic.html#about-elastic-ips
 
+Networks
+
+See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.8/networking_and_traffic.html
+
 NICs
 
 See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/networking_and_traffic.html#configuring-multiple-ip-addresses-on-a-single-nic

--- a/networks.go
+++ b/networks.go
@@ -1,5 +1,7 @@
 package egoscale
 
+import "net"
+
 // Network represents a network
 type Network struct {
 	ID                          string         `json:"id"`
@@ -12,17 +14,17 @@ type Network struct {
 	Cidr                        string         `json:"cidr,omitempty"`
 	DisplayNetwork              bool           `json:"diplaynetwork,omitempty"`
 	DisplayText                 string         `json:"displaytext"`
-	DNS1                        string         `json:"dns1,omitempty"`
-	DNS2                        string         `json:"dns2,omitempty"`
+	DNS1                        net.IP         `json:"dns1,omitempty"`
+	DNS2                        net.IP         `json:"dns2,omitempty"`
 	Domain                      string         `json:"domain,omitempty"`
 	DomainID                    string         `json:"domainid,omitempty"`
-	Gateway                     string         `json:"gateway,omitempty"`
+	Gateway                     net.IP         `json:"gateway,omitempty"`
 	IP6Cidr                     string         `json:"ip6cidr,omitempty"`
-	IP6Gateway                  string         `json:"ip6gateway,omitempty"`
+	IP6Gateway                  net.IP         `json:"ip6gateway,omitempty"`
 	IsDefault                   bool           `json:"isdefault,omitempty"`
 	IsPersistent                bool           `json:"ispersistent,omitempty"`
 	Name                        string         `json:"name"`
-	Netmask                     string         `json:"netmask,omitempty"`
+	Netmask                     net.IP         `json:"netmask,omitempty"`
 	NetworkCidr                 string         `json:"networkcidr,omitempty"`
 	NetworkDomain               string         `json:"networkdomain,omitempty"`
 	NetworkOfferingAvailability string         `json:"networkofferingavailability,omitempty"`
@@ -93,18 +95,18 @@ type CreateNetwork struct {
 	ACLType           string `json:"acltype,omitempty"`        // Account or Domain
 	DisplayNetwork    bool   `json:"displaynetwork,omitempty"` // root only
 	DomainID          string `json:"domainid,omitempty"`
-	EndIP             string `json:"endip,omitempty"`
-	EndIpv6           string `json:"endipv6,omitempty"`
-	Gateway           string `json:"gateway,omitempty"`
+	EndIP             net.IP `json:"endip,omitempty"`
+	EndIpv6           net.IP `json:"endipv6,omitempty"`
+	Gateway           net.IP `json:"gateway,omitempty"`
 	IP6Cidr           string `json:"ip6cidr,omitempty"`
-	IP6Gateway        string `json:"ip6gateway,omitempty"`
+	IP6Gateway        net.IP `json:"ip6gateway,omitempty"`
 	IsolatedPVlan     string `json:"isolatedpvlan,omitempty"`
-	Netmask           string `json:"netmask,omitempty"`
+	Netmask           net.IP `json:"netmask,omitempty"`
 	NetworkDomain     string `json:"networkdomain,omitempty"`
 	PhysicalNetworkID string `json:"physicalnetworkid,omitempty"`
 	ProjectID         string `json:"projectid,omitempty"`
-	StartIP           string `json:"startip,omitempty"`
-	StartIpv6         string `json:"startipv6,omitempty"`
+	StartIP           net.IP `json:"startip,omitempty"`
+	StartIpv6         net.IP `json:"startipv6,omitempty"`
 	SubdomainAccess   string `json:"subdomainaccess,omitempty"`
 	Vlan              string `json:"vlan,omitempty"`
 	VpcID             string `json:"vpcid,omitempty"`
@@ -128,13 +130,13 @@ type UpdateNetwork struct {
 	ID                string `json:"id"`
 	ChangeCidr        bool   `json:"changecidr,omitempty"`
 	CustomID          string `json:"customid,omitempty"` // root only
-	DisplayNetwork    string `json:"displaynetwork"`
-	DisplayText       string `json:"displaytext"`
+	DisplayNetwork    string `json:"displaynetwork,omitempty"`
+	DisplayText       string `json:"displaytext,omitempty"`
 	Forced            bool   `json:"forced,omitempty"`
 	GuestVMCidr       string `json:"guestvmcidr,omitempty"`
-	Name              string `json:"name"`
+	Name              string `json:"name,omitempty"`
 	NetworkDomain     string `json:"networkdomain,omitempty"`
-	NetworkOfferingID string `json:"networkofferingid"`
+	NetworkOfferingID string `json:"networkofferingid,omitempty"`
 	UpdateInSequence  bool   `json:"updateinsequence,omitempty"`
 }
 

--- a/nics.go
+++ b/nics.go
@@ -1,18 +1,23 @@
 package egoscale
 
+import (
+	"fmt"
+	"net"
+)
+
 // Nic represents a Network Interface Controller (NIC)
 type Nic struct {
 	ID               string            `json:"id,omitempty"`
 	BroadcastURI     string            `json:"broadcasturi,omitempty"`
-	Gateway          string            `json:"gateway,omitempty"`
-	IP6Address       string            `json:"ip6address,omitempty"`
+	Gateway          net.IP            `json:"gateway,omitempty"`
+	IP6Address       net.IP            `json:"ip6address,omitempty"`
 	IP6Cidr          string            `json:"ip6cidr,omitempty"`
-	IP6Gateway       string            `json:"ip6gateway,omitempty"`
-	IPAddress        string            `json:"ipaddress,omitempty"`
+	IP6Gateway       net.IP            `json:"ip6gateway,omitempty"`
+	IPAddress        net.IP            `json:"ipaddress,omitempty"`
 	IsDefault        bool              `json:"isdefault,omitempty"`
 	IsolationURI     string            `json:"isolationuri,omitempty"`
 	MacAddress       string            `json:"macaddress,omitempty"`
-	Netmask          string            `json:"netmask,omitempty"`
+	Netmask          net.IP            `json:"netmask,omitempty"`
 	NetworkID        string            `json:"networkid,omitempty"`
 	NetworkName      string            `json:"networkname,omitempty"`
 	SecondaryIP      []*NicSecondaryIP `json:"secondaryip,omitempty"`
@@ -24,7 +29,7 @@ type Nic struct {
 // NicSecondaryIP represents a link between NicID and IPAddress
 type NicSecondaryIP struct {
 	ID               string `json:"id"`
-	IPAddress        string `json:"ipaddress"`
+	IPAddress        net.IP `json:"ipaddress"`
 	NetworkID        string `json:"networkid"`
 	NicID            string `json:"nicid"`
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
@@ -58,7 +63,7 @@ type ListNicsResponse struct {
 // AddIPToNic represents the assignation of a secondary IP
 type AddIPToNic struct {
 	NicID     string `json:"nicid"`
-	IPAddress string `json:"ipaddress"`
+	IPAddress net.IP `json:"ipaddress"`
 }
 
 func (req *AddIPToNic) name() string {
@@ -102,9 +107,13 @@ func (exo *Client) ListNics(req *ListNics) ([]*Nic, error) {
 //
 // Deprecated: use the API directly
 func (exo *Client) AddIPToNic(nicID string, ipAddress string, async AsyncInfo) (*NicSecondaryIP, error) {
+	ip := net.ParseIP(ipAddress)
+	if ip == nil {
+		return nil, fmt.Errorf("%s is not a valid IP address", ipAddress)
+	}
 	req := &AddIPToNic{
 		NicID:     nicID,
-		IPAddress: ipAddress,
+		IPAddress: ip,
 	}
 	resp, err := exo.AsyncRequest(req, async)
 	if err != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -29,6 +30,7 @@ func TestPrepareValues(t *testing.T) {
 		IDs      []string          `json:"ids,omitempty"`
 		Tags     []*tag            `json:"tags,omitempty"`
 		Map      map[string]string `json:"map"`
+		IP       net.IP            `json:"ip,omitempty"`
 	}{
 		IgnoreMe: "bar",
 		Name:     "world",
@@ -45,6 +47,7 @@ func TestPrepareValues(t *testing.T) {
 		Map: map[string]string{
 			"foo": "bar",
 		},
+		IP: net.IPv4(192, 168, 0, 11),
 	}
 
 	params := url.Values{}
@@ -91,6 +94,11 @@ func TestPrepareValues(t *testing.T) {
 	v = params.Get("is_great")
 	if v != "false" {
 		t.Errorf("expected bool to be serialized as \"false\", got %#v", v)
+	}
+
+	v = params.Get("ip")
+	if v != "192.168.0.11" {
+		t.Errorf("expected ip to be serialized as \"192.168.0.11\", got %#v", v)
 	}
 }
 
@@ -161,6 +169,32 @@ func TestPrepareValuesSliceString(t *testing.T) {
 	profile := struct {
 		RequiredField []string `json:"requiredfield"`
 	}{}
+
+	params := url.Values{}
+	err := prepareValues("", &params, &profile)
+	if err == nil {
+		t.Errorf("It should have failed")
+	}
+}
+
+func TestPrepareValuesIP(t *testing.T) {
+	profile := struct {
+		RequiredField net.IP `json:"requiredfield"`
+	}{}
+
+	params := url.Values{}
+	err := prepareValues("", &params, &profile)
+	if err == nil {
+		t.Errorf("It should have failed")
+	}
+}
+
+func TestPrepareValuesIPZero(t *testing.T) {
+	profile := struct {
+		RequiredField net.IP `json:"requiredfield"`
+	}{
+		RequiredField: net.IPv4zero,
+	}
 
 	params := url.Values{}
 	err := prepareValues("", &params, &profile)

--- a/zones.go
+++ b/zones.go
@@ -1,5 +1,7 @@
 package egoscale
 
+import "net"
+
 // Zone represents a data center
 type Zone struct {
 	ID                    string            `json:"id"`
@@ -8,16 +10,16 @@ type Zone struct {
 	Description           string            `json:"description,omitempty"`
 	DhcpProvider          string            `json:"dhcpprovider,omitempty"`
 	DisplayText           string            `json:"displaytext,omitempty"`
-	DNS1                  string            `json:"dns1,omitempty"`
-	DNS2                  string            `json:"dns2,omitempty"`
+	DNS1                  net.IP            `json:"dns1,omitempty"`
+	DNS2                  net.IP            `json:"dns2,omitempty"`
 	Domain                string            `json:"domain,omitempty"`
 	DomainID              string            `json:"domainid,omitempty"`
 	DomainName            string            `json:"domainname,omitempty"`
 	GuestCidrAddress      string            `json:"guestcidraddress,omitempty"`
-	InternalDNS1          string            `json:"internaldns1,omitempty"`
-	InternalDNS2          string            `json:"internaldns2,omitempty"`
-	IP6DNS1               string            `json:"ip6dns1,omitempty"`
-	IP6DNS2               string            `json:"ip6dns2,omitempty"`
+	InternalDNS1          net.IP            `json:"internaldns1,omitempty"`
+	InternalDNS2          net.IP            `json:"internaldns2,omitempty"`
+	IP6DNS1               net.IP            `json:"ip6dns1,omitempty"`
+	IP6DNS2               net.IP            `json:"ip6dns2,omitempty"`
 	LocalStorageEnabled   bool              `json:"localstorageenabled,omitempty"`
 	Name                  string            `json:"name,omitempty"`
 	NetworkType           string            `json:"networktype,omitempty"`


### PR DESCRIPTION
`net.IP` safely serializes to json back and forth.

https://play.golang.org/p/lY04V2brMmN

It's not the case for `net.IPMask`, or `net.HardwareAddr`.