### PR TITLE
global: add Taggable interface for ResourceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+Changelog
+=========
+
+0.9.7
+-----
+
+- feat: add Taggable interface to expose ResourceType
+
+0.9.6
+-----
+
+- fix: update UpdateVirtualMachine userdata
+- fix. Network's name/displaytext might be empty
+
+0.9.5
+-----
+
+- fix: serialization of slice
+
+0.9.4
+-----
+
+- fix: constants
+
+0.9.3
+-----
+
+- change: userdata expects a string
+- change: no pointer in sub-struct's
+
 0.9.2
 -----
 

--- a/addresses.go
+++ b/addresses.go
@@ -38,6 +38,11 @@ type IPAddress struct {
 	JobStatus                 JobStatusType `json:"jobstatus,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*IPAddress) ResourceType() string {
+	return "PublicIpAddress"
+}
+
 // AssociateIPAddress (Async) represents the IP creation
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/associateIpAddress.html

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -5,10 +5,18 @@ import (
 )
 
 func TestAddressess(t *testing.T) {
+	var _ Taggable = (*IPAddress)(nil)
 	var _ AsyncCommand = (*AssociateIPAddress)(nil)
 	var _ AsyncCommand = (*DisassociateIPAddress)(nil)
 	var _ Command = (*ListPublicIPAddresses)(nil)
 	var _ AsyncCommand = (*UpdateIPAddress)(nil)
+}
+
+func TestIPAddress(t *testing.T) {
+	instance := &IPAddress{}
+	if instance.ResourceType() != "PublicIpAddress" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestAssociateIPAddress(t *testing.T) {

--- a/networks.go
+++ b/networks.go
@@ -56,6 +56,11 @@ type Network struct {
 	Tags                        []ResourceTag `json:"tags"`
 }
 
+// ResourceType returns the type of the resource
+func (*Network) ResourceType() string {
+	return "Network"
+}
+
 // Service is a feature of a network
 type Service struct {
 	Name       string              `json:"name"`

--- a/networks_test.go
+++ b/networks_test.go
@@ -5,11 +5,19 @@ import (
 )
 
 func TestListNetworksIsACommand(t *testing.T) {
+	var _ Taggable = (*Network)(nil)
 	var _ Command = (*CreateNetwork)(nil)
 	var _ AsyncCommand = (*DeleteNetwork)(nil)
 	var _ Command = (*ListNetworks)(nil)
 	var _ AsyncCommand = (*RestartNetwork)(nil)
 	var _ AsyncCommand = (*UpdateNetwork)(nil)
+}
+
+func TestNetwork(t *testing.T) {
+	instance := &Network{}
+	if instance.ResourceType() != "Network" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestListNetworks(t *testing.T) {

--- a/security_groups.go
+++ b/security_groups.go
@@ -24,6 +24,11 @@ type SecurityGroup struct {
 	JobStatus           JobStatusType `json:"jobstatus,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*SecurityGroup) ResourceType() string {
+	return "SecurityGroup"
+}
+
 // IngressRule represents the ingress rule
 type IngressRule struct {
 	RuleID                string              `json:"ruleid"`

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestGroupsRequests(t *testing.T) {
+	var _ Taggable = (*SecurityGroup)(nil)
 	var _ AsyncCommand = (*AuthorizeSecurityGroupEgress)(nil)
 	var _ onBeforeHook = (*AuthorizeSecurityGroupEgress)(nil)
 	var _ AsyncCommand = (*AuthorizeSecurityGroupIngress)(nil)
@@ -14,6 +15,13 @@ func TestGroupsRequests(t *testing.T) {
 	var _ Command = (*ListSecurityGroups)(nil)
 	var _ AsyncCommand = (*RevokeSecurityGroupEgress)(nil)
 	var _ AsyncCommand = (*RevokeSecurityGroupIngress)(nil)
+}
+
+func TestSecurityGroup(t *testing.T) {
+	instance := &SecurityGroup{}
+	if instance.ResourceType() != "SecurityGroup" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestAuthorizeSecurityGroupEgress(t *testing.T) {

--- a/snapshots.go
+++ b/snapshots.go
@@ -25,6 +25,11 @@ type Snapshot struct {
 	JobStatus    JobStatusType `json:"jobstatus,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*Snapshot) ResourceType() string {
+	return "Snapshot"
+}
+
 // CreateSnapshot represents a request to create a volume snapshot
 //
 // CloudStackAPI: http://cloudstack.apache.org/api/apidocs-4.10/apis/createSnapshot.html

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -5,10 +5,18 @@ import (
 )
 
 func TestSnapshots(t *testing.T) {
+	var _ Taggable = (*Snapshot)(nil)
 	var _ AsyncCommand = (*CreateSnapshot)(nil)
 	var _ Command = (*ListSnapshots)(nil)
 	var _ AsyncCommand = (*DeleteSnapshot)(nil)
 	var _ AsyncCommand = (*RevertSnapshot)(nil)
+}
+
+func TestSnapshot(t *testing.T) {
+	instance := &Snapshot{}
+	if instance.ResourceType() != "Snapshot" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestCreateSnapshot(t *testing.T) {

--- a/tags.go
+++ b/tags.go
@@ -1,5 +1,13 @@
 package egoscale
 
+// Taggable represents a resource which can have tags attached
+//
+// This is a helper to fill the resourcetype of a CreateTags call
+type Taggable interface {
+	// CloudStack resource type of the Taggable type
+	ResourceType() string
+}
+
 // ResourceTag is a tag associated with a resource
 //
 // http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.9/management.html

--- a/templates.go
+++ b/templates.go
@@ -37,6 +37,11 @@ type Template struct {
 	Zonename              string            `json:"zonename,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*Template) ResourceType() string {
+	return "Template"
+}
+
 // ListTemplates represents a template query filter
 type ListTemplates struct {
 	TemplateFilter string        `json:"templatefilter"` // featured, etc.

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,0 +1,25 @@
+package egoscale
+
+import (
+	"testing"
+)
+
+func TestTemplates(t *testing.T) {
+	var _ Taggable = (*Template)(nil)
+	var _ Command = (*ListTemplates)(nil)
+}
+
+func TestTemplate(t *testing.T) {
+	instance := &Template{}
+	if instance.ResourceType() != "Template" {
+		t.Errorf("ResourceType doesn't match")
+	}
+}
+
+func TestListTemplates(t *testing.T) {
+	req := &ListTemplates{}
+	if req.name() != "listTemplates" {
+		t.Errorf("API call doesn't match")
+	}
+	_ = req.response().(*ListTemplatesResponse)
+}

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -77,6 +77,11 @@ type VirtualMachine struct {
 	JobStatus             JobStatusType     `json:"jobstatus,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*VirtualMachine) ResourceType() string {
+	return "UserVM"
+}
+
 // NicsByType returns the corresponding interfaces base on the given type
 func (vm *VirtualMachine) NicsByType(nicType string) []Nic {
 	nics := make([]Nic, 0)

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestVirtualMachines(t *testing.T) {
+	var _ Taggable = (*VirtualMachine)(nil)
 	var _ AsyncCommand = (*DeployVirtualMachine)(nil)
 	var _ AsyncCommand = (*DestroyVirtualMachine)(nil)
 	var _ AsyncCommand = (*RebootVirtualMachine)(nil)
@@ -22,6 +23,13 @@ func TestVirtualMachines(t *testing.T) {
 	var _ AsyncCommand = (*AddNicToVirtualMachine)(nil)
 	var _ AsyncCommand = (*RemoveNicFromVirtualMachine)(nil)
 	var _ AsyncCommand = (*UpdateDefaultNicForVirtualMachine)(nil)
+}
+
+func TestVirtualMachine(t *testing.T) {
+	instance := &VirtualMachine{}
+	if instance.ResourceType() != "UserVM" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestDeployVirtualMachine(t *testing.T) {

--- a/volumes.go
+++ b/volumes.go
@@ -33,6 +33,11 @@ type Volume struct {
 	JobStatus                  JobStatusType `json:"jobstatus,omitempty"`
 }
 
+// ResourceType returns the type of the resource
+func (*Volume) ResourceType() string {
+	return "Volume"
+}
+
 // ResizeVolume (Async) resizes a volume
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resizeVolume.html

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -5,8 +5,16 @@ import (
 )
 
 func TestVolumes(t *testing.T) {
+	var _ Taggable = (*Volume)(nil)
 	var _ Command = (*ListVolumes)(nil)
 	var _ AsyncCommand = (*ResizeVolume)(nil)
+}
+
+func TestVolume(t *testing.T) {
+	instance := &Volume{}
+	if instance.ResourceType() != "Volume" {
+		t.Errorf("ResourceType doesn't match")
+	}
 }
 
 func TestListVolumes(t *testing.T) {


### PR DESCRIPTION
CreateTags/DeleteTags require a string representing the resource and its value is not trivial. To make one's life easier, it's now in the library.

source of truth: https://github.com/apache/cloudstack/blob/a86160b389057e6f7241f49313c031db0b079a4f/test/integration/component/test_tags.py