### PR TITLE
global: less pointers, keep it simple

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -4,38 +4,38 @@ import "net"
 
 // IPAddress represents an IP Address
 type IPAddress struct {
-	ID                        string         `json:"id"`
-	Account                   string         `json:"account,omitempty"`
-	AllocatedAt               string         `json:"allocated,omitempty"`
-	AssociatedNetworkID       string         `json:"associatednetworkid,omitempty"`
-	AssociatedNetworkName     string         `json:"associatednetworkname,omitempty"`
-	DomainID                  string         `json:"domainid,omitempty"`
-	DomainName                string         `json:"domainname,omitempty"`
-	ForDisplay                bool           `json:"fordisplay,omitempty"`
-	ForVirtualNetwork         bool           `json:"forvirtualnetwork,omitempty"`
-	IPAddress                 net.IP         `json:"ipaddress"`
-	IsElastic                 bool           `json:"iselastic,omitempty"`
-	IsPortable                bool           `json:"isportable,omitempty"`
-	IsSourceNat               bool           `json:"issourcenat,omitempty"`
-	IsSystem                  bool           `json:"issystem,omitempty"`
-	NetworkID                 string         `json:"networkid,omitempty"`
-	PhysicalNetworkID         string         `json:"physicalnetworkid,omitempty"`
-	Project                   string         `json:"project,omitempty"`
-	ProjectID                 string         `json:"projectid,omitempty"`
-	Purpose                   string         `json:"purpose,omitempty"`
-	State                     string         `json:"state,omitempty"`
-	VirtualMachineDisplayName string         `json:"virtualmachinedisplayname,omitempty"`
-	VirtualMachineID          string         `json:"virtualmachineid,omitempty"`
-	VirtualMachineName        string         `json:"virtualmachineName,omitempty"`
-	VlanID                    string         `json:"vlanid,omitempty"`
-	VlanName                  string         `json:"vlanname,omitempty"`
-	VMIPAddress               net.IP         `json:"vmipaddress,omitempty"`
-	VpcID                     string         `json:"vpcid,omitempty"`
-	ZoneID                    string         `json:"zoneid,omitempty"`
-	ZoneName                  string         `json:"zonename,omitempty"`
-	Tags                      []*ResourceTag `json:"tags,omitempty"`
-	JobID                     string         `json:"jobid,omitempty"`
-	JobStatus                 JobStatusType  `json:"jobstatus,omitempty"`
+	ID                        string        `json:"id"`
+	Account                   string        `json:"account,omitempty"`
+	AllocatedAt               string        `json:"allocated,omitempty"`
+	AssociatedNetworkID       string        `json:"associatednetworkid,omitempty"`
+	AssociatedNetworkName     string        `json:"associatednetworkname,omitempty"`
+	DomainID                  string        `json:"domainid,omitempty"`
+	DomainName                string        `json:"domainname,omitempty"`
+	ForDisplay                bool          `json:"fordisplay,omitempty"`
+	ForVirtualNetwork         bool          `json:"forvirtualnetwork,omitempty"`
+	IPAddress                 net.IP        `json:"ipaddress"`
+	IsElastic                 bool          `json:"iselastic,omitempty"`
+	IsPortable                bool          `json:"isportable,omitempty"`
+	IsSourceNat               bool          `json:"issourcenat,omitempty"`
+	IsSystem                  bool          `json:"issystem,omitempty"`
+	NetworkID                 string        `json:"networkid,omitempty"`
+	PhysicalNetworkID         string        `json:"physicalnetworkid,omitempty"`
+	Project                   string        `json:"project,omitempty"`
+	ProjectID                 string        `json:"projectid,omitempty"`
+	Purpose                   string        `json:"purpose,omitempty"`
+	State                     string        `json:"state,omitempty"`
+	VirtualMachineDisplayName string        `json:"virtualmachinedisplayname,omitempty"`
+	VirtualMachineID          string        `json:"virtualmachineid,omitempty"`
+	VirtualMachineName        string        `json:"virtualmachineName,omitempty"`
+	VlanID                    string        `json:"vlanid,omitempty"`
+	VlanName                  string        `json:"vlanname,omitempty"`
+	VMIPAddress               net.IP        `json:"vmipaddress,omitempty"`
+	VpcID                     string        `json:"vpcid,omitempty"`
+	ZoneID                    string        `json:"zoneid,omitempty"`
+	ZoneName                  string        `json:"zonename,omitempty"`
+	Tags                      []ResourceTag `json:"tags,omitempty"`
+	JobID                     string        `json:"jobid,omitempty"`
+	JobStatus                 JobStatusType `json:"jobstatus,omitempty"`
 }
 
 // AssociateIPAddress (Async) represents the IP creation
@@ -63,7 +63,7 @@ func (*AssociateIPAddress) asyncResponse() interface{} {
 
 // AssociateIPAddressResponse represents the response to the creation of an IPAddress
 type AssociateIPAddressResponse struct {
-	IPAddress *IPAddress `json:"ipaddress"`
+	IPAddress IPAddress `json:"ipaddress"`
 }
 
 // DisassociateIPAddress (Async) represents the IP deletion
@@ -103,29 +103,29 @@ type UpdateIPAddressResponse AssociateIPAddressResponse
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listPublicIpAddresses.html
 type ListPublicIPAddresses struct {
-	Account            string         `json:"account,omitempty"`
-	AllocatedOnly      bool           `json:"allocatedonly,omitempty"`
-	AllocatedNetworkID string         `json:"allocatednetworkid,omitempty"`
-	DomainID           string         `json:"domainid,omitempty"`
-	ForDisplay         bool           `json:"fordisplay,omitempty"`
-	ForLoadBalancing   bool           `json:"forloadbalancing,omitempty"`
-	ForVirtualNetwork  string         `json:"forvirtualnetwork,omitempty"`
-	ID                 string         `json:"id,omitempty"`
-	IPAddress          net.IP         `json:"ipaddress,omitempty"`
-	IsElastic          bool           `json:"iselastic,omitempty"`
-	IsRecursive        bool           `json:"isrecursive,omitempty"`
-	IsSourceNat        bool           `json:"issourcenat,omitempty"`
-	IsStaticNat        bool           `json:"isstaticnat,omitempty"`
-	Keyword            string         `json:"keyword,omitempty"`
-	ListAll            bool           `json:"listall,omiempty"`
-	Page               int            `json:"page,omitempty"`
-	PageSize           int            `json:"pagesize,omitempty"`
-	PhysicalNetworkID  string         `json:"physicalnetworkid,omitempty"`
-	ProjectID          string         `json:"projectid,omitempty"`
-	Tags               []*ResourceTag `json:"tags,omitempty"`
-	VlanID             string         `json:"vlanid,omitempty"`
-	VpcID              string         `json:"vpcid,omitempty"`
-	ZoneID             string         `json:"zoneid,omitempty"`
+	Account            string        `json:"account,omitempty"`
+	AllocatedOnly      bool          `json:"allocatedonly,omitempty"`
+	AllocatedNetworkID string        `json:"allocatednetworkid,omitempty"`
+	DomainID           string        `json:"domainid,omitempty"`
+	ForDisplay         bool          `json:"fordisplay,omitempty"`
+	ForLoadBalancing   bool          `json:"forloadbalancing,omitempty"`
+	ForVirtualNetwork  string        `json:"forvirtualnetwork,omitempty"`
+	ID                 string        `json:"id,omitempty"`
+	IPAddress          net.IP        `json:"ipaddress,omitempty"`
+	IsElastic          bool          `json:"iselastic,omitempty"`
+	IsRecursive        bool          `json:"isrecursive,omitempty"`
+	IsSourceNat        bool          `json:"issourcenat,omitempty"`
+	IsStaticNat        bool          `json:"isstaticnat,omitempty"`
+	Keyword            string        `json:"keyword,omitempty"`
+	ListAll            bool          `json:"listall,omiempty"`
+	Page               int           `json:"page,omitempty"`
+	PageSize           int           `json:"pagesize,omitempty"`
+	PhysicalNetworkID  string        `json:"physicalnetworkid,omitempty"`
+	ProjectID          string        `json:"projectid,omitempty"`
+	Tags               []ResourceTag `json:"tags,omitempty"`
+	VlanID             string        `json:"vlanid,omitempty"`
+	VpcID              string        `json:"vpcid,omitempty"`
+	ZoneID             string        `json:"zoneid,omitempty"`
 }
 
 func (*ListPublicIPAddresses) name() string {
@@ -138,6 +138,6 @@ func (*ListPublicIPAddresses) response() interface{} {
 
 // ListPublicIPAddressesResponse represents a list of public IP addresses
 type ListPublicIPAddressesResponse struct {
-	Count           int          `json:"count"`
-	PublicIPAddress []*IPAddress `json:"publicipaddress"`
+	Count           int         `json:"count"`
+	PublicIPAddress []IPAddress `json:"publicipaddress"`
 }

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -32,17 +32,17 @@ type CreateAffinityGroup struct {
 	DomainID    string `json:"domainid,omitempty"`
 }
 
-func (req *CreateAffinityGroup) name() string {
+func (*CreateAffinityGroup) name() string {
 	return "createAffinityGroup"
 }
 
-func (req *CreateAffinityGroup) asyncResponse() interface{} {
+func (*CreateAffinityGroup) asyncResponse() interface{} {
 	return new(CreateAffinityGroupResponse)
 }
 
 // CreateAffinityGroupResponse represents the response of the creation of an (anti-)affinity group
 type CreateAffinityGroupResponse struct {
-	AffinityGroup *AffinityGroup `json:"affinitygroup"`
+	AffinityGroup AffinityGroup `json:"affinitygroup"`
 }
 
 // UpdateVMAffinityGroup (Async) represents a modification of a (anti-)affinity group
@@ -54,11 +54,11 @@ type UpdateVMAffinityGroup struct {
 	AffinityGroupNames []string `json:"affinitygroupnames,omitempty"` // mutually exclusive with ids
 }
 
-func (req *UpdateVMAffinityGroup) name() string {
+func (*UpdateVMAffinityGroup) name() string {
 	return "updateVMAffinityGroup"
 }
 
-func (req *UpdateVMAffinityGroup) asyncResponse() interface{} {
+func (*UpdateVMAffinityGroup) asyncResponse() interface{} {
 	return new(UpdateVMAffinityGroupResponse)
 }
 
@@ -85,11 +85,11 @@ type DeleteAffinityGroup struct {
 	DomainID    string `json:"domainid,omitempty"`
 }
 
-func (req *DeleteAffinityGroup) name() string {
+func (*DeleteAffinityGroup) name() string {
 	return "deleteAffinityGroup"
 }
 
-func (req *DeleteAffinityGroup) asyncResponse() interface{} {
+func (*DeleteAffinityGroup) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -110,11 +110,11 @@ type ListAffinityGroups struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-func (req *ListAffinityGroups) name() string {
+func (*ListAffinityGroups) name() string {
 	return "listAffinityGroups"
 }
 
-func (req *ListAffinityGroups) response() interface{} {
+func (*ListAffinityGroups) response() interface{} {
 	return new(ListAffinityGroupsResponse)
 }
 
@@ -127,24 +127,24 @@ type ListAffinityGroupTypes struct {
 	PageSize int    `json:"pagesize,omitempty"`
 }
 
-func (req *ListAffinityGroupTypes) name() string {
+func (*ListAffinityGroupTypes) name() string {
 	return "listAffinityGroupTypes"
 }
 
-func (req *ListAffinityGroupTypes) response() interface{} {
+func (*ListAffinityGroupTypes) response() interface{} {
 	return new(ListAffinityGroupTypesResponse)
 }
 
 // ListAffinityGroupsResponse represents a list of (anti-)affinity groups
 type ListAffinityGroupsResponse struct {
-	Count         int              `json:"count"`
-	AffinityGroup []*AffinityGroup `json:"affinitygroup"`
+	Count         int             `json:"count"`
+	AffinityGroup []AffinityGroup `json:"affinitygroup"`
 }
 
 // ListAffinityGroupTypesResponse represents a list of (anti-)affinity group types
 type ListAffinityGroupTypesResponse struct {
-	Count             int                  `json:"count"`
-	AffinityGroupType []*AffinityGroupType `json:"affinitygrouptype"`
+	Count             int                 `json:"count"`
+	AffinityGroupType []AffinityGroupType `json:"affinitygrouptype"`
 }
 
 // Legacy methods
@@ -161,7 +161,8 @@ func (exo *Client) CreateAffinityGroup(name string, async AsyncInfo) (*AffinityG
 		return nil, err
 	}
 
-	return resp.(CreateAffinityGroupResponse).AffinityGroup, nil
+	ag := resp.(*CreateAffinityGroupResponse).AffinityGroup
+	return &ag, nil
 }
 
 // DeleteAffinityGroup deletes a group

--- a/apis.go
+++ b/apis.go
@@ -2,14 +2,14 @@ package egoscale
 
 // API represents an API service
 type API struct {
-	Description string         `json:"description"`
-	IsAsync     bool           `json:"isasync"`
-	Name        string         `json:"name"`
-	Related     string         `json:"related"` // comma separated
-	Since       string         `json:"since"`
-	Type        string         `json:"type"`
-	Params      []*APIParam    `json:"params"`
-	Response    []*APIResponse `json:"responses"`
+	Description string        `json:"description"`
+	IsAsync     bool          `json:"isasync"`
+	Name        string        `json:"name"`
+	Related     string        `json:"related"` // comma separated
+	Since       string        `json:"since"`
+	Type        string        `json:"type"`
+	Params      []APIParam    `json:"params"`
+	Response    []APIResponse `json:"responses"`
 }
 
 // APIParam represents an API parameter field
@@ -24,10 +24,10 @@ type APIParam struct {
 
 // APIResponse represents an API response field
 type APIResponse struct {
-	Description string         `json:"description"`
-	Name        string         `json:"name"`
-	Response    []*APIResponse `json:"response"`
-	Type        string         `json:"type"`
+	Description string        `json:"description"`
+	Name        string        `json:"name"`
+	Response    []APIResponse `json:"response"`
+	Type        string        `json:"type"`
 }
 
 // ListAPIs represents a query to list the api
@@ -37,16 +37,16 @@ type ListAPIs struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (req *ListAPIs) name() string {
+func (*ListAPIs) name() string {
 	return "listApis"
 }
 
-func (req *ListAPIs) response() interface{} {
+func (*ListAPIs) response() interface{} {
 	return new(ListAPIsResponse)
 }
 
 // ListAPIsResponse represents a list of API
 type ListAPIsResponse struct {
-	Count int    `json:"count"`
-	API   []*API `json:"api"`
+	Count int   `json:"count"`
+	API   []API `json:"api"`
 }

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -27,11 +27,11 @@ type QueryAsyncJobResult struct {
 	JobID string `json:"jobid"`
 }
 
-func (req *QueryAsyncJobResult) name() string {
+func (*QueryAsyncJobResult) name() string {
 	return "queryAsyncJobResult"
 }
 
-func (req *QueryAsyncJobResult) response() interface{} {
+func (*QueryAsyncJobResult) response() interface{} {
 	return new(QueryAsyncJobResultResponse)
 }
 
@@ -51,16 +51,16 @@ type ListAsyncJobs struct {
 	StartDate   string `json:"startdate,omitempty"`
 }
 
-func (req *ListAsyncJobs) name() string {
+func (*ListAsyncJobs) name() string {
 	return "listAsyncJobs"
 }
 
-func (req *ListAsyncJobs) response() interface{} {
+func (*ListAsyncJobs) response() interface{} {
 	return new(ListAsyncJobsResponse)
 }
 
 // ListAsyncJobsResponse represents a list of job results
 type ListAsyncJobsResponse struct {
-	Count     int               `json:"count"`
-	AsyncJobs []*AsyncJobResult `json:"asyncjobs"`
+	Count     int              `json:"count"`
+	AsyncJobs []AsyncJobResult `json:"asyncjobs"`
 }

--- a/dns.go
+++ b/dns.go
@@ -50,7 +50,7 @@ type DNSRecord struct {
 
 // DNSRecordResponse represents the creation of a DNS record
 type DNSRecordResponse struct {
-	Record *DNSRecord `json:"record"`
+	Record DNSRecord `json:"record"`
 }
 
 // DNSErrorResponse represents an error in the API
@@ -129,27 +129,27 @@ func (exo *Client) GetRecord(domain string, recordID int64) (*DNSRecord, error) 
 		return nil, err
 	}
 
-	var r *DNSRecordResponse
+	var r DNSRecordResponse
 	if err = json.Unmarshal(resp, &r); err != nil {
 		return nil, err
 	}
 
-	return r.Record, nil
+	return &(r.Record), nil
 }
 
 // GetRecords returns the DNS records
-func (exo *Client) GetRecords(name string) ([]*DNSRecord, error) {
+func (exo *Client) GetRecords(name string) ([]DNSRecord, error) {
 	resp, err := exo.dnsRequest("/v1/domains/"+name+"/records", "", "GET")
 	if err != nil {
 		return nil, err
 	}
 
-	var r []*DNSRecordResponse
+	var r []DNSRecordResponse
 	if err = json.Unmarshal(resp, &r); err != nil {
 		return nil, err
 	}
 
-	records := make([]*DNSRecord, 0, len(r))
+	records := make([]DNSRecord, 0, len(r))
 	for _, rec := range r {
 		records = append(records, rec.Record)
 	}
@@ -160,7 +160,7 @@ func (exo *Client) GetRecords(name string) ([]*DNSRecord, error) {
 // CreateRecord creates a DNS record
 func (exo *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
 	body, err := json.Marshal(DNSRecordResponse{
-		Record: &rec,
+		Record: rec,
 	})
 	if err != nil {
 		return nil, err
@@ -171,18 +171,18 @@ func (exo *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 		return nil, err
 	}
 
-	var r *DNSRecordResponse
+	var r DNSRecordResponse
 	if err = json.Unmarshal(resp, &r); err != nil {
 		return nil, err
 	}
 
-	return r.Record, nil
+	return &(r.Record), nil
 }
 
 // UpdateRecord updates a DNS record
 func (exo *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
 	body, err := json.Marshal(DNSRecordResponse{
-		Record: &rec,
+		Record: rec,
 	})
 	if err != nil {
 		return nil, err
@@ -194,12 +194,12 @@ func (exo *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 		return nil, err
 	}
 
-	var r *DNSRecordResponse
+	var r DNSRecordResponse
 	if err = json.Unmarshal(resp, &r); err != nil {
 		return nil, err
 	}
 
-	return r.Record, nil
+	return &(r.Record), nil
 }
 
 // DeleteRecord deletes a record

--- a/doc.go
+++ b/doc.go
@@ -2,6 +2,12 @@
 
 Package egoscale is a mapping for with the CloudStack API (http://cloudstack.apache.org/api.html) from Go. It has been designed against the Exoscale (https://www.exoscale.ch/) infrastructure but should fit other CloudStack services.
 
+Requests and Responses
+
+The paradigm used in this library is that CloudStack defines two types of requests synchronous (client.Request) and asynchronous (client.AsyncRequest). And when the expected responses is a success message, you may use the boolean requests variants (client.BooleanRequest, client.BooleanAsyncRequest). To build a request, construct the adequate struct. This library expects a pointer for efficiency reasons only. The response is a struct corresponding to the request itself. E.g. DeployVirtualMachine gives DeployVirtualMachineResponse, as a pointer as well to avoid big copies.
+
+Then everything within the struct is not a pointer.
+
 Affinity and Anti-Affinity groups
 
 Affinity and Anti-Affinity groups provide a way to influence where VMs should run. See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/stable/virtual_machines.html#affinity-groups
@@ -17,7 +23,7 @@ All the available APIs on the server and provided by the API Discovery plugin
 		panic(err)
 	}
 
-	for _, api := range resp.(*ListAPIsResponse).API {
+	for _, api := range resp.(*egoscale.ListAPIsResponse).API {
 		fmt.Println("%s %s", api.Name, api.Description)
 	}
 	// Output:
@@ -42,13 +48,13 @@ Security Groups
 
 Security Groups provide a way to isolate traffic to VMs.
 
-	resp, err := cs.Request(&CreateSecurityGroup{
+	resp, err := cs.Request(&egoscale.CreateSecurityGroup{
 		Name: "Load balancer",
 		Description: "Opens HTTP/HTTPS ports from the outside world",
 	})
-	securityGroup := resp.(*CreateSecurityGroupResponse).SecurityGroup
+	securityGroup := resp.(*egoscale.CreateSecurityGroupResponse).SecurityGroup
 	// ...
-	err = client.BooleanRequest(&DeleteSecurityGroup{
+	err = client.BooleanRequest(&egoscale.DeleteSecurityGroup{
 		ID: securityGroup.ID,
 	})
 	// ...
@@ -72,6 +78,12 @@ Virtual Machines
 ... todo ...
 
 See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/stable/virtual_machines.html
+
+Templates
+
+... todo ...
+
+See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/templates.html
 
 Zones
 

--- a/events.go
+++ b/events.go
@@ -43,18 +43,18 @@ type ListEvents struct {
 	Type        string `json:"type,omitempty"`
 }
 
-func (req *ListEvents) name() string {
+func (*ListEvents) name() string {
 	return "listEvents"
 }
 
-func (req *ListEvents) response() interface{} {
+func (*ListEvents) response() interface{} {
 	return new(ListEventsResponse)
 }
 
 // ListEventsResponse represents a response of a list query
 type ListEventsResponse struct {
-	Count int      `json:"count"`
-	Event []*Event `json:"event"`
+	Count int     `json:"count"`
+	Event []Event `json:"event"`
 }
 
 // ListEventTypes list the event types
@@ -62,16 +62,16 @@ type ListEventsResponse struct {
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/listEventTypes.html
 type ListEventTypes struct{}
 
-func (req *ListEventTypes) name() string {
+func (*ListEventTypes) name() string {
 	return "listEventTypes"
 }
 
-func (req *ListEventTypes) response() interface{} {
+func (*ListEventTypes) response() interface{} {
 	return new(ListEventTypesResponse)
 }
 
 // ListEventTypesResponse represents a response of a list query
 type ListEventTypesResponse struct {
-	Count     int          `json:"count"`
-	EventType []*EventType `json:"eventtype"`
+	Count     int         `json:"count"`
+	EventType []EventType `json:"eventtype"`
 }

--- a/keypairs.go
+++ b/keypairs.go
@@ -20,17 +20,17 @@ type CreateSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (req *CreateSSHKeyPair) name() string {
+func (*CreateSSHKeyPair) name() string {
 	return "createSSHKeyPair"
 }
 
-func (req *CreateSSHKeyPair) response() interface{} {
+func (*CreateSSHKeyPair) response() interface{} {
 	return new(CreateSSHKeyPairResponse)
 }
 
 // CreateSSHKeyPairResponse represents the creation of an SSH Key Pair
 type CreateSSHKeyPairResponse struct {
-	KeyPair *SSHKeyPair `json:"keypair"`
+	KeyPair SSHKeyPair `json:"keypair"`
 }
 
 // DeleteSSHKeyPair represents a new keypair to be created
@@ -43,11 +43,11 @@ type DeleteSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (req *DeleteSSHKeyPair) name() string {
+func (*DeleteSSHKeyPair) name() string {
 	return "deleteSSHKeyPair"
 }
 
-func (req *DeleteSSHKeyPair) response() interface{} {
+func (*DeleteSSHKeyPair) response() interface{} {
 	return new(booleanSyncResponse)
 }
 
@@ -62,17 +62,17 @@ type RegisterSSHKeyPair struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (req *RegisterSSHKeyPair) name() string {
+func (*RegisterSSHKeyPair) name() string {
 	return "registerSSHKeyPair"
 }
 
-func (req *RegisterSSHKeyPair) response() interface{} {
+func (*RegisterSSHKeyPair) response() interface{} {
 	return new(RegisterSSHKeyPairResponse)
 }
 
 // RegisterSSHKeyPairResponse represents the creation of an SSH Key Pair
 type RegisterSSHKeyPairResponse struct {
-	KeyPair *SSHKeyPair `json:"keypair"`
+	KeyPair SSHKeyPair `json:"keypair"`
 }
 
 // ListSSHKeyPairs represents a query for a list of SSH KeyPairs
@@ -91,18 +91,18 @@ type ListSSHKeyPairs struct {
 	ProjectID   string `json:"projectid,omitempty"`
 }
 
-func (req *ListSSHKeyPairs) name() string {
+func (*ListSSHKeyPairs) name() string {
 	return "listSSHKeyPairs"
 }
 
-func (req *ListSSHKeyPairs) response() interface{} {
+func (*ListSSHKeyPairs) response() interface{} {
 	return new(ListSSHKeyPairsResponse)
 }
 
 // ListSSHKeyPairsResponse represents a list of SSH key pairs
 type ListSSHKeyPairsResponse struct {
-	Count      int           `json:"count"`
-	SSHKeyPair []*SSHKeyPair `json:"sshkeypair"`
+	Count      int          `json:"count"`
+	SSHKeyPair []SSHKeyPair `json:"sshkeypair"`
 }
 
 // ResetSSHKeyForVirtualMachine (Async) represents a change for the key pairs
@@ -116,11 +116,11 @@ type ResetSSHKeyForVirtualMachine struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-func (req *ResetSSHKeyForVirtualMachine) name() string {
+func (*ResetSSHKeyForVirtualMachine) name() string {
 	return "resetSSHKeyForVirtualMachine"
 }
 
-func (req *ResetSSHKeyForVirtualMachine) asyncResponse() interface{} {
+func (*ResetSSHKeyForVirtualMachine) asyncResponse() interface{} {
 	return new(ResetSSHKeyForVirtualMachineResponse)
 }
 
@@ -139,7 +139,8 @@ func (exo *Client) CreateKeypair(name string) (*SSHKeyPair, error) {
 		return nil, err
 	}
 
-	return resp.(*CreateSSHKeyPairResponse).KeyPair, nil
+	keypair := resp.(*CreateSSHKeyPairResponse).KeyPair
+	return &keypair, nil
 }
 
 // DeleteKeypair deletes an SSH key pair
@@ -165,5 +166,6 @@ func (exo *Client) RegisterKeypair(name string, publicKey string) (*SSHKeyPair, 
 		return nil, err
 	}
 
-	return resp.(*RegisterSSHKeyPairResponse).KeyPair, nil
+	keypair := resp.(*RegisterSSHKeyPairResponse).KeyPair
+	return &keypair, nil
 }

--- a/network_offerings.go
+++ b/network_offerings.go
@@ -22,47 +22,47 @@ type NetworkOffering struct {
 	State                    string            `json:"state"` // Disabled/Enabled/Inactive
 	SupportsPublicAccess     bool              `json:"supportspublicaccess,omitempty"`
 	SupportsStrechedL2Subnet bool              `json:"supportsstrechedl2subnet,omitempty"`
-	Tags                     []*ResourceTag    `json:"tags,omitempty"`
+	Tags                     []ResourceTag     `json:"tags,omitempty"`
 	TrafficType              string            `json:"traffictype,omitempty"` // Public, Management, Control, ...
-	Service                  []*Service        `json:"service,omitempty"`
+	Service                  []Service         `json:"service,omitempty"`
 }
 
 // ListNetworkOfferings represents a query for network offerings
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listNetworkOfferings.html
 type ListNetworkOfferings struct {
-	Availability       string         `json:"availability,omitempty"`
-	DisplayText        string         `json:"displaytext,omitempty"`
-	ForVPC             bool           `json:"forvpc,omitempty"`
-	GuestIPType        string         `json:"guestiptype,omitempty"` // shared of isolated
-	ID                 string         `json:"id,omitempty"`
-	IsDefault          bool           `json:"isdefault,omitempty"`
-	IsTagged           bool           `json:"istagged,omitempty"`
-	Keyword            string         `json:"keyword,omitempty"`
-	Name               string         `json:"name,omitempty"`
-	NetworkID          string         `json:"networkid,omitempty"`
-	Page               int            `json:"page,omitempty"`
-	PageSize           int            `json:"pagesize,omitempty"`
-	SourceNATSupported bool           `json:"sourcenatsupported,omitempty"`
-	SpecifyIPRanges    bool           `json:"specifyipranges,omitempty"`
-	SpecifyVlan        string         `json:"specifyvlan,omitempty"`
-	State              string         `json:"state,omitempty"`
-	SupportedServices  string         `json:"supportedservices,omitempty"`
-	Tags               []*ResourceTag `json:"tags,omitempty"`
-	TrafficType        string         `json:"traffictype,omitempty"`
-	ZoneID             string         `json:"zoneid,omitempty"`
+	Availability       string        `json:"availability,omitempty"`
+	DisplayText        string        `json:"displaytext,omitempty"`
+	ForVPC             bool          `json:"forvpc,omitempty"`
+	GuestIPType        string        `json:"guestiptype,omitempty"` // shared of isolated
+	ID                 string        `json:"id,omitempty"`
+	IsDefault          bool          `json:"isdefault,omitempty"`
+	IsTagged           bool          `json:"istagged,omitempty"`
+	Keyword            string        `json:"keyword,omitempty"`
+	Name               string        `json:"name,omitempty"`
+	NetworkID          string        `json:"networkid,omitempty"`
+	Page               int           `json:"page,omitempty"`
+	PageSize           int           `json:"pagesize,omitempty"`
+	SourceNATSupported bool          `json:"sourcenatsupported,omitempty"`
+	SpecifyIPRanges    bool          `json:"specifyipranges,omitempty"`
+	SpecifyVlan        string        `json:"specifyvlan,omitempty"`
+	State              string        `json:"state,omitempty"`
+	SupportedServices  string        `json:"supportedservices,omitempty"`
+	Tags               []ResourceTag `json:"tags,omitempty"`
+	TrafficType        string        `json:"traffictype,omitempty"`
+	ZoneID             string        `json:"zoneid,omitempty"`
 }
 
-func (req *ListNetworkOfferings) name() string {
+func (*ListNetworkOfferings) name() string {
 	return "listNetworkOfferings"
 }
 
-func (req *ListNetworkOfferings) response() interface{} {
+func (*ListNetworkOfferings) response() interface{} {
 	return new(ListNetworkOfferingsResponse)
 }
 
 // ListNetworkOfferingsResponse represents a list of service offerings
 type ListNetworkOfferingsResponse struct {
-	Count           int                `json:"count"`
-	NetworkOffering []*NetworkOffering `json:"networkoffering"`
+	Count           int               `json:"count"`
+	NetworkOffering []NetworkOffering `json:"networkoffering"`
 }

--- a/networks.go
+++ b/networks.go
@@ -4,60 +4,60 @@ import "net"
 
 // Network represents a network
 type Network struct {
-	ID                          string         `json:"id"`
-	Account                     string         `json:"account"`
-	ACLID                       string         `json:"aclid,omitempty"`
-	ACLType                     string         `json:"acltype,omitempty"`
-	BroadcastDomainType         string         `json:"broadcastdomaintype,omitempty"`
-	BroadcastURI                string         `json:"broadcasturi,omitempty"`
-	CanUseForDeploy             bool           `json:"canusefordeploy,omitempty"`
-	Cidr                        string         `json:"cidr,omitempty"`
-	DisplayNetwork              bool           `json:"diplaynetwork,omitempty"`
-	DisplayText                 string         `json:"displaytext"`
-	DNS1                        net.IP         `json:"dns1,omitempty"`
-	DNS2                        net.IP         `json:"dns2,omitempty"`
-	Domain                      string         `json:"domain,omitempty"`
-	DomainID                    string         `json:"domainid,omitempty"`
-	Gateway                     net.IP         `json:"gateway,omitempty"`
-	IP6Cidr                     string         `json:"ip6cidr,omitempty"`
-	IP6Gateway                  net.IP         `json:"ip6gateway,omitempty"`
-	IsDefault                   bool           `json:"isdefault,omitempty"`
-	IsPersistent                bool           `json:"ispersistent,omitempty"`
-	Name                        string         `json:"name"`
-	Netmask                     net.IP         `json:"netmask,omitempty"`
-	NetworkCidr                 string         `json:"networkcidr,omitempty"`
-	NetworkDomain               string         `json:"networkdomain,omitempty"`
-	NetworkOfferingAvailability string         `json:"networkofferingavailability,omitempty"`
-	NetworkOfferingConserveMode bool           `json:"networkofferingconservemode,omitempty"`
-	NetworkOfferingDisplayText  string         `json:"networkofferingdisplaytext,omitempty"`
-	NetworkOfferingID           string         `json:"networkofferingid,omitempty"`
-	NetworkOfferingName         string         `json:"networkofferingname,omitempty"`
-	PhysicalNetworkID           string         `json:"physicalnetworkid,omitempty"`
-	Project                     string         `json:"project,omitempty"`
-	ProjectID                   string         `json:"projectid,omitempty"`
-	Related                     string         `json:"related,omitempty"`
-	ReserveIPRange              string         `json:"reserveiprange,omitempty"`
-	RestartRequired             bool           `json:"restartrequired,omitempty"`
-	SpecifyIPRanges             bool           `json:"specifyipranges,omitempty"`
-	State                       string         `json:"state"`
-	StrechedL2Subnet            bool           `json:"strechedl2subnet,omitempty"`
-	SubdomainAccess             bool           `json:"subdomainaccess,omitempty"`
-	TrafficType                 string         `json:"traffictype"`
-	Type                        string         `json:"type"`
-	Vlan                        string         `json:"vlan,omitemtpy"` // root only
-	VpcID                       string         `json:"vpcid,omitempty"`
-	ZoneID                      string         `json:"zoneid,omitempty"`
-	ZoneName                    string         `json:"zonename,omitempty"`
-	ZonesNetworkSpans           string         `json:"zonesnetworkspans,omitempty"`
-	Service                     []*Service     `json:"service"`
-	Tags                        []*ResourceTag `json:"tags"`
+	ID                          string        `json:"id"`
+	Account                     string        `json:"account"`
+	ACLID                       string        `json:"aclid,omitempty"`
+	ACLType                     string        `json:"acltype,omitempty"`
+	BroadcastDomainType         string        `json:"broadcastdomaintype,omitempty"`
+	BroadcastURI                string        `json:"broadcasturi,omitempty"`
+	CanUseForDeploy             bool          `json:"canusefordeploy,omitempty"`
+	Cidr                        string        `json:"cidr,omitempty"`
+	DisplayNetwork              bool          `json:"diplaynetwork,omitempty"`
+	DisplayText                 string        `json:"displaytext"`
+	DNS1                        net.IP        `json:"dns1,omitempty"`
+	DNS2                        net.IP        `json:"dns2,omitempty"`
+	Domain                      string        `json:"domain,omitempty"`
+	DomainID                    string        `json:"domainid,omitempty"`
+	Gateway                     net.IP        `json:"gateway,omitempty"`
+	IP6Cidr                     string        `json:"ip6cidr,omitempty"`
+	IP6Gateway                  net.IP        `json:"ip6gateway,omitempty"`
+	IsDefault                   bool          `json:"isdefault,omitempty"`
+	IsPersistent                bool          `json:"ispersistent,omitempty"`
+	Name                        string        `json:"name"`
+	Netmask                     net.IP        `json:"netmask,omitempty"`
+	NetworkCidr                 string        `json:"networkcidr,omitempty"`
+	NetworkDomain               string        `json:"networkdomain,omitempty"`
+	NetworkOfferingAvailability string        `json:"networkofferingavailability,omitempty"`
+	NetworkOfferingConserveMode bool          `json:"networkofferingconservemode,omitempty"`
+	NetworkOfferingDisplayText  string        `json:"networkofferingdisplaytext,omitempty"`
+	NetworkOfferingID           string        `json:"networkofferingid,omitempty"`
+	NetworkOfferingName         string        `json:"networkofferingname,omitempty"`
+	PhysicalNetworkID           string        `json:"physicalnetworkid,omitempty"`
+	Project                     string        `json:"project,omitempty"`
+	ProjectID                   string        `json:"projectid,omitempty"`
+	Related                     string        `json:"related,omitempty"`
+	ReserveIPRange              string        `json:"reserveiprange,omitempty"`
+	RestartRequired             bool          `json:"restartrequired,omitempty"`
+	SpecifyIPRanges             bool          `json:"specifyipranges,omitempty"`
+	State                       string        `json:"state"`
+	StrechedL2Subnet            bool          `json:"strechedl2subnet,omitempty"`
+	SubdomainAccess             bool          `json:"subdomainaccess,omitempty"`
+	TrafficType                 string        `json:"traffictype"`
+	Type                        string        `json:"type"`
+	Vlan                        string        `json:"vlan,omitemtpy"` // root only
+	VpcID                       string        `json:"vpcid,omitempty"`
+	ZoneID                      string        `json:"zoneid,omitempty"`
+	ZoneName                    string        `json:"zonename,omitempty"`
+	ZonesNetworkSpans           string        `json:"zonesnetworkspans,omitempty"`
+	Service                     []Service     `json:"service"`
+	Tags                        []ResourceTag `json:"tags"`
 }
 
 // Service is a feature of a network
 type Service struct {
-	Name       string               `json:"name"`
-	Capability []*ServiceCapability `json:"capability,omitempty"`
-	Provider   []*ServiceProvider   `json:"provider,omitempty"`
+	Name       string              `json:"name"`
+	Capability []ServiceCapability `json:"capability,omitempty"`
+	Provider   []ServiceProvider   `json:"provider,omitempty"`
 }
 
 // ServiceCapability represents optional capability of a service
@@ -79,7 +79,7 @@ type ServiceProvider struct {
 
 // NetworkResponse represents a network
 type NetworkResponse struct {
-	Network *Network `json:"network"`
+	Network Network `json:"network"`
 }
 
 // CreateNetwork creates a network
@@ -112,11 +112,11 @@ type CreateNetwork struct {
 	VpcID             string `json:"vpcid,omitempty"`
 }
 
-func (req *CreateNetwork) name() string {
+func (*CreateNetwork) name() string {
 	return "createNetwork"
 }
 
-func (req *CreateNetwork) response() interface{} {
+func (*CreateNetwork) response() interface{} {
 	return new(CreateNetworkResponse)
 }
 
@@ -140,11 +140,11 @@ type UpdateNetwork struct {
 	UpdateInSequence  bool   `json:"updateinsequence,omitempty"`
 }
 
-func (req *UpdateNetwork) name() string {
+func (*UpdateNetwork) name() string {
 	return "updateNetwork"
 }
 
-func (req *UpdateNetwork) asyncResponse() interface{} {
+func (*UpdateNetwork) asyncResponse() interface{} {
 	return new(UpdateNetworkResponse)
 }
 
@@ -159,11 +159,11 @@ type RestartNetwork struct {
 	Cleanup bool   `json:"cleanup,omitempty"`
 }
 
-func (req *RestartNetwork) name() string {
+func (*RestartNetwork) name() string {
 	return "restartNetwork"
 }
 
-func (req *RestartNetwork) asyncResponse() interface{} {
+func (*RestartNetwork) asyncResponse() interface{} {
 	return new(RestartNetworkResponse)
 }
 
@@ -178,11 +178,11 @@ type DeleteNetwork struct {
 	Forced bool   `json:"forced,omitempty"`
 }
 
-func (req *DeleteNetwork) name() string {
+func (*DeleteNetwork) name() string {
 	return "deleteNetwork"
 }
 
-func (req *DeleteNetwork) asyncResponse() interface{} {
+func (*DeleteNetwork) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -190,41 +190,41 @@ func (req *DeleteNetwork) asyncResponse() interface{} {
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/listNetworks.html
 type ListNetworks struct {
-	Account           string         `json:"account,omitempty"`
-	ACLType           string         `json:"acltype,omitempty"` // Account or Domain
-	CanUseForDeploy   bool           `json:"canusefordeploy,omitempty"`
-	DisplayNetwork    bool           `json:"displaynetwork,omitempty"` // root only
-	DomainID          string         `json:"domainid,omitempty"`
-	ForVpc            string         `json:"forvpc,omitempty"`
-	ID                string         `json:"id,omitempty"`
-	IsRecursive       bool           `json:"isrecursive,omitempty"`
-	IsSystem          bool           `json:"issystem,omitempty"`
-	Keyword           string         `json:"keyword,omitempty"`
-	ListAll           bool           `json:"listall,omitempty"`
-	Page              int            `json:"page,omitempty"`
-	PageSize          int            `json:"pagesize,omitempty"`
-	PhysicalNetworkID string         `json:"physicalnetworkid,omitempty"`
-	ProjectID         string         `json:"projectid,omitempty"`
-	RestartRequired   bool           `json:"restartrequired,omitempty"`
-	SpecifyRanges     bool           `json:"specifyranges,omitempty"`
-	SupportedServices []*Service     `json:"supportedservices,omitempty"`
-	Tags              []*ResourceTag `json:"resourcetag,omitempty"`
-	TrafficType       string         `json:"traffictype,omitempty"`
-	Type              string         `json:"type,omitempty"`
-	VpcID             string         `json:"vpcid,omitempty"`
-	ZoneID            string         `json:"zoneid,omitempty"`
+	Account           string        `json:"account,omitempty"`
+	ACLType           string        `json:"acltype,omitempty"` // Account or Domain
+	CanUseForDeploy   bool          `json:"canusefordeploy,omitempty"`
+	DisplayNetwork    bool          `json:"displaynetwork,omitempty"` // root only
+	DomainID          string        `json:"domainid,omitempty"`
+	ForVpc            string        `json:"forvpc,omitempty"`
+	ID                string        `json:"id,omitempty"`
+	IsRecursive       bool          `json:"isrecursive,omitempty"`
+	IsSystem          bool          `json:"issystem,omitempty"`
+	Keyword           string        `json:"keyword,omitempty"`
+	ListAll           bool          `json:"listall,omitempty"`
+	Page              int           `json:"page,omitempty"`
+	PageSize          int           `json:"pagesize,omitempty"`
+	PhysicalNetworkID string        `json:"physicalnetworkid,omitempty"`
+	ProjectID         string        `json:"projectid,omitempty"`
+	RestartRequired   bool          `json:"restartrequired,omitempty"`
+	SpecifyRanges     bool          `json:"specifyranges,omitempty"`
+	SupportedServices []Service     `json:"supportedservices,omitempty"`
+	Tags              []ResourceTag `json:"resourcetag,omitempty"`
+	TrafficType       string        `json:"traffictype,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	VpcID             string        `json:"vpcid,omitempty"`
+	ZoneID            string        `json:"zoneid,omitempty"`
 }
 
-func (req *ListNetworks) name() string {
+func (*ListNetworks) name() string {
 	return "listNetworks"
 }
 
-func (req *ListNetworks) response() interface{} {
+func (*ListNetworks) response() interface{} {
 	return new(ListNetworksResponse)
 }
 
 // ListNetworksResponse represents the list of networks
 type ListNetworksResponse struct {
-	Count   int        `json:"count"`
-	Network []*Network `json:"network"`
+	Count   int       `json:"count"`
+	Network []Network `json:"network"`
 }

--- a/nics.go
+++ b/nics.go
@@ -7,23 +7,23 @@ import (
 
 // Nic represents a Network Interface Controller (NIC)
 type Nic struct {
-	ID               string            `json:"id,omitempty"`
-	BroadcastURI     string            `json:"broadcasturi,omitempty"`
-	Gateway          net.IP            `json:"gateway,omitempty"`
-	IP6Address       net.IP            `json:"ip6address,omitempty"`
-	IP6Cidr          string            `json:"ip6cidr,omitempty"`
-	IP6Gateway       net.IP            `json:"ip6gateway,omitempty"`
-	IPAddress        net.IP            `json:"ipaddress,omitempty"`
-	IsDefault        bool              `json:"isdefault,omitempty"`
-	IsolationURI     string            `json:"isolationuri,omitempty"`
-	MacAddress       string            `json:"macaddress,omitempty"`
-	Netmask          net.IP            `json:"netmask,omitempty"`
-	NetworkID        string            `json:"networkid,omitempty"`
-	NetworkName      string            `json:"networkname,omitempty"`
-	SecondaryIP      []*NicSecondaryIP `json:"secondaryip,omitempty"`
-	Traffictype      string            `json:"traffictype,omitempty"`
-	Type             string            `json:"type,omitempty"`
-	VirtualMachineID string            `json:"virtualmachineid,omitempty"`
+	ID               string           `json:"id,omitempty"`
+	BroadcastURI     string           `json:"broadcasturi,omitempty"`
+	Gateway          net.IP           `json:"gateway,omitempty"`
+	IP6Address       net.IP           `json:"ip6address,omitempty"`
+	IP6Cidr          string           `json:"ip6cidr,omitempty"`
+	IP6Gateway       net.IP           `json:"ip6gateway,omitempty"`
+	IPAddress        net.IP           `json:"ipaddress,omitempty"`
+	IsDefault        bool             `json:"isdefault,omitempty"`
+	IsolationURI     string           `json:"isolationuri,omitempty"`
+	MacAddress       string           `json:"macaddress,omitempty"`
+	Netmask          net.IP           `json:"netmask,omitempty"`
+	NetworkID        string           `json:"networkid,omitempty"`
+	NetworkName      string           `json:"networkname,omitempty"`
+	SecondaryIP      []NicSecondaryIP `json:"secondaryip,omitempty"`
+	Traffictype      string           `json:"traffictype,omitempty"`
+	Type             string           `json:"type,omitempty"`
+	VirtualMachineID string           `json:"virtualmachineid,omitempty"`
 }
 
 // NicSecondaryIP represents a link between NicID and IPAddress
@@ -46,18 +46,18 @@ type ListNics struct {
 	PageSize         int    `json:"pagesize,omitempty"`
 }
 
-func (req *ListNics) name() string {
+func (*ListNics) name() string {
 	return "listNics"
 }
 
-func (req *ListNics) response() interface{} {
+func (*ListNics) response() interface{} {
 	return new(ListNicsResponse)
 }
 
 // ListNicsResponse represents a list of templates
 type ListNicsResponse struct {
-	Count int    `json:"count"`
-	Nic   []*Nic `json:"nic"`
+	Count int   `json:"count"`
+	Nic   []Nic `json:"nic"`
 }
 
 // AddIPToNic represents the assignation of a secondary IP
@@ -66,16 +66,16 @@ type AddIPToNic struct {
 	IPAddress net.IP `json:"ipaddress"`
 }
 
-func (req *AddIPToNic) name() string {
+func (*AddIPToNic) name() string {
 	return "addIpToNic"
 }
-func (req *AddIPToNic) asyncResponse() interface{} {
+func (*AddIPToNic) asyncResponse() interface{} {
 	return new(AddIPToNicResponse)
 }
 
 // AddIPToNicResponse represents the addition of an IP to a NIC
 type AddIPToNicResponse struct {
-	NicSecondaryIP *NicSecondaryIP `json:"nicsecondaryip"`
+	NicSecondaryIP NicSecondaryIP `json:"nicsecondaryip"`
 }
 
 // RemoveIPFromNic represents a deletion request
@@ -83,18 +83,18 @@ type RemoveIPFromNic struct {
 	ID string `json:"id"`
 }
 
-func (req *RemoveIPFromNic) name() string {
+func (*RemoveIPFromNic) name() string {
 	return "removeIpFromNic"
 }
 
-func (req *RemoveIPFromNic) asyncResponse() interface{} {
+func (*RemoveIPFromNic) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
 // ListNics lists the NIC of a VM
 //
 // Deprecated: use the API directly
-func (exo *Client) ListNics(req *ListNics) ([]*Nic, error) {
+func (exo *Client) ListNics(req *ListNics) ([]Nic, error) {
 	resp, err := exo.Request(req)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,8 @@ func (exo *Client) AddIPToNic(nicID string, ipAddress string, async AsyncInfo) (
 		return nil, err
 	}
 
-	return resp.(AddIPToNicResponse).NicSecondaryIP, nil
+	nic := resp.(AddIPToNicResponse).NicSecondaryIP
+	return &nic, nil
 }
 
 // RemoveIPFromNic removes an IP from a NIC

--- a/request.go
+++ b/request.go
@@ -304,7 +304,7 @@ func (exo *Client) Request(req Command) (interface{}, error) {
 	resp := req.response()
 	if err := json.Unmarshal(body, resp); err != nil {
 		r := new(ErrorResponse)
-		if e := json.Unmarshal(body, &r); e != nil {
+		if e := json.Unmarshal(body, r); e != nil {
 			return nil, r
 		}
 		return nil, err
@@ -312,25 +312,6 @@ func (exo *Client) Request(req Command) (interface{}, error) {
 
 	return resp, nil
 }
-
-// Request performs a simple request
-/*
-func (exo *Client) Request(req Request, v interface{}) error {
-	resp, err := exo.request(req.Name(), req)
-	if err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(resp, v); err != nil {
-		var r ErrorResponse
-		if e := json.Unmarshal(resp, &r); e == nil {
-			return r
-		}
-		return err
-	}
-
-	return nil
-}*/
 
 // request makes a Request while being close to the metal
 func (exo *Client) request(command string, req interface{}) (json.RawMessage, error) {

--- a/security_groups.go
+++ b/security_groups.go
@@ -7,40 +7,40 @@ import (
 
 // SecurityGroup represent a firewalling set of rules
 type SecurityGroup struct {
-	ID                  string         `json:"id"`
-	Account             string         `json:"account,omitempty"`
-	Description         string         `json:"description,omitempty"`
-	Domain              string         `json:"domain,omitempty"`
-	DomainID            string         `json:"domainid,omitempty"`
-	Name                string         `json:"name"`
-	Project             string         `json:"project,omitempty"`
-	ProjectID           string         `json:"projectid,omitempty"`
-	VirtualMachineCount int            `json:"virtualmachinecount,omitempty"` // CloudStack 4.6+
-	VirtualMachineIDs   []string       `json:"virtualmachineids,omitempty"`   // CloudStack 4.6+
-	IngressRule         []*IngressRule `json:"ingressrule"`
-	EgressRule          []*EgressRule  `json:"egressrule"`
-	Tags                []*ResourceTag `json:"tags,omitempty"`
-	JobID               string         `json:"jobid,omitempty"`
-	JobStatus           JobStatusType  `json:"jobstatus,omitempty"`
+	ID                  string        `json:"id"`
+	Account             string        `json:"account,omitempty"`
+	Description         string        `json:"description,omitempty"`
+	Domain              string        `json:"domain,omitempty"`
+	DomainID            string        `json:"domainid,omitempty"`
+	Name                string        `json:"name"`
+	Project             string        `json:"project,omitempty"`
+	ProjectID           string        `json:"projectid,omitempty"`
+	VirtualMachineCount int           `json:"virtualmachinecount,omitempty"` // CloudStack 4.6+
+	VirtualMachineIDs   []string      `json:"virtualmachineids,omitempty"`   // CloudStack 4.6+
+	IngressRule         []IngressRule `json:"ingressrule"`
+	EgressRule          []EgressRule  `json:"egressrule"`
+	Tags                []ResourceTag `json:"tags,omitempty"`
+	JobID               string        `json:"jobid,omitempty"`
+	JobStatus           JobStatusType `json:"jobstatus,omitempty"`
 }
 
 // IngressRule represents the ingress rule
 type IngressRule struct {
-	RuleID                string               `json:"ruleid"`
-	Account               string               `json:"account,omitempty"`
-	Cidr                  string               `json:"cidr,omitempty"`
-	Description           string               `json:"description,omitempty"`
-	IcmpType              int                  `json:"icmptype,omitempty"`
-	IcmpCode              int                  `json:"icmpcode,omitempty"`
-	StartPort             int                  `json:"startport,omitempty"`
-	EndPort               int                  `json:"endport,omitempty"`
-	Protocol              string               `json:"protocol,omitempty"`
-	Tags                  []*ResourceTag       `json:"tags,omitempty"`
-	SecurityGroupID       string               `json:"securitygroupid,omitempty"`
-	SecurityGroupName     string               `json:"securitygroupname,omitempty"`
-	UserSecurityGroupList []*UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
-	JobID                 string               `json:"jobid,omitempty"`
-	JobStatus             JobStatusType        `json:"jobstatus,omitempty"`
+	RuleID                string              `json:"ruleid"`
+	Account               string              `json:"account,omitempty"`
+	Cidr                  string              `json:"cidr,omitempty"`
+	Description           string              `json:"description,omitempty"`
+	IcmpType              int                 `json:"icmptype,omitempty"`
+	IcmpCode              int                 `json:"icmpcode,omitempty"`
+	StartPort             int                 `json:"startport,omitempty"`
+	EndPort               int                 `json:"endport,omitempty"`
+	Protocol              string              `json:"protocol,omitempty"`
+	Tags                  []ResourceTag       `json:"tags,omitempty"`
+	SecurityGroupID       string              `json:"securitygroupid,omitempty"`
+	SecurityGroupName     string              `json:"securitygroupname,omitempty"`
+	UserSecurityGroupList []UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
+	JobID                 string              `json:"jobid,omitempty"`
+	JobStatus             JobStatusType       `json:"jobstatus,omitempty"`
 }
 
 // EgressRule represents the ingress rule
@@ -54,7 +54,7 @@ type UserSecurityGroup struct {
 
 // SecurityGroupResponse represents a generic security group response
 type SecurityGroupResponse struct {
-	SecurityGroup *SecurityGroup `json:"securitygroup"`
+	SecurityGroup SecurityGroup `json:"securitygroup"`
 }
 
 // CreateSecurityGroup represents a security group creation
@@ -65,11 +65,11 @@ type CreateSecurityGroup struct {
 	Description string `json:"description,omitempty"`
 }
 
-func (req *CreateSecurityGroup) name() string {
+func (*CreateSecurityGroup) name() string {
 	return "createSecurityGroup"
 }
 
-func (req *CreateSecurityGroup) response() interface{} {
+func (*CreateSecurityGroup) response() interface{} {
 	return new(CreateSecurityGroupResponse)
 }
 
@@ -87,11 +87,11 @@ type DeleteSecurityGroup struct {
 	ProjectID string `json:"project,omitempty"`
 }
 
-func (req *DeleteSecurityGroup) name() string {
+func (*DeleteSecurityGroup) name() string {
 	return "deleteSecurityGroup"
 }
 
-func (req *DeleteSecurityGroup) response() interface{} {
+func (*DeleteSecurityGroup) response() interface{} {
 	return new(booleanSyncResponse)
 }
 
@@ -99,26 +99,26 @@ func (req *DeleteSecurityGroup) response() interface{} {
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/authorizeSecurityGroupIngress.html
 type AuthorizeSecurityGroupIngress struct {
-	Account               string               `json:"account,omitempty"`
-	CidrList              []string             `json:"cidrlist,omitempty"`
-	Description           string               `json:"description,omitempty"`
-	DomainID              string               `json:"domainid,omitempty"`
-	IcmpType              int                  `json:"icmptype,omitempty"`
-	IcmpCode              int                  `json:"icmpcode,omitempty"`
-	StartPort             int                  `json:"startport,omitempty"`
-	EndPort               int                  `json:"endport,omitempty"`
-	ProjectID             string               `json:"projectid,omitempty"`
-	Protocol              string               `json:"protocol,omitempty"`
-	SecurityGroupID       string               `json:"securitygroupid,omitempty"`
-	SecurityGroupName     string               `json:"securitygroupname,omitempty"`
-	UserSecurityGroupList []*UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
+	Account               string              `json:"account,omitempty"`
+	CidrList              []string            `json:"cidrlist,omitempty"`
+	Description           string              `json:"description,omitempty"`
+	DomainID              string              `json:"domainid,omitempty"`
+	IcmpType              int                 `json:"icmptype,omitempty"`
+	IcmpCode              int                 `json:"icmpcode,omitempty"`
+	StartPort             int                 `json:"startport,omitempty"`
+	EndPort               int                 `json:"endport,omitempty"`
+	ProjectID             string              `json:"projectid,omitempty"`
+	Protocol              string              `json:"protocol,omitempty"`
+	SecurityGroupID       string              `json:"securitygroupid,omitempty"`
+	SecurityGroupName     string              `json:"securitygroupname,omitempty"`
+	UserSecurityGroupList []UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
 }
 
-func (req *AuthorizeSecurityGroupIngress) name() string {
+func (*AuthorizeSecurityGroupIngress) name() string {
 	return "authorizeSecurityGroupIngress"
 }
 
-func (req *AuthorizeSecurityGroupIngress) asyncResponse() interface{} {
+func (*AuthorizeSecurityGroupIngress) asyncResponse() interface{} {
 	return new(AuthorizeSecurityGroupIngressResponse)
 }
 
@@ -140,11 +140,11 @@ type AuthorizeSecurityGroupIngressResponse SecurityGroupResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/authorizeSecurityGroupEgress.html
 type AuthorizeSecurityGroupEgress AuthorizeSecurityGroupIngress
 
-func (req *AuthorizeSecurityGroupEgress) name() string {
+func (*AuthorizeSecurityGroupEgress) name() string {
 	return "authorizeSecurityGroupEgress"
 }
 
-func (req *AuthorizeSecurityGroupEgress) asyncResponse() interface{} {
+func (*AuthorizeSecurityGroupEgress) asyncResponse() interface{} {
 	return new(AuthorizeSecurityGroupEgressResponse)
 }
 
@@ -163,11 +163,11 @@ type RevokeSecurityGroupIngress struct {
 	ID string `json:"id"`
 }
 
-func (req *RevokeSecurityGroupIngress) name() string {
+func (*RevokeSecurityGroupIngress) name() string {
 	return "revokeSecurityGroupIngress"
 }
 
-func (req *RevokeSecurityGroupIngress) asyncResponse() interface{} {
+func (*RevokeSecurityGroupIngress) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -178,11 +178,11 @@ type RevokeSecurityGroupEgress struct {
 	ID string `json:"id"`
 }
 
-func (req *RevokeSecurityGroupEgress) name() string {
+func (*RevokeSecurityGroupEgress) name() string {
 	return "revokeSecurityGroupEgress"
 }
 
-func (req *RevokeSecurityGroupEgress) asyncResponse() interface{} {
+func (*RevokeSecurityGroupEgress) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -190,39 +190,39 @@ func (req *RevokeSecurityGroupEgress) asyncResponse() interface{} {
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listSecurityGroups.html
 type ListSecurityGroups struct {
-	Account           string         `json:"account,omitempty"`
-	DomainID          string         `json:"domainid,omitempty"`
-	ID                string         `json:"id,omitempty"`
-	IsRecursive       bool           `json:"isrecursive,omitempty"`
-	Keyword           string         `json:"keyword,omitempty"`
-	ListAll           bool           `json:"listall,omitempty"`
-	Page              int            `json:"page,omitempty"`
-	PageSize          int            `json:"pagesize,omitempty"`
-	ProjectID         string         `json:"projectid,omitempty"`
-	Type              string         `json:"type,omitempty"`
-	SecurityGroupName string         `json:"securitygroupname,omitempty"`
-	Tags              []*ResourceTag `json:"tags,omitempty"`
-	VirtualMachineID  string         `json:"virtualmachineid,omitempty"`
+	Account           string        `json:"account,omitempty"`
+	DomainID          string        `json:"domainid,omitempty"`
+	ID                string        `json:"id,omitempty"`
+	IsRecursive       bool          `json:"isrecursive,omitempty"`
+	Keyword           string        `json:"keyword,omitempty"`
+	ListAll           bool          `json:"listall,omitempty"`
+	Page              int           `json:"page,omitempty"`
+	PageSize          int           `json:"pagesize,omitempty"`
+	ProjectID         string        `json:"projectid,omitempty"`
+	Type              string        `json:"type,omitempty"`
+	SecurityGroupName string        `json:"securitygroupname,omitempty"`
+	Tags              []ResourceTag `json:"tags,omitempty"`
+	VirtualMachineID  string        `json:"virtualmachineid,omitempty"`
 }
 
-func (req *ListSecurityGroups) name() string {
+func (*ListSecurityGroups) name() string {
 	return "listSecurityGroups"
 }
 
-func (req *ListSecurityGroups) response() interface{} {
+func (*ListSecurityGroups) response() interface{} {
 	return new(ListSecurityGroupsResponse)
 }
 
 // ListSecurityGroupsResponse represents a list of security groups
 type ListSecurityGroupsResponse struct {
-	Count         int              `json:"count"`
-	SecurityGroup []*SecurityGroup `json:"securitygroup"`
+	Count         int             `json:"count"`
+	SecurityGroup []SecurityGroup `json:"securitygroup"`
 }
 
 // CreateIngressRule creates a set of ingress rules
 //
 // Deprecated: use the API directly
-func (exo *Client) CreateIngressRule(req *AuthorizeSecurityGroupIngress, async AsyncInfo) ([]*IngressRule, error) {
+func (exo *Client) CreateIngressRule(req *AuthorizeSecurityGroupIngress, async AsyncInfo) ([]IngressRule, error) {
 	resp, err := exo.AsyncRequest(req, async)
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func (exo *Client) CreateIngressRule(req *AuthorizeSecurityGroupIngress, async A
 // CreateEgressRule creates a set of egress rules
 //
 // Deprecated: use the API directly
-func (exo *Client) CreateEgressRule(req *AuthorizeSecurityGroupEgress, async AsyncInfo) ([]*EgressRule, error) {
+func (exo *Client) CreateEgressRule(req *AuthorizeSecurityGroupEgress, async AsyncInfo) ([]EgressRule, error) {
 	resp, err := exo.AsyncRequest(req, async)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ func (exo *Client) CreateEgressRule(req *AuthorizeSecurityGroupEgress, async Asy
 // Warning: it doesn't rollback in case of a failure!
 //
 // Deprecated: use the API directly
-func (exo *Client) CreateSecurityGroupWithRules(name string, ingress []*AuthorizeSecurityGroupIngress, egress []*AuthorizeSecurityGroupEgress, async AsyncInfo) (*SecurityGroup, error) {
+func (exo *Client) CreateSecurityGroupWithRules(name string, ingress []AuthorizeSecurityGroupIngress, egress []AuthorizeSecurityGroupEgress, async AsyncInfo) (*SecurityGroup, error) {
 	req := &CreateSecurityGroup{
 		Name: name,
 	}
@@ -255,19 +255,21 @@ func (exo *Client) CreateSecurityGroupWithRules(name string, ingress []*Authoriz
 	}
 
 	sg := resp.(*SecurityGroupResponse).SecurityGroup
-
+	reqs := make([]AsyncCommand, 0, len(ingress)+len(egress))
+	// Egress rules
 	for _, ereq := range egress {
 		ereq.SecurityGroupID = sg.ID
+		reqs = append(reqs, &ereq)
 
-		_, err := exo.AsyncRequest(ereq, async)
-		if err != nil {
-			return nil, err
-		}
 	}
+	// Ingress rules
 	for _, ireq := range ingress {
 		ireq.SecurityGroupID = sg.ID
+		reqs = append(reqs, &ireq)
+	}
 
-		_, err := exo.AsyncRequest(ireq, async)
+	for _, r := range reqs {
+		_, err := exo.AsyncRequest(r, async)
 		if err != nil {
 			return nil, err
 		}
@@ -280,7 +282,8 @@ func (exo *Client) CreateSecurityGroupWithRules(name string, ingress []*Authoriz
 		return nil, err
 	}
 
-	return r.(*ListSecurityGroupsResponse).SecurityGroup[0], nil
+	sg = r.(*ListSecurityGroupsResponse).SecurityGroup[0]
+	return &sg, nil
 }
 
 // DeleteSecurityGroup deletes a security group

--- a/service_offerings.go
+++ b/service_offerings.go
@@ -31,7 +31,7 @@ type ServiceOffering struct {
 	ServiceOfferingDetails    map[string]string `json:"serviceofferingdetails,omitempty"`
 	StorageType               string            `json:"storagetype,omitempty"`
 	SystemVMType              string            `json:"systemvmtype,omitempty"`
-	Tags                      []*ResourceTag    `json:"tags,omitempty"`
+	Tags                      []ResourceTag     `json:"tags,omitempty"`
 }
 
 // ListServiceOfferings represents a query for service offerings
@@ -50,16 +50,16 @@ type ListServiceOfferings struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-func (req *ListServiceOfferings) name() string {
+func (*ListServiceOfferings) name() string {
 	return "listServiceOfferings"
 }
 
-func (req *ListServiceOfferings) response() interface{} {
+func (*ListServiceOfferings) response() interface{} {
 	return new(ListServiceOfferingsResponse)
 }
 
 // ListServiceOfferingsResponse represents a list of service offerings
 type ListServiceOfferingsResponse struct {
-	Count           int                `json:"count"`
-	ServiceOffering []*ServiceOffering `json:"serviceoffering"`
+	Count           int               `json:"count"`
+	ServiceOffering []ServiceOffering `json:"serviceoffering"`
 }

--- a/snapshots.go
+++ b/snapshots.go
@@ -2,27 +2,27 @@ package egoscale
 
 // Snapshot represents a volume snapshot
 type Snapshot struct {
-	ID           string         `json:"id"`
-	Account      string         `json:"account"`
-	Created      string         `json:"created,omitempty"`
-	Domain       string         `json:"domain"`
-	DomainID     string         `json:"domainid"`
-	IntervalType string         `json:"intervaltype,omitempty"` // hourly, daily, weekly, monthly, ..., none
-	Name         string         `json:"name,omitempty"`
-	PhysicalSize int64          `json:"physicalsize"`
-	Project      string         `json:"project"`
-	ProjectID    string         `json:"projectid"`
-	Revertable   bool           `json:"revertable,omitempty"`
-	Size         int64          `json:"size,omitempty"`
-	SnapshotType string         `json:"snapshottype,omitempty"`
-	State        string         `json:"state"` // BackedUp, Creating, BackingUp, ...
-	VolumeID     string         `json:"volumeid"`
-	VolumeName   string         `json:"volumename,omitempty"`
-	VolumeType   string         `json:"volumetype,omitempty"`
-	ZoneID       string         `json:"zoneid"`
-	Tags         []*ResourceTag `json:"tags"`
-	JobID        string         `json:"jobid,omitempty"`
-	JobStatus    JobStatusType  `json:"jobstatus,omitempty"`
+	ID           string        `json:"id"`
+	Account      string        `json:"account"`
+	Created      string        `json:"created,omitempty"`
+	Domain       string        `json:"domain"`
+	DomainID     string        `json:"domainid"`
+	IntervalType string        `json:"intervaltype,omitempty"` // hourly, daily, weekly, monthly, ..., none
+	Name         string        `json:"name,omitempty"`
+	PhysicalSize int64         `json:"physicalsize"`
+	Project      string        `json:"project"`
+	ProjectID    string        `json:"projectid"`
+	Revertable   bool          `json:"revertable,omitempty"`
+	Size         int64         `json:"size,omitempty"`
+	SnapshotType string        `json:"snapshottype,omitempty"`
+	State        string        `json:"state"` // BackedUp, Creating, BackingUp, ...
+	VolumeID     string        `json:"volumeid"`
+	VolumeName   string        `json:"volumename,omitempty"`
+	VolumeType   string        `json:"volumetype,omitempty"`
+	ZoneID       string        `json:"zoneid"`
+	Tags         []ResourceTag `json:"tags"`
+	JobID        string        `json:"jobid,omitempty"`
+	JobStatus    JobStatusType `json:"jobstatus,omitempty"`
 }
 
 // CreateSnapshot represents a request to create a volume snapshot
@@ -36,52 +36,52 @@ type CreateSnapshot struct {
 	QuiesceVM bool   `json:"quiescevm,omitempty"`
 }
 
-func (req *CreateSnapshot) name() string {
+func (*CreateSnapshot) name() string {
 	return "createSnapshot"
 }
 
-func (req *CreateSnapshot) asyncResponse() interface{} {
+func (*CreateSnapshot) asyncResponse() interface{} {
 	return new(CreateSnapshotResponse)
 }
 
 // CreateSnapshotResponse represents a freshly created snapshot
 type CreateSnapshotResponse struct {
-	Snapshot *Snapshot `json:"snapshot"`
+	Snapshot Snapshot `json:"snapshot"`
 }
 
 // ListSnapshots lists the volume snapshots
 //
 // CloudStackAPI: http://cloudstack.apache.org/api/apidocs-4.10/apis/listSnapshots.html
 type ListSnapshots struct {
-	Account      string         `json:"account,omitempty"`
-	DomainID     string         `json:"domainid,omitempty"`
-	ID           string         `json:"id,omitempty"`
-	IntervalType string         `json:"intervaltype,omitempty"`
-	IsRecursive  bool           `json:"isrecursive,omitempty"`
-	Keyword      string         `json:"keyword,omitempty"`
-	ListAll      bool           `json:"listall,omitempty"`
-	Name         string         `json:"name,omitempty"`
-	Page         int            `json:"page,omitempty"`
-	PageSize     int            `json:"pagesize,omitempty"`
-	ProjectID    string         `json:"projectid,omitempty"`
-	SnapshotType string         `json:"snapshottype,omitempty"`
-	Tags         []*ResourceTag `json:"tags,omitempty"`
-	VolumeID     string         `json:"volumeid,omitempty"`
-	ZoneID       string         `json:"zoneid,omitempty"`
+	Account      string        `json:"account,omitempty"`
+	DomainID     string        `json:"domainid,omitempty"`
+	ID           string        `json:"id,omitempty"`
+	IntervalType string        `json:"intervaltype,omitempty"`
+	IsRecursive  bool          `json:"isrecursive,omitempty"`
+	Keyword      string        `json:"keyword,omitempty"`
+	ListAll      bool          `json:"listall,omitempty"`
+	Name         string        `json:"name,omitempty"`
+	Page         int           `json:"page,omitempty"`
+	PageSize     int           `json:"pagesize,omitempty"`
+	ProjectID    string        `json:"projectid,omitempty"`
+	SnapshotType string        `json:"snapshottype,omitempty"`
+	Tags         []ResourceTag `json:"tags,omitempty"`
+	VolumeID     string        `json:"volumeid,omitempty"`
+	ZoneID       string        `json:"zoneid,omitempty"`
 }
 
-func (req *ListSnapshots) name() string {
+func (*ListSnapshots) name() string {
 	return "listSnapshots"
 }
 
-func (req *ListSnapshots) response() interface{} {
+func (*ListSnapshots) response() interface{} {
 	return new(ListSnapshotsResponse)
 }
 
 // ListSnapshotsResponse represents a list of volume snapshots
 type ListSnapshotsResponse struct {
-	Count    int         `json:"count"`
-	Snapshot []*Snapshot `json:"snapshot"`
+	Count    int        `json:"count"`
+	Snapshot []Snapshot `json:"snapshot"`
 }
 
 // DeleteSnapshot represents the deletion of a volume snapshot
@@ -91,11 +91,11 @@ type DeleteSnapshot struct {
 	ID string `json:"id"`
 }
 
-func (req *DeleteSnapshot) name() string {
+func (*DeleteSnapshot) name() string {
 	return "deleteSnapshot"
 }
 
-func (req *DeleteSnapshot) asyncResponse() interface{} {
+func (*DeleteSnapshot) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -106,10 +106,10 @@ type RevertSnapshot struct {
 	ID string `json:"id"`
 }
 
-func (req *RevertSnapshot) name() string {
+func (*RevertSnapshot) name() string {
 	return "revertSnapshot"
 }
 
-func (req *RevertSnapshot) asyncResponse() interface{} {
+func (*RevertSnapshot) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }

--- a/tags.go
+++ b/tags.go
@@ -20,17 +20,17 @@ type ResourceTag struct {
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/createTags.html
 type CreateTags struct {
-	ResourceIDs  []string       `json:"resourceids"`
-	ResourceType string         `json:"resourcetype"`
-	Tags         []*ResourceTag `json:"tags"`
-	Customer     string         `json:"customer,omitempty"`
+	ResourceIDs  []string      `json:"resourceids"`
+	ResourceType string        `json:"resourcetype"`
+	Tags         []ResourceTag `json:"tags"`
+	Customer     string        `json:"customer,omitempty"`
 }
 
-func (req *CreateTags) name() string {
+func (*CreateTags) name() string {
 	return "createTags"
 }
 
-func (req *CreateTags) asyncResponse() interface{} {
+func (*CreateTags) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -38,16 +38,16 @@ func (req *CreateTags) asyncResponse() interface{} {
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/deleteTags.html
 type DeleteTags struct {
-	ResourceIDs  []string       `json:"resourceids"`
-	ResourceType string         `json:"resourcetype"`
-	Tags         []*ResourceTag `json:"tags,omitempty"`
+	ResourceIDs  []string      `json:"resourceids"`
+	ResourceType string        `json:"resourcetype"`
+	Tags         []ResourceTag `json:"tags,omitempty"`
 }
 
-func (req *DeleteTags) name() string {
+func (*DeleteTags) name() string {
 	return "deleteTags"
 }
 
-func (req *DeleteTags) asyncResponse() interface{} {
+func (*DeleteTags) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -70,16 +70,16 @@ type ListTags struct {
 	Value        string `json:"value,omitempty"`
 }
 
-func (req *ListTags) name() string {
+func (*ListTags) name() string {
 	return "listTags"
 }
 
-func (req *ListTags) response() interface{} {
+func (*ListTags) response() interface{} {
 	return new(ListTagsResponse)
 }
 
 // ListTagsResponse represents a list of resource tags
 type ListTagsResponse struct {
-	Count int            `json:"count"`
-	Tag   []*ResourceTag `json:"tag"`
+	Count int           `json:"count"`
+	Tag   []ResourceTag `json:"tag"`
 }

--- a/templates.go
+++ b/templates.go
@@ -1,9 +1,3 @@
-/*
-Templates
-
-See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/templates.html
-*/
-
 package egoscale
 
 // Template represents a machine to be deployed
@@ -45,33 +39,33 @@ type Template struct {
 
 // ListTemplates represents a template query filter
 type ListTemplates struct {
-	TemplateFilter string         `json:"templatefilter"` // featured, etc.
-	Account        string         `json:"account,omitempty"`
-	DomainID       string         `json:"domainid,omitempty"`
-	Hypervisor     string         `json:"hypervisor,omitempty"`
-	ID             string         `json:"id,omitempty"`
-	IsRecursive    bool           `json:"isrecursive,omitempty"`
-	Keyword        string         `json:"keyword,omitempty"`
-	ListAll        bool           `json:"listall,omitempty"`
-	Name           string         `json:"name,omitempty"`
-	Page           int            `json:"page,omitempty"`
-	PageSize       int            `json:"pagesize,omitempty"`
-	ProjectID      string         `json:"projectid,omitempty"`
-	ShowRemoved    bool           `json:"showremoved,omitempty"`
-	Tags           []*ResourceTag `json:"tags,omitempty"`
-	ZoneID         string         `json:"zoneid,omitempty"`
+	TemplateFilter string        `json:"templatefilter"` // featured, etc.
+	Account        string        `json:"account,omitempty"`
+	DomainID       string        `json:"domainid,omitempty"`
+	Hypervisor     string        `json:"hypervisor,omitempty"`
+	ID             string        `json:"id,omitempty"`
+	IsRecursive    bool          `json:"isrecursive,omitempty"`
+	Keyword        string        `json:"keyword,omitempty"`
+	ListAll        bool          `json:"listall,omitempty"`
+	Name           string        `json:"name,omitempty"`
+	Page           int           `json:"page,omitempty"`
+	PageSize       int           `json:"pagesize,omitempty"`
+	ProjectID      string        `json:"projectid,omitempty"`
+	ShowRemoved    bool          `json:"showremoved,omitempty"`
+	Tags           []ResourceTag `json:"tags,omitempty"`
+	ZoneID         string        `json:"zoneid,omitempty"`
 }
 
-func (req *ListTemplates) name() string {
+func (*ListTemplates) name() string {
 	return "listTemplates"
 }
 
-func (req *ListTemplates) response() interface{} {
+func (*ListTemplates) response() interface{} {
 	return new(ListTemplatesResponse)
 }
 
 // ListTemplatesResponse represents a list of templates
 type ListTemplatesResponse struct {
-	Count    int         `json:"count"`
-	Template []*Template `json:"template"`
+	Count    int        `json:"count"`
+	Template []Template `json:"template"`
 }

--- a/topology.go
+++ b/topology.go
@@ -18,7 +18,7 @@ func (exo *Client) GetSecurityGroups() (map[string]SecurityGroup, error) {
 
 	sgs = make(map[string]SecurityGroup)
 	for _, sg := range resp.(*ListSecurityGroupsResponse).SecurityGroup {
-		sgs[sg.Name] = *sg
+		sgs[sg.Name] = sg
 	}
 	return sgs, nil
 }
@@ -89,7 +89,7 @@ func (exo *Client) GetKeypairs() ([]SSHKeyPair, error) {
 	r := resp.(*ListSSHKeyPairsResponse)
 	keypairs = make([]SSHKeyPair, r.Count)
 	for i, keypair := range r.SSHKeyPair {
-		keypairs[i] = *keypair
+		keypairs[i] = keypair
 	}
 	return keypairs, nil
 }

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -69,10 +69,10 @@ type VirtualMachine struct {
 	Vgpu                  string            `json:"vgpu,omitempty"`     // not in the doc
 	ZoneID                string            `json:"zoneid,omitempty"`
 	ZoneName              string            `json:"zonename,omitempty"`
-	AffinityGroup         []*AffinityGroup  `json:"affinitygroup,omitempty"`
-	Nic                   []*Nic            `json:"nic,omitempty"`
-	SecurityGroup         []*SecurityGroup  `json:"securitygroup,omitempty"`
-	Tags                  []*ResourceTag    `json:"tags,omitempty"`
+	AffinityGroup         []AffinityGroup   `json:"affinitygroup,omitempty"`
+	Nic                   []Nic             `json:"nic,omitempty"`
+	SecurityGroup         []SecurityGroup   `json:"securitygroup,omitempty"`
+	Tags                  []ResourceTag     `json:"tags,omitempty"`
 	JobID                 string            `json:"jobid,omitempty"`
 	JobStatus             JobStatusType     `json:"jobstatus,omitempty"`
 }
@@ -84,7 +84,7 @@ func (vm *VirtualMachine) NicsByType(nicType string) []Nic {
 		if nic.Type == nicType {
 			// XXX The CloudStack API forgets to specify it
 			nic.VirtualMachineID = vm.ID
-			nics = append(nics, *nic)
+			nics = append(nics, nic)
 		}
 	}
 	return nics
@@ -95,7 +95,7 @@ func (vm *VirtualMachine) NicByNetworkID(networkID string) *Nic {
 	for _, nic := range vm.Nic {
 		if nic.NetworkID == networkID {
 			nic.VirtualMachineID = vm.ID
-			return nic
+			return &nic
 		}
 	}
 	return nil
@@ -106,7 +106,7 @@ func (vm *VirtualMachine) NicByID(nicID string) *Nic {
 	for _, nic := range vm.Nic {
 		if nic.ID == nicID {
 			nic.VirtualMachineID = vm.ID
-			return nic
+			return &nic
 		}
 	}
 
@@ -122,7 +122,7 @@ type IPToNetwork struct {
 
 // VirtualMachineResponse represents a generic Virtual Machine response
 type VirtualMachineResponse struct {
-	VirtualMachine *VirtualMachine `json:"virtualmachine"`
+	VirtualMachine VirtualMachine `json:"virtualmachine"`
 }
 
 // DeployVirtualMachine (Async) represents the machine creation
@@ -147,7 +147,7 @@ type DeployVirtualMachine struct {
 	Hypervisor         string            `json:"hypervisor,omitempty"`
 	IP6Address         net.IP            `json:"ip6address,omitempty"`
 	IPAddress          net.IP            `json:"ipaddress,omitempty"`
-	IPToNetworkList    []*IPToNetwork    `json:"iptonetworklist,omitempty"`
+	IPToNetworkList    []IPToNetwork     `json:"iptonetworklist,omitempty"`
 	Keyboard           string            `json:"keyboard,omitempty"`
 	KeyPair            string            `json:"keypair,omitempty"`
 	Name               string            `json:"name,omitempty"`
@@ -161,11 +161,11 @@ type DeployVirtualMachine struct {
 	UserData           []byte            `json:"userdata,omitempty"`
 }
 
-func (req *DeployVirtualMachine) name() string {
+func (*DeployVirtualMachine) name() string {
 	return "deployVirtualMachine"
 }
 
-func (req *DeployVirtualMachine) asyncResponse() interface{} {
+func (*DeployVirtualMachine) asyncResponse() interface{} {
 	return new(DeployVirtualMachineResponse)
 }
 
@@ -181,10 +181,10 @@ type StartVirtualMachine struct {
 	HostID            string `json:"hostid,omitempty"`            // root only
 }
 
-func (req *StartVirtualMachine) name() string {
+func (*StartVirtualMachine) name() string {
 	return "startVirtualMachine"
 }
-func (req *StartVirtualMachine) asyncResponse() interface{} {
+func (*StartVirtualMachine) asyncResponse() interface{} {
 	return new(StartVirtualMachineResponse)
 }
 
@@ -199,11 +199,11 @@ type StopVirtualMachine struct {
 	Forced bool   `json:"forced,omitempty"`
 }
 
-func (req *StopVirtualMachine) name() string {
+func (*StopVirtualMachine) name() string {
 	return "stopVirtualMachine"
 }
 
-func (req *StopVirtualMachine) asyncResponse() interface{} {
+func (*StopVirtualMachine) asyncResponse() interface{} {
 	return new(StopVirtualMachineResponse)
 }
 
@@ -217,11 +217,11 @@ type RebootVirtualMachine struct {
 	ID string `json:"id"`
 }
 
-func (req *RebootVirtualMachine) name() string {
+func (*RebootVirtualMachine) name() string {
 	return "rebootVirtualMachine"
 }
 
-func (req *RebootVirtualMachine) asyncResponse() interface{} {
+func (*RebootVirtualMachine) asyncResponse() interface{} {
 	return new(RebootVirtualMachineResponse)
 }
 
@@ -236,11 +236,11 @@ type RestoreVirtualMachine struct {
 	TemplateID       string `json:"templateid,omitempty"`
 }
 
-func (req *RestoreVirtualMachine) name() string {
+func (*RestoreVirtualMachine) name() string {
 	return "restoreVirtualMachine"
 }
 
-func (req *RestoreVirtualMachine) asyncResponse() interface{} {
+func (*RestoreVirtualMachine) asyncResponse() interface{} {
 	return new(RestoreVirtualMachineResponse)
 }
 
@@ -254,11 +254,11 @@ type RecoverVirtualMachine struct {
 	ID string `json:"virtualmachineid"`
 }
 
-func (req *RecoverVirtualMachine) name() string {
+func (*RecoverVirtualMachine) name() string {
 	return "recoverVirtualMachine"
 }
 
-func (req *RecoverVirtualMachine) response() interface{} {
+func (*RecoverVirtualMachine) response() interface{} {
 	return new(RecoverVirtualMachineResponse)
 }
 
@@ -273,11 +273,11 @@ type DestroyVirtualMachine struct {
 	Expunge bool   `json:"expunge,omitempty"`
 }
 
-func (req *DestroyVirtualMachine) name() string {
+func (*DestroyVirtualMachine) name() string {
 	return "destroyVirtualMachine"
 }
 
-func (req *DestroyVirtualMachine) asyncResponse() interface{} {
+func (*DestroyVirtualMachine) asyncResponse() interface{} {
 	return new(DestroyVirtualMachineResponse)
 }
 
@@ -302,11 +302,11 @@ type UpdateVirtualMachine struct {
 	UserData              []byte            `json:"userdata,omitempty"`
 }
 
-func (req *UpdateVirtualMachine) name() string {
+func (*UpdateVirtualMachine) name() string {
 	return "updateVirtualMachine"
 }
 
-func (req *UpdateVirtualMachine) response() interface{} {
+func (*UpdateVirtualMachine) response() interface{} {
 	return new(UpdateVirtualMachineResponse)
 }
 
@@ -318,11 +318,11 @@ type ExpungeVirtualMachine struct {
 	ID string `json:"id"`
 }
 
-func (req *ExpungeVirtualMachine) name() string {
+func (*ExpungeVirtualMachine) name() string {
 	return "expungeVirtualMachine"
 }
 
-func (req *ExpungeVirtualMachine) asyncResponse() interface{} {
+func (*ExpungeVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -338,11 +338,11 @@ type ScaleVirtualMachine struct {
 	Details           map[string]string `json:"details,omitempty"`
 }
 
-func (req *ScaleVirtualMachine) name() string {
+func (*ScaleVirtualMachine) name() string {
 	return "scaleVirtualMachine"
 }
 
-func (req *ScaleVirtualMachine) asyncResponse() interface{} {
+func (*ScaleVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
@@ -351,11 +351,11 @@ func (req *ScaleVirtualMachine) asyncResponse() interface{} {
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/changeServiceForVirtualMachine.html
 type ChangeServiceForVirtualMachine ScaleVirtualMachine
 
-func (req *ChangeServiceForVirtualMachine) name() string {
+func (*ChangeServiceForVirtualMachine) name() string {
 	return "changeServiceForVirtualMachine"
 }
 
-func (req *ChangeServiceForVirtualMachine) response() interface{} {
+func (*ChangeServiceForVirtualMachine) response() interface{} {
 	return new(ChangeServiceForVirtualMachineResponse)
 }
 
@@ -367,11 +367,11 @@ type ChangeServiceForVirtualMachineResponse VirtualMachineResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resetPasswordForVirtualMachine.html
 type ResetPasswordForVirtualMachine ScaleVirtualMachine
 
-func (req *ResetPasswordForVirtualMachine) name() string {
+func (*ResetPasswordForVirtualMachine) name() string {
 	return "resetPasswordForVirtualMachine"
 }
 
-func (req *ResetPasswordForVirtualMachine) asyncResponse() interface{} {
+func (*ResetPasswordForVirtualMachine) asyncResponse() interface{} {
 	return new(ResetPasswordForVirtualMachineResponse)
 }
 
@@ -385,11 +385,11 @@ type GetVMPassword struct {
 	ID string `json:"id"`
 }
 
-func (req *GetVMPassword) name() string {
+func (*GetVMPassword) name() string {
 	return "getVMPassword"
 }
 
-func (req *GetVMPassword) response() interface{} {
+func (*GetVMPassword) response() interface{} {
 	return new(GetVMPasswordResponse)
 }
 
@@ -428,25 +428,25 @@ type ListVirtualMachines struct {
 	ServiceOfferindID string            `json:"serviceofferingid,omitempty"`
 	State             string            `json:"state,omitempty"` // Running, Stopped, Present, ...
 	StorageID         string            `json:"storageid,omitempty"`
-	Tags              []*ResourceTag    `json:"tags,omitempty"`
+	Tags              []ResourceTag     `json:"tags,omitempty"`
 	TemplateID        string            `json:"templateid,omitempty"`
 	UserID            string            `json:"userid,omitempty"`
 	VpcID             string            `json:"vpcid,omitempty"`
 	ZoneID            string            `json:"zoneid,omitempty"`
 }
 
-func (req *ListVirtualMachines) name() string {
+func (*ListVirtualMachines) name() string {
 	return "listVirtualMachines"
 }
 
-func (req *ListVirtualMachines) response() interface{} {
+func (*ListVirtualMachines) response() interface{} {
 	return new(ListVirtualMachinesResponse)
 }
 
 // ListVirtualMachinesResponse represents a list of virtual machines
 type ListVirtualMachinesResponse struct {
-	Count          int               `json:"count"`
-	VirtualMachine []*VirtualMachine `json:"virtualmachine"`
+	Count          int              `json:"count"`
+	VirtualMachine []VirtualMachine `json:"virtualmachine"`
 }
 
 // AddNicToVirtualMachine (Async) adds a NIC to a VM
@@ -458,11 +458,11 @@ type AddNicToVirtualMachine struct {
 	IPAddress        net.IP `json:"ipaddress,omitempty"`
 }
 
-func (req *AddNicToVirtualMachine) name() string {
+func (*AddNicToVirtualMachine) name() string {
 	return "addNicToVirtualMachine"
 }
 
-func (req *AddNicToVirtualMachine) asyncResponse() interface{} {
+func (*AddNicToVirtualMachine) asyncResponse() interface{} {
 	return new(AddNicToVirtualMachineResponse)
 }
 
@@ -477,11 +477,11 @@ type RemoveNicFromVirtualMachine struct {
 	VirtualMachineID string `json:"virtualmachineid"`
 }
 
-func (req *RemoveNicFromVirtualMachine) name() string {
+func (*RemoveNicFromVirtualMachine) name() string {
 	return "removeNicFromVirtualMachine"
 }
 
-func (req *RemoveNicFromVirtualMachine) asyncResponse() interface{} {
+func (*RemoveNicFromVirtualMachine) asyncResponse() interface{} {
 	return new(RemoveNicFromVirtualMachineResponse)
 }
 
@@ -497,11 +497,11 @@ type UpdateDefaultNicForVirtualMachine struct {
 	IPAddress        net.IP `json:"ipaddress,omitempty"`
 }
 
-func (req *UpdateDefaultNicForVirtualMachine) name() string {
+func (*UpdateDefaultNicForVirtualMachine) name() string {
 	return "updateDefaultNicForVirtualMachine"
 }
 
-func (req *UpdateDefaultNicForVirtualMachine) asyncResponse() interface{} {
+func (*UpdateDefaultNicForVirtualMachine) asyncResponse() interface{} {
 	return new(UpdateDefaultNicForVirtualMachineResponse)
 }
 

--- a/volumes.go
+++ b/volumes.go
@@ -6,31 +6,31 @@ import (
 
 // Volume represents a volume linked to a VM
 type Volume struct {
-	ID                         string         `json:"id"`
-	Account                    string         `json:"account,omitempty"`
-	Attached                   string         `json:"attached,omitempty"`
-	ChainInfo                  string         `json:"chaininfo,omitempty"`
-	Created                    string         `json:"created,omitempty"`
-	Destroyed                  bool           `json:"destroyed,omitempty"`
-	DisplayVolume              bool           `json:"displayvolume,omitempty"`
-	Domain                     string         `json:"domain,omitempty"`
-	DomainID                   string         `json:"domainid,omitempty"`
-	Name                       string         `json:"name,omitempty"`
-	QuiesceVM                  bool           `json:"quiescevm,omitempty"`
-	ServiceOfferingDisplayText string         `json:"serviceofferingdisplaytext,omitempty"`
-	ServiceOfferingID          string         `json:"serviceofferingid,omitempty"`
-	ServiceOfferingName        string         `json:"serviceofferingname,omitempty"`
-	Size                       uint64         `json:"size,omitempty"`
-	State                      string         `json:"state,omitempty"`
-	Type                       string         `json:"type,omitempty"`
-	VirtualMachineID           string         `json:"virtualmachineid,omitempty"`
-	VMName                     string         `json:"vmname,omitempty"`
-	VMState                    string         `json:"vmstate,omitempty"`
-	ZoneID                     string         `json:"zoneid,omitempty"`
-	ZoneName                   string         `json:"zonename,omitempty"`
-	Tags                       []*ResourceTag `json:"tags,omitempty"`
-	JobID                      string         `json:"jobid,omitempty"`
-	JobStatus                  JobStatusType  `json:"jobstatus,omitempty"`
+	ID                         string        `json:"id"`
+	Account                    string        `json:"account,omitempty"`
+	Attached                   string        `json:"attached,omitempty"`
+	ChainInfo                  string        `json:"chaininfo,omitempty"`
+	Created                    string        `json:"created,omitempty"`
+	Destroyed                  bool          `json:"destroyed,omitempty"`
+	DisplayVolume              bool          `json:"displayvolume,omitempty"`
+	Domain                     string        `json:"domain,omitempty"`
+	DomainID                   string        `json:"domainid,omitempty"`
+	Name                       string        `json:"name,omitempty"`
+	QuiesceVM                  bool          `json:"quiescevm,omitempty"`
+	ServiceOfferingDisplayText string        `json:"serviceofferingdisplaytext,omitempty"`
+	ServiceOfferingID          string        `json:"serviceofferingid,omitempty"`
+	ServiceOfferingName        string        `json:"serviceofferingname,omitempty"`
+	Size                       uint64        `json:"size,omitempty"`
+	State                      string        `json:"state,omitempty"`
+	Type                       string        `json:"type,omitempty"`
+	VirtualMachineID           string        `json:"virtualmachineid,omitempty"`
+	VMName                     string        `json:"vmname,omitempty"`
+	VMState                    string        `json:"vmstate,omitempty"`
+	ZoneID                     string        `json:"zoneid,omitempty"`
+	ZoneName                   string        `json:"zonename,omitempty"`
+	Tags                       []ResourceTag `json:"tags,omitempty"`
+	JobID                      string        `json:"jobid,omitempty"`
+	JobStatus                  JobStatusType `json:"jobstatus,omitempty"`
 }
 
 // ResizeVolume (Async) resizes a volume
@@ -43,56 +43,56 @@ type ResizeVolume struct {
 	Size           int64  `json:"size,omitempty"` // in GiB
 }
 
-func (req *ResizeVolume) name() string {
+func (*ResizeVolume) name() string {
 	return "resizeVolume"
 }
 
-func (req *ResizeVolume) asyncResponse() interface{} {
+func (*ResizeVolume) asyncResponse() interface{} {
 	return new(ResizeVolumeResponse)
 }
 
 // ResizeVolumeResponse represents the new Volume
 type ResizeVolumeResponse struct {
-	Volume *Volume `json:"volume"`
+	Volume Volume `json:"volume"`
 }
 
 // ListVolumes represents a query listing volumes
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listVolumes.html
 type ListVolumes struct {
-	Account          string         `json:"account,omitempty"`
-	DiskOfferingID   string         `json:"diskoffering,omitempty"`
-	DisplayVolume    string         `json:"displayvolume,omitempty"` // root only
-	DomainID         string         `json:"domainid,omitempty"`
-	HostID           string         `json:"hostid,omitempty"`
-	ID               string         `json:"id,omitempty"`
-	IsRecursive      bool           `json:"isrecursive,omitempty"`
-	Keyword          string         `json:"keyword,omitempty"`
-	ListAll          bool           `json:"listall,omitempty"`
-	Name             string         `json:"name,omitempty"`
-	Page             int            `json:"page,omitempty"`
-	PageSize         int            `json:"pagesize,omitempty"`
-	PodID            string         `json:"podid,omitempty"`
-	ProjectID        string         `json:"projectid,omitempty"`
-	StorageID        string         `json:"storageid,omitempty"`
-	Tags             []*ResourceTag `json:"tags,omitempty"`
-	Type             string         `json:"type,omitempty"`
-	VirtualMachineID string         `json:"virtualmachineid,omitempty"`
-	ZoneID           string         `json:"zoneid,omitempty"`
+	Account          string        `json:"account,omitempty"`
+	DiskOfferingID   string        `json:"diskoffering,omitempty"`
+	DisplayVolume    string        `json:"displayvolume,omitempty"` // root only
+	DomainID         string        `json:"domainid,omitempty"`
+	HostID           string        `json:"hostid,omitempty"`
+	ID               string        `json:"id,omitempty"`
+	IsRecursive      bool          `json:"isrecursive,omitempty"`
+	Keyword          string        `json:"keyword,omitempty"`
+	ListAll          bool          `json:"listall,omitempty"`
+	Name             string        `json:"name,omitempty"`
+	Page             int           `json:"page,omitempty"`
+	PageSize         int           `json:"pagesize,omitempty"`
+	PodID            string        `json:"podid,omitempty"`
+	ProjectID        string        `json:"projectid,omitempty"`
+	StorageID        string        `json:"storageid,omitempty"`
+	Tags             []ResourceTag `json:"tags,omitempty"`
+	Type             string        `json:"type,omitempty"`
+	VirtualMachineID string        `json:"virtualmachineid,omitempty"`
+	ZoneID           string        `json:"zoneid,omitempty"`
 }
 
-func (req *ListVolumes) name() string {
+func (*ListVolumes) name() string {
 	return "listVolumes"
 }
 
-func (req *ListVolumes) response() interface{} {
+func (*ListVolumes) response() interface{} {
 	return new(ListVolumesResponse)
 }
 
 // ListVolumesResponse represents a list of volumes
 type ListVolumesResponse struct {
-	Count  int       `json:"count"`
-	Volume []*Volume `json:"volume"`
+	Count  int      `json:"count"`
+	Volume []Volume `json:"volume"`
 }
 
 // GetRootVolumeForVirtualMachine returns the root volume of a VM
@@ -112,5 +112,5 @@ func (exo *Client) GetRootVolumeForVirtualMachine(virtualMachineID string) (*Vol
 		return nil, fmt.Errorf("Expected exactly one volume for %v, got %d", virtualMachineID, r.Count)
 	}
 
-	return r.Volume[0], nil
+	return &(r.Volume[0]), nil
 }

--- a/zones.go
+++ b/zones.go
@@ -27,34 +27,34 @@ type Zone struct {
 	SecurityGroupsEnabled bool              `json:"securitygroupsenabled,omitempty"`
 	Vlan                  string            `json:"vlan,omitempty"`
 	ZoneToken             string            `json:"zonetoken,omitempty"`
-	Tags                  []*ResourceTag    `json:"tags,omitempty"`
+	Tags                  []ResourceTag     `json:"tags,omitempty"`
 }
 
 // ListZones represents a query for zones
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listZones.html
 type ListZones struct {
-	Available      bool           `json:"available,omitempty"`
-	DomainID       string         `json:"domainid,omitempty"`
-	ID             string         `json:"id,omitempty"`
-	Keyword        string         `json:"keyword,omitempty"`
-	Name           string         `json:"name,omitempty"`
-	Page           int            `json:"page,omitempty"`
-	PageSize       int            `json:"pagesize,omitempty"`
-	ShowCapacities bool           `json:"showcapacities,omitempty"`
-	Tags           []*ResourceTag `json:"tags,omitempty"`
+	Available      bool          `json:"available,omitempty"`
+	DomainID       string        `json:"domainid,omitempty"`
+	ID             string        `json:"id,omitempty"`
+	Keyword        string        `json:"keyword,omitempty"`
+	Name           string        `json:"name,omitempty"`
+	Page           int           `json:"page,omitempty"`
+	PageSize       int           `json:"pagesize,omitempty"`
+	ShowCapacities bool          `json:"showcapacities,omitempty"`
+	Tags           []ResourceTag `json:"tags,omitempty"`
 }
 
-func (req *ListZones) name() string {
+func (*ListZones) name() string {
 	return "listZones"
 }
 
-func (req *ListZones) response() interface{} {
+func (*ListZones) response() interface{} {
 	return new(ListZonesResponse)
 }
 
 // ListZonesResponse represents a list of zones
 type ListZonesResponse struct {
-	Count int     `json:"count"`
-	Zone  []*Zone `json:"zone"`
+	Count int    `json:"count"`
+	Zone  []Zone `json:"zone"`
 }


### PR DESCRIPTION
Remove:
- slices of pointers
- raw pointers in responses

Keep:
- passing pointer to struct even though we don't modify them

   > _Pass values [...] This advice does not apply to large structs, or even small structs that might grow._
   >
   > <https://github.com/golang/go/wiki/CodeReviewComments#pass-values>

- pointer receiver
    > when in doubt, use a pointer receiver.
    >
    > <https://github.com/golang/go/wiki/CodeReviewComments#receiver-type>

The API of the library doesn't change: you give it pointers to struct, and get back pointers to struct. Although it changes the way you build and process those structs.