### PR TITLE
global: enable *bool to send false omitempty values

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -74,10 +74,10 @@ type ListAccounts struct {
 	AccountType       int64  `json:"accounttype,omitempty"`
 	DomainID          string `json:"domainid,omitempty"`
 	ID                string `json:"id,omitempty"`
-	IsCleanUpRequired bool   `json:"iscleanuprequired,omitempty"`
-	IsRecursive       bool   `json:"isrecursive,omitempty"`
+	IsCleanUpRequired *bool  `json:"iscleanuprequired,omitempty"`
+	IsRecursive       *bool  `json:"isrecursive,omitempty"`
 	Keyword           string `json:"keyword,omitempty"`
-	ListAll           bool   `json:"listall,omitempty"`
+	ListAll           *bool  `json:"listall,omitempty"`
 	Page              int    `json:"page,omitempty"`
 	PageSize          int    `json:"pagesize,omitempty"`
 	State             string `json:"state,omitempty"`

--- a/addresses.go
+++ b/addresses.go
@@ -49,8 +49,8 @@ func (*IPAddress) ResourceType() string {
 type AssociateIPAddress struct {
 	Account    string `json:"account,omitempty"`
 	DomainID   string `json:"domainid,omitempty"`
-	ForDisplay bool   `json:"fordisplay,omitempty"`
-	IsPortable bool   `json:"isportable,omitempty"`
+	ForDisplay *bool  `json:"fordisplay,omitempty"`
+	IsPortable *bool  `json:"isportable,omitempty"`
 	NetworkdID string `json:"networkid,omitempty"`
 	ProjectID  string `json:"projectid,omitempty"`
 	RegionID   string `json:"regionid,omitempty"`
@@ -91,7 +91,7 @@ func (*DisassociateIPAddress) asyncResponse() interface{} {
 type UpdateIPAddress struct {
 	ID         string `json:"id"`
 	CustomID   string `json:"customid,omitempty"` // root only
-	ForDisplay bool   `json:"fordisplay,omitempty"`
+	ForDisplay *bool  `json:"fordisplay,omitempty"`
 }
 
 func (*UpdateIPAddress) name() string {
@@ -109,20 +109,20 @@ type UpdateIPAddressResponse AssociateIPAddressResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listPublicIpAddresses.html
 type ListPublicIPAddresses struct {
 	Account            string        `json:"account,omitempty"`
-	AllocatedOnly      bool          `json:"allocatedonly,omitempty"`
+	AllocatedOnly      *bool         `json:"allocatedonly,omitempty"`
 	AllocatedNetworkID string        `json:"allocatednetworkid,omitempty"`
 	DomainID           string        `json:"domainid,omitempty"`
-	ForDisplay         bool          `json:"fordisplay,omitempty"`
-	ForLoadBalancing   bool          `json:"forloadbalancing,omitempty"`
+	ForDisplay         *bool         `json:"fordisplay,omitempty"`
+	ForLoadBalancing   *bool         `json:"forloadbalancing,omitempty"`
 	ForVirtualNetwork  string        `json:"forvirtualnetwork,omitempty"`
 	ID                 string        `json:"id,omitempty"`
 	IPAddress          net.IP        `json:"ipaddress,omitempty"`
-	IsElastic          bool          `json:"iselastic,omitempty"`
-	IsRecursive        bool          `json:"isrecursive,omitempty"`
-	IsSourceNat        bool          `json:"issourcenat,omitempty"`
-	IsStaticNat        bool          `json:"isstaticnat,omitempty"`
+	IsElastic          *bool         `json:"iselastic,omitempty"`
+	IsRecursive        *bool         `json:"isrecursive,omitempty"`
+	IsSourceNat        *bool         `json:"issourcenat,omitempty"`
+	IsStaticNat        *bool         `json:"isstaticnat,omitempty"`
 	Keyword            string        `json:"keyword,omitempty"`
-	ListAll            bool          `json:"listall,omiempty"`
+	ListAll            *bool         `json:"listall,omiempty"`
 	Page               int           `json:"page,omitempty"`
 	PageSize           int           `json:"pagesize,omitempty"`
 	PhysicalNetworkID  string        `json:"physicalnetworkid,omitempty"`

--- a/addresses.go
+++ b/addresses.go
@@ -122,7 +122,7 @@ type ListPublicIPAddresses struct {
 	IsSourceNat        *bool         `json:"issourcenat,omitempty"`
 	IsStaticNat        *bool         `json:"isstaticnat,omitempty"`
 	Keyword            string        `json:"keyword,omitempty"`
-	ListAll            *bool         `json:"listall,omiempty"`
+	ListAll            *bool         `json:"listall,omitempty"`
 	Page               int           `json:"page,omitempty"`
 	PageSize           int           `json:"pagesize,omitempty"`
 	PhysicalNetworkID  string        `json:"physicalnetworkid,omitempty"`

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -100,9 +100,9 @@ type ListAffinityGroups struct {
 	Account          string `json:"account,omitempty"`
 	DomainID         string `json:"domainid,omitempty"`
 	ID               string `json:"id,omitempty"`
-	IsRecursive      bool   `json:"isrecursive,omitempty"`
+	IsRecursive      *bool  `json:"isrecursive,omitempty"`
 	Keyword          string `json:"keyword,omitempty"`
-	ListAll          bool   `json:"listall,omitempty"`
+	ListAll          *bool  `json:"listall,omitempty"`
 	Name             string `json:"name,omitempty"`
 	Page             int    `json:"page,omitempty"`
 	PageSize         int    `json:"pagesize,omitempty"`

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -44,7 +44,7 @@ type QueryAsyncJobResultResponse AsyncJobResult
 type ListAsyncJobs struct {
 	Account     string `json:"account,omitempty"`
 	DomainID    string `json:"domainid,omitempty"`
-	IsRecursive bool   `json:"isrecursive,omitempty"`
+	IsRecursive *bool  `json:"isrecursive,omitempty"`
 	Keyword     string `json:"keyword,omitempty"`
 	Page        int    `json:"page,omitempty"`
 	PageSize    int    `json:"pagesize,omitempty"`

--- a/events.go
+++ b/events.go
@@ -32,10 +32,10 @@ type ListEvents struct {
 	EndDate     string `json:"enddate,omitempty"`
 	EntryTime   int    `json:"entrytime,omitempty"`
 	ID          string `json:"id,omitempty"`
-	IsRecursive bool   `json:"isrecursive,omitempty"`
+	IsRecursive *bool  `json:"isrecursive,omitempty"`
 	Keyword     string `json:"keyword,omitempty"`
 	Level       string `json:"level,omitempty"` // INFO, WARN, ERROR
-	ListAll     bool   `json:"listall,omitempty"`
+	ListAll     *bool  `json:"listall,omitempty"`
 	Page        int    `json:"page,omitempty"`
 	PageSize    int    `json:"pagesize,omitempty"`
 	ProjectID   string `json:"projectid,omitempty"`

--- a/keypairs.go
+++ b/keypairs.go
@@ -82,9 +82,9 @@ type ListSSHKeyPairs struct {
 	Account     string `json:"account,omitempty"`
 	DomainID    string `json:"domainid,omitempty"`
 	Fingerprint string `json:"fingerprint,omitempty"`
-	IsRecursive bool   `json:"isrecursive,omitempty"`
+	IsRecursive *bool  `json:"isrecursive,omitempty"`
 	Keyword     string `json:"keyword,omitempty"`
-	ListAll     bool   `json:"listall,omitempty"`
+	ListAll     *bool  `json:"listall,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Page        int    `json:"page,omitempty"`
 	PageSize    int    `json:"pagesize,omitempty"`

--- a/limits.go
+++ b/limits.go
@@ -69,9 +69,9 @@ type ListResourceLimits struct {
 	Account          string           `json:"account,omittempty"`
 	DomainID         string           `json:"domainid,omitempty"`
 	ID               string           `json:"id,omitempty"`
-	IsRecursive      bool             `json:"isrecursive,omitempty"`
+	IsRecursive      *bool            `json:"isrecursive,omitempty"`
 	Keyword          string           `json:"keyword,omitempty"`
-	ListAll          bool             `json:"listall,omitempty"`
+	ListAll          *bool            `json:"listall,omitempty"`
 	Page             int              `json:"page,omitempty"`
 	PageSize         int              `json:"pagesize,omitempty"`
 	ProjectID        string           `json:"projectid,omitempty"`

--- a/networks.go
+++ b/networks.go
@@ -101,7 +101,7 @@ type CreateNetwork struct {
 	Account           string `json:"account,omitempty"`
 	ACLID             string `json:"aclid,omitempty"`
 	ACLType           string `json:"acltype,omitempty"`        // Account or Domain
-	DisplayNetwork    bool   `json:"displaynetwork,omitempty"` // root only
+	DisplayNetwork    *bool  `json:"displaynetwork,omitempty"` // root only
 	DomainID          string `json:"domainid,omitempty"`
 	EndIP             net.IP `json:"endip,omitempty"`
 	EndIpv6           net.IP `json:"endipv6,omitempty"`
@@ -147,16 +147,16 @@ type CreateNetworkResponse NetworkResponse
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateNetwork.html
 type UpdateNetwork struct {
 	ID                string `json:"id"`
-	ChangeCidr        bool   `json:"changecidr,omitempty"`
+	ChangeCidr        *bool  `json:"changecidr,omitempty"`
 	CustomID          string `json:"customid,omitempty"` // root only
 	DisplayNetwork    string `json:"displaynetwork,omitempty"`
 	DisplayText       string `json:"displaytext,omitempty"`
-	Forced            bool   `json:"forced,omitempty"`
+	Forced            *bool  `json:"forced,omitempty"`
 	GuestVMCidr       string `json:"guestvmcidr,omitempty"`
 	Name              string `json:"name,omitempty"`
 	NetworkDomain     string `json:"networkdomain,omitempty"`
 	NetworkOfferingID string `json:"networkofferingid,omitempty"`
-	UpdateInSequence  bool   `json:"updateinsequence,omitempty"`
+	UpdateInSequence  *bool  `json:"updateinsequence,omitempty"`
 }
 
 func (*UpdateNetwork) name() string {
@@ -175,7 +175,7 @@ type UpdateNetworkResponse NetworkResponse
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/restartNetwork.html
 type RestartNetwork struct {
 	ID      string `json:"id"`
-	Cleanup bool   `json:"cleanup,omitempty"`
+	Cleanup *bool  `json:"cleanup,omitempty"`
 }
 
 func (*RestartNetwork) name() string {
@@ -194,7 +194,7 @@ type RestartNetworkResponse NetworkResponse
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/deleteNetwork.html
 type DeleteNetwork struct {
 	ID     string `json:"id"`
-	Forced bool   `json:"forced,omitempty"`
+	Forced *bool  `json:"forced,omitempty"`
 }
 
 func (*DeleteNetwork) name() string {
@@ -211,21 +211,21 @@ func (*DeleteNetwork) asyncResponse() interface{} {
 type ListNetworks struct {
 	Account           string        `json:"account,omitempty"`
 	ACLType           string        `json:"acltype,omitempty"` // Account or Domain
-	CanUseForDeploy   bool          `json:"canusefordeploy,omitempty"`
-	DisplayNetwork    bool          `json:"displaynetwork,omitempty"` // root only
+	CanUseForDeploy   *bool         `json:"canusefordeploy,omitempty"`
+	DisplayNetwork    *bool         `json:"displaynetwork,omitempty"` // root only
 	DomainID          string        `json:"domainid,omitempty"`
 	ForVpc            string        `json:"forvpc,omitempty"`
 	ID                string        `json:"id,omitempty"`
-	IsRecursive       bool          `json:"isrecursive,omitempty"`
-	IsSystem          bool          `json:"issystem,omitempty"`
+	IsRecursive       *bool         `json:"isrecursive,omitempty"`
+	IsSystem          *bool         `json:"issystem,omitempty"`
 	Keyword           string        `json:"keyword,omitempty"`
-	ListAll           bool          `json:"listall,omitempty"`
+	ListAll           *bool         `json:"listall,omitempty"`
 	Page              int           `json:"page,omitempty"`
 	PageSize          int           `json:"pagesize,omitempty"`
 	PhysicalNetworkID string        `json:"physicalnetworkid,omitempty"`
 	ProjectID         string        `json:"projectid,omitempty"`
-	RestartRequired   bool          `json:"restartrequired,omitempty"`
-	SpecifyRanges     bool          `json:"specifyranges,omitempty"`
+	RestartRequired   *bool         `json:"restartrequired,omitempty"`
+	SpecifyRanges     *bool         `json:"specifyranges,omitempty"`
 	SupportedServices []Service     `json:"supportedservices,omitempty"`
 	Tags              []ResourceTag `json:"resourcetag,omitempty"`
 	TrafficType       string        `json:"traffictype,omitempty"`

--- a/request.go
+++ b/request.go
@@ -497,6 +497,19 @@ func prepareValues(prefix string, params *url.Values, command interface{}) error
 				} else {
 					(*params).Set(name, "true")
 				}
+			case reflect.Ptr:
+				if val.IsNil() {
+					if required {
+						return fmt.Errorf("%s.%s (%v) is required, got empty ptr", typeof.Name(), field.Name, val.Kind())
+					}
+				} else {
+					switch field.Type.Elem().Kind() {
+					case reflect.Bool:
+						params.Set(name, strconv.FormatBool(val.Elem().Bool()))
+					default:
+						log.Printf("[SKIP] %s.%s (%v) not supported", typeof.Name(), field.Name, field.Type.Elem().Kind())
+					}
+				}
 			case reflect.Slice:
 				switch field.Type.Elem().Kind() {
 				case reflect.Uint8:

--- a/security_groups.go
+++ b/security_groups.go
@@ -198,9 +198,9 @@ type ListSecurityGroups struct {
 	Account           string        `json:"account,omitempty"`
 	DomainID          string        `json:"domainid,omitempty"`
 	ID                string        `json:"id,omitempty"`
-	IsRecursive       bool          `json:"isrecursive,omitempty"`
+	IsRecursive       *bool         `json:"isrecursive,omitempty"`
 	Keyword           string        `json:"keyword,omitempty"`
-	ListAll           bool          `json:"listall,omitempty"`
+	ListAll           *bool         `json:"listall,omitempty"`
 	Page              int           `json:"page,omitempty"`
 	PageSize          int           `json:"pagesize,omitempty"`
 	ProjectID         string        `json:"projectid,omitempty"`

--- a/service_offerings.go
+++ b/service_offerings.go
@@ -40,8 +40,8 @@ type ServiceOffering struct {
 type ListServiceOfferings struct {
 	DomainID         string `json:"domainid,omitempty"`
 	ID               string `json:"id,omitempty"`
-	IsRecursive      bool   `json:"isrecursive,omitempty"`
-	IsSystem         bool   `json:"issystem,omitempty"`
+	IsRecursive      *bool  `json:"isrecursive,omitempty"`
+	IsSystem         *bool  `json:"issystem,omitempty"`
 	Keyword          string `json:"keyword,omitempty"`
 	Name             string `json:"name,omitempty"`
 	Page             int    `json:"page,omitempty"`

--- a/snapshots.go
+++ b/snapshots.go
@@ -38,7 +38,7 @@ type CreateSnapshot struct {
 	Account   string `json:"account,omitempty"`
 	DomainID  string `json:"domainid,omitempty"`
 	PolicyID  string `json:"policyid,omitempty"`
-	QuiesceVM bool   `json:"quiescevm,omitempty"`
+	QuiesceVM *bool  `json:"quiescevm,omitempty"`
 }
 
 func (*CreateSnapshot) name() string {
@@ -62,9 +62,9 @@ type ListSnapshots struct {
 	DomainID     string        `json:"domainid,omitempty"`
 	ID           string        `json:"id,omitempty"`
 	IntervalType string        `json:"intervaltype,omitempty"`
-	IsRecursive  bool          `json:"isrecursive,omitempty"`
+	IsRecursive  *bool         `json:"isrecursive,omitempty"`
 	Keyword      string        `json:"keyword,omitempty"`
-	ListAll      bool          `json:"listall,omitempty"`
+	ListAll      *bool         `json:"listall,omitempty"`
 	Name         string        `json:"name,omitempty"`
 	Page         int           `json:"page,omitempty"`
 	PageSize     int           `json:"pagesize,omitempty"`

--- a/tags.go
+++ b/tags.go
@@ -66,10 +66,10 @@ type ListTags struct {
 	Account      string `json:"account,omitempty"`
 	Customer     string `json:"customer,omitempty"`
 	DomainID     string `json:"domainid,omitempty"`
-	IsRecursive  bool   `json:"isrecursive,omitempty"`
+	IsRecursive  *bool  `json:"isrecursive,omitempty"`
 	Key          string `json:"key,omitempty"`
 	Keyword      string `json:"keyword,omitempty"`
-	ListAll      bool   `json:"listall,omitempty"`
+	ListAll      *bool  `json:"listall,omitempty"`
 	Page         int    `json:"page,omitempty"`
 	PageSize     int    `json:"pagesize,omitempty"`
 	ProjectID    string `json:"projectid,omitempty"`

--- a/templates.go
+++ b/templates.go
@@ -49,14 +49,14 @@ type ListTemplates struct {
 	DomainID       string        `json:"domainid,omitempty"`
 	Hypervisor     string        `json:"hypervisor,omitempty"`
 	ID             string        `json:"id,omitempty"`
-	IsRecursive    bool          `json:"isrecursive,omitempty"`
+	IsRecursive    *bool         `json:"isrecursive,omitempty"`
 	Keyword        string        `json:"keyword,omitempty"`
-	ListAll        bool          `json:"listall,omitempty"`
+	ListAll        *bool         `json:"listall,omitempty"`
 	Name           string        `json:"name,omitempty"`
 	Page           int           `json:"page,omitempty"`
 	PageSize       int           `json:"pagesize,omitempty"`
 	ProjectID      string        `json:"projectid,omitempty"`
-	ShowRemoved    bool          `json:"showremoved,omitempty"`
+	ShowRemoved    *bool         `json:"showremoved,omitempty"`
 	Tags           []ResourceTag `json:"tags,omitempty"`
 	ZoneID         string        `json:"zoneid,omitempty"`
 }

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -27,7 +27,7 @@ type VirtualMachine struct {
 	Group                 string            `json:"group,omitempty"`
 	GroupID               string            `json:"groupid,omitempty"`
 	GuestOsID             string            `json:"guestosid,omitempty"`
-	HaEnable              bool              `json:"haenable,omitempty"`
+	HAEnable              bool              `json:"haenable,omitempty"`
 	HostID                string            `json:"hostid,omitempty"`
 	HostName              string            `json:"hostname,omitempty"`
 	Hypervisor            string            `json:"hypervisor,omitempty"`
@@ -158,7 +158,7 @@ type DeployVirtualMachine struct {
 	Details            map[string]string `json:"details,omitempty"`
 	DiskOfferingID     string            `json:"diskofferingid,omitempty"`
 	DisplayName        string            `json:"displayname,omitempty"`
-	DisplayVM          bool              `json:"displayvm,omitempty"`
+	DisplayVM          *bool             `json:"displayvm,omitempty"`
 	DomainID           string            `json:"domainid,omitempty"`
 	Group              string            `json:"group,omitempty"`
 	HostID             string            `json:"hostid,omitempty"`
@@ -175,7 +175,7 @@ type DeployVirtualMachine struct {
 	SecurityGroupIDs   []string          `json:"securitygroupids,omitempty"`
 	SecurityGroupNames []string          `json:"securitygroupnames,omitempty"` // does nothing, mutually exclusive
 	Size               string            `json:"size,omitempty"`               // mutually exclusive with DiskOfferingID
-	StartVM            bool              `json:"startvm,omitempty"`
+	StartVM            *bool             `json:"startvm,omitempty"`
 	UserData           string            `json:"userdata,omitempty"` // the client is responsible to base64/gzip it
 }
 
@@ -214,7 +214,7 @@ type StartVirtualMachineResponse VirtualMachineResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/stopVirtualMachine.html
 type StopVirtualMachine struct {
 	ID     string `json:"id"`
-	Forced bool   `json:"forced,omitempty"`
+	Forced *bool  `json:"forced,omitempty"`
 }
 
 func (*StopVirtualMachine) name() string {
@@ -289,7 +289,7 @@ type RecoverVirtualMachineResponse VirtualMachineResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/destroyVirtualMachine.html
 type DestroyVirtualMachine struct {
 	ID      string `json:"id"`
-	Expunge bool   `json:"expunge,omitempty"`
+	Expunge *bool  `json:"expunge,omitempty"`
 }
 
 func (*DestroyVirtualMachine) name() string {
@@ -311,10 +311,10 @@ type UpdateVirtualMachine struct {
 	CustomID              string            `json:"customid,omitempty"` // root only
 	Details               map[string]string `json:"details,omitempty"`
 	DisplayName           string            `json:"displayname,omitempty"`
-	DisplayVM             bool              `json:"displayvm,omitempty"`
+	DisplayVM             *bool             `json:"displayvm,omitempty"`
 	Group                 string            `json:"group,omitempty"`
-	HAEnable              bool              `json:"haenable,omitempty"`
-	IsDynamicallyScalable bool              `json:"isdynamicallyscalable,omitempty"`
+	HAEnable              *bool             `json:"haenable,omitempty"`
+	IsDynamicallyScalable *bool             `json:"isdynamicallyscalable,omitempty"`
 	Name                  string            `json:"name,omitempty"` // must reboot
 	OsTypeID              int64             `json:"ostypeid,omitempty"`
 	SecurityGroupIDs      []string          `json:"securitygroupids,omitempty"`
@@ -425,19 +425,19 @@ type ListVirtualMachines struct {
 	Account           string            `json:"account,omitempty"`
 	AffinityGroupID   string            `json:"affinitygroupid,omitempty"`
 	Details           map[string]string `json:"details,omitempty"`
-	DisplayVM         bool              `json:"displayvm,omitempty"` // root only
+	DisplayVM         *bool             `json:"displayvm,omitempty"` // root only
 	DomainID          string            `json:"domainid,omitempty"`
-	ForVirtualNetwork bool              `json:"forvirtualnetwork,omitempty"`
+	ForVirtualNetwork *bool             `json:"forvirtualnetwork,omitempty"`
 	GroupID           string            `json:"groupid,omitempty"`
 	HostID            string            `json:"hostid,omitempty"`
 	Hypervisor        string            `json:"hypervisor,omitempty"`
 	ID                string            `json:"id,omitempty"`
 	IDs               []string          `json:"ids,omitempty"` // mutually exclusive with id
 	IsoID             string            `json:"isoid,omitempty"`
-	IsRecursive       bool              `json:"isrecursive,omitempty"`
+	IsRecursive       *bool             `json:"isrecursive,omitempty"`
 	KeyPair           string            `json:"keypair,omitempty"`
 	Keyword           string            `json:"keyword,omitempty"`
-	ListAll           bool              `json:"listall,omitempty"`
+	ListAll           *bool             `json:"listall,omitempty"`
 	Name              string            `json:"name,omitempty"`
 	NetworkID         string            `json:"networkid,omitempty"`
 	Page              int               `json:"page,omitempty"`

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -82,9 +82,9 @@ type ListInstanceGroups struct {
 	Account     string `json:"account,omitempty"`
 	DomainID    string `json:"domainid,omitempty"`
 	ID          string `json:"id,omitempty"`
-	IsRecursive bool   `json:"isrecursive,omitempty"`
+	IsRecursive *bool  `json:"isrecursive,omitempty"`
 	Keyword     string `json:"keyword,omitempty"`
-	ListAll     bool   `json:"listall,omitempty"`
+	ListAll     *bool  `json:"listall,omitempty"`
 	Page        int    `json:"page,omitempty"`
 	PageSize    int    `json:"pagesize,omitempty"`
 	State       string `json:"state,omitempty"`

--- a/volumes.go
+++ b/volumes.go
@@ -44,7 +44,7 @@ func (*Volume) ResourceType() string {
 type ResizeVolume struct {
 	ID             string `json:"id"`
 	DiskOfferingID string `json:"diskofferingid,omitempty"`
-	ShrinkOk       bool   `json:"shrinkok,omitempty"`
+	ShrinkOk       *bool  `json:"shrinkok,omitempty"`
 	Size           int64  `json:"size,omitempty"` // in GiB
 }
 
@@ -71,9 +71,9 @@ type ListVolumes struct {
 	DomainID         string        `json:"domainid,omitempty"`
 	HostID           string        `json:"hostid,omitempty"`
 	ID               string        `json:"id,omitempty"`
-	IsRecursive      bool          `json:"isrecursive,omitempty"`
+	IsRecursive      *bool         `json:"isrecursive,omitempty"`
 	Keyword          string        `json:"keyword,omitempty"`
-	ListAll          bool          `json:"listall,omitempty"`
+	ListAll          *bool         `json:"listall,omitempty"`
 	Name             string        `json:"name,omitempty"`
 	Page             int           `json:"page,omitempty"`
 	PageSize         int           `json:"pagesize,omitempty"`

--- a/zones.go
+++ b/zones.go
@@ -34,14 +34,14 @@ type Zone struct {
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listZones.html
 type ListZones struct {
-	Available      bool          `json:"available,omitempty"`
+	Available      *bool         `json:"available,omitempty"`
 	DomainID       string        `json:"domainid,omitempty"`
 	ID             string        `json:"id,omitempty"`
 	Keyword        string        `json:"keyword,omitempty"`
 	Name           string        `json:"name,omitempty"`
 	Page           int           `json:"page,omitempty"`
 	PageSize       int           `json:"pagesize,omitempty"`
-	ShowCapacities bool          `json:"showcapacities,omitempty"`
+	ShowCapacities *bool         `json:"showcapacities,omitempty"`
 	Tags           []ResourceTag `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
When the default value of a boolean field is true, it's impossible to send the `false` value.