### PR TITLE
vm: make security/affinity group ids and names mutually exclusive

### DIFF
--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -1,6 +1,10 @@
 package egoscale
 
-import "net"
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
 
 // VirtualMachine reprents a virtual machine
 type VirtualMachine struct {
@@ -151,10 +155,10 @@ type DeployVirtualMachine struct {
 	TemplateID         string            `json:"templateid"`
 	ZoneID             string            `json:"zoneid"`
 	Account            string            `json:"account,omitempty"`
-	AffinityGroupIDs   []string          `json:"affinitygroupids,omitempty"`
-	AffinityGroupNames []string          `json:"affinitygroupnames,omitempty"`
-	CustomID           string            `json:"customid,omitempty"`          // root only
-	DeploymentPlanner  string            `json:"deploymentplanner,omitempty"` // root only
+	AffinityGroupIDs   []string          `json:"affinitygroupids,omitempty"`   // mutually exclusive with AffinityGroupNames
+	AffinityGroupNames []string          `json:"affinitygroupnames,omitempty"` // mutually exclusive with AffinityGroupIDs
+	CustomID           string            `json:"customid,omitempty"`           // root only
+	DeploymentPlanner  string            `json:"deploymentplanner,omitempty"`  // root only
 	Details            map[string]string `json:"details,omitempty"`
 	DiskOfferingID     string            `json:"diskofferingid,omitempty"`
 	DisplayName        string            `json:"displayname,omitempty"`
@@ -171,9 +175,9 @@ type DeployVirtualMachine struct {
 	Name               string            `json:"name,omitempty"`
 	NetworkIDs         []string          `json:"networkids,omitempty"` // mutually exclusive with IPToNetworkList
 	ProjectID          string            `json:"projectid,omitempty"`
-	RootDiskSize       int64             `json:"rootdisksize,omitempty"` // in GiB
-	SecurityGroupIDs   []string          `json:"securitygroupids,omitempty"`
-	SecurityGroupNames []string          `json:"securitygroupnames,omitempty"` // does nothing, mutually exclusive
+	RootDiskSize       int64             `json:"rootdisksize,omitempty"`       // in GiB
+	SecurityGroupIDs   []string          `json:"securitygroupids,omitempty"`   // mutually exclusive with SecurityGroupNames
+	SecurityGroupNames []string          `json:"securitygroupnames,omitempty"` // mutually exclusive with SecurityGroupIDs
 	Size               string            `json:"size,omitempty"`               // mutually exclusive with DiskOfferingID
 	StartVM            *bool             `json:"startvm,omitempty"`
 	UserData           string            `json:"userdata,omitempty"` // the client is responsible to base64/gzip it
@@ -182,6 +186,22 @@ type DeployVirtualMachine struct {
 // APIName returns the CloudStack API command name
 func (*DeployVirtualMachine) APIName() string {
 	return "deployVirtualMachine"
+}
+
+func (req *DeployVirtualMachine) onBeforeSend(params *url.Values) error {
+	// Either AffinityGroupIDs or AffinityGroupNames must be set
+	if len(req.AffinityGroupIDs) > 0 && len(req.AffinityGroupNames) > 0 {
+		return fmt.Errorf("Either AffinityGroupIDs or AffinityGroupNames must be set")
+	}
+
+	// Either SecurityGroupIDs or SecurityGroupNames must be set
+	if len(req.SecurityGroupIDs) == 0 && len(req.SecurityGroupNames) == 0 {
+		return fmt.Errorf("SecurityGroupIDs or SecurityGroupNames must be non-empty")
+	} else if len(req.SecurityGroupIDs) > 0 && len(req.SecurityGroupNames) > 0 {
+		return fmt.Errorf("Either SecurityGroupIDs or SecurityGroupNames must be set")
+	}
+
+	return nil
 }
 
 func (*DeployVirtualMachine) asyncResponse() interface{} {
@@ -323,7 +343,7 @@ type UpdateVirtualMachine struct {
 	HAEnable              *bool             `json:"haenable,omitempty"`
 	IsDynamicallyScalable *bool             `json:"isdynamicallyscalable,omitempty"`
 	Name                  string            `json:"name,omitempty"` // must reboot
-	OsTypeID              int64             `json:"ostypeid,omitempty"`
+	OSTypeID              int64             `json:"ostypeid,omitempty"`
 	SecurityGroupIDs      []string          `json:"securitygroupids,omitempty"`
 	UserData              string            `json:"userdata,omitempty"`
 }

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -195,9 +195,7 @@ func (req *DeployVirtualMachine) onBeforeSend(params *url.Values) error {
 	}
 
 	// Either SecurityGroupIDs or SecurityGroupNames must be set
-	if len(req.SecurityGroupIDs) == 0 && len(req.SecurityGroupNames) == 0 {
-		return fmt.Errorf("SecurityGroupIDs or SecurityGroupNames must be non-empty")
-	} else if len(req.SecurityGroupIDs) > 0 && len(req.SecurityGroupNames) > 0 {
+	if len(req.SecurityGroupIDs) > 0 && len(req.SecurityGroupNames) > 0 {
 		return fmt.Errorf("Either SecurityGroupIDs or SecurityGroupNames must be set")
 	}
 

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -2,6 +2,7 @@ package egoscale
 
 import (
 	"net"
+	"net/url"
 	"testing"
 )
 
@@ -167,6 +168,51 @@ func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateDefaultNicForVirtualMachineResponse)
+}
+
+func TestDeployOnBeforeSend(t *testing.T) {
+	req := &DeployVirtualMachine{
+		SecurityGroupNames: []string{"default"},
+	}
+	params := new(url.Values)
+
+	if err := req.onBeforeSend(params); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDeployOnBeforeSendNoSG(t *testing.T) {
+	req := &DeployVirtualMachine{}
+	params := new(url.Values)
+
+	if err := req.onBeforeSend(params); err == nil {
+		t.Errorf("DeployVM should have at least some SG")
+	}
+}
+
+func TestDeployOnBeforeSendBothSG(t *testing.T) {
+	req := &DeployVirtualMachine{
+		SecurityGroupIDs:   []string{"1"},
+		SecurityGroupNames: []string{"foo"},
+	}
+	params := new(url.Values)
+
+	if err := req.onBeforeSend(params); err == nil {
+		t.Errorf("DeployVM should only accept SG ids or names")
+	}
+}
+
+func TestDeployOnBeforeSendBothAG(t *testing.T) {
+	req := &DeployVirtualMachine{
+		SecurityGroupIDs:   []string{"1"},
+		AffinityGroupIDs:   []string{"2"},
+		AffinityGroupNames: []string{"foo"},
+	}
+	params := new(url.Values)
+
+	if err := req.onBeforeSend(params); err == nil {
+		t.Errorf("DeployVM should only accept SG ids or names")
+	}
 }
 
 func TestNicHelpers(t *testing.T) {

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -185,8 +185,9 @@ func TestDeployOnBeforeSendNoSG(t *testing.T) {
 	req := &DeployVirtualMachine{}
 	params := new(url.Values)
 
-	if err := req.onBeforeSend(params); err == nil {
-		t.Errorf("DeployVM should have at least some SG")
+	// CS will pick the default oiine
+	if err := req.onBeforeSend(params); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -204,7 +205,6 @@ func TestDeployOnBeforeSendBothSG(t *testing.T) {
 
 func TestDeployOnBeforeSendBothAG(t *testing.T) {
 	req := &DeployVirtualMachine{
-		SecurityGroupIDs:   []string{"1"},
 		AffinityGroupIDs:   []string{"2"},
 		AffinityGroupNames: []string{"foo"},
 	}


### PR DESCRIPTION
`DeployVM` now requires at least one security group, either by name or id. And one cannot set both affinity group by name and id.