### PR TITLE
request: uuidList isn't a list of string

### DIFF
--- a/request.go
+++ b/request.go
@@ -116,10 +116,17 @@ type JobResultResponse struct {
 
 // ErrorResponse represents the standard error response from CloudStack
 type ErrorResponse struct {
-	ErrorCode   ErrorCode `json:"errorcode"`
-	CsErrorCode int       `json:"cserrorcode"`
-	ErrorText   string    `json:"errortext"`
-	UUIDList    []string  `json:"uuidList,omitempty"` // uuid*L*ist is not a typo
+	ErrorCode   ErrorCode  `json:"errorcode"`
+	CsErrorCode int        `json:"cserrorcode"`
+	ErrorText   string     `json:"errortext"`
+	UUIDList    []UUIDItem `json:"uuidList,omitempty"` // uuid*L*ist is not a typo
+}
+
+// UUIDItem represents an item of the UUIDList part of an ErrorResponse
+type UUIDItem struct {
+	Description      string `json:"description,omitempty"`
+	SerialVersionUID int64  `json:"serialVersionUID,omitempty"`
+	UUID             string `json:"uuid"`
 }
 
 // Error formats a CloudStack error into a standard error


### PR DESCRIPTION
```
> cs deleteSSHKeyPair name=docker-machine-test
Cloudstack error: HTTP response 431
{
  "deletesshkeypairresponse": {
    "cserrorcode": 4350,
    "errorcode": 431,
    "errortext": "A key pair with name 'docker-machine-test' does not exist for account XXX in specified domain id",
    "uuidList": [
      {
        "description": "domainId",
        "serialVersionUID": -7514266713085362352,
        "uuid": "2da0d0d3-e7b2-42ef-805d-eb2ea90ae7ef"
      }
    ]
  }
}
```