### PR TITLE
client: generic list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,7 @@ script:
   - go test -race -coverprofile=coverage.out -covermode=atomic .
 
 after_success:
-  - codeclimate-test-reporter < coverage.out
+  - >
+    if [ "${TRAVIS_GO_VERSION}" = "1.10" ]; then
+      codeclimate-test-reporter < coverage.out;
+    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.9.16
+------
+
+- feat: new `Listable` interface
+- feat: `Nic` is `Listable`
+- feat: `Volume` is `Listable`
+- feat: `Zone` is `Listable`
+- feat: `AffinityGroup` is `Listable`
+- remove: deprecated methods `ListNics`, `AddIPToNic`, and `RemoveIPFromNic`
+- remove: deprecated method `GetRoomVolumeForVirtualMachine`
+
 0.9.15
 ------
 

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -53,7 +53,7 @@ func TestUpdateIPAddress(t *testing.T) {
 }
 
 func TestGetIPAddress(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listpublicipaddressesresponse": {
 	"count": 1,
 	"publicipaddress": [
@@ -78,7 +78,7 @@ func TestGetIPAddress(t *testing.T) {
 			"zonename": "ch-gva-2"
 		}
 	]
-}}`)
+}}`})
 
 	defer ts.Close()
 
@@ -97,7 +97,7 @@ func TestGetIPAddress(t *testing.T) {
 }
 
 func TestGetIPAddressInvalid(t *testing.T) {
-	ts := newServer(400, ``)
+	ts := newServer(response{400, ``})
 
 	defer ts.Close()
 
@@ -109,9 +109,9 @@ func TestGetIPAddressInvalid(t *testing.T) {
 }
 
 func TestGetIPAddressMissing(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listpublicipaddressesresponse":{}}
-`)
+`})
 
 	defer ts.Close()
 
@@ -125,7 +125,7 @@ func TestGetIPAddressMissing(t *testing.T) {
 }
 
 func TestGetIPAddressMultiple(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listpublicipaddressesresponse":{
 	"count": 2,
 	"publicipaddress": [
@@ -133,7 +133,7 @@ func TestGetIPAddressMultiple(t *testing.T) {
 		{"id": "2"}
 	]
 }}
-`)
+`})
 
 	defer ts.Close()
 
@@ -147,11 +147,11 @@ func TestGetIPAddressMultiple(t *testing.T) {
 }
 
 func TestGetIPAddressError(t *testing.T) {
-	ts := newServer(400, `
+	ts := newServer(response{400, `
 {"listpublicipaddressesresponse": {
 	"errorcode": 431,
 	"errortext": "foo"
-}}`)
+}}`})
 
 	defer ts.Close()
 
@@ -165,7 +165,7 @@ func TestGetIPAddressError(t *testing.T) {
 }
 
 func TestDeleteIPAddress(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"queryasyncjobresultresponse": {
 	"jobid": "b1ac7d06-3320-4388-b234-43420bcb236c",
 	"jobprocstatus": 0,
@@ -173,7 +173,7 @@ func TestDeleteIPAddress(t *testing.T) {
 		"success": true
 	},
 	"jobstatus": 2
-}}`)
+}}`})
 
 	defer ts.Close()
 
@@ -187,7 +187,7 @@ func TestDeleteIPAddress(t *testing.T) {
 }
 
 func TestDeleteIPAddressInvalid(t *testing.T) {
-	ts := newServer(400, ``)
+	ts := newServer(response{400, ``})
 
 	defer ts.Close()
 
@@ -199,7 +199,7 @@ func TestDeleteIPAddressInvalid(t *testing.T) {
 }
 
 func TestDeleteIPAddressError(t *testing.T) {
-	ts := newServer(400, `
+	ts := newServer(response{400, `
 {"queryasyncjobresultresponse": {
 	"jobid": "b1ac7d06-3320-4388-b234-43420bcb236c",
 	"jobprocstatus": 0,
@@ -208,7 +208,7 @@ func TestDeleteIPAddressError(t *testing.T) {
 		"errortext": "Only elastic IP can be released explicitly."
 	},
 	"jobstatus": 2
-}}`)
+}}`})
 
 	defer ts.Close()
 

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -67,7 +67,7 @@ func TestUpdateVMOnBeforeSend(t *testing.T) {
 }
 
 func TestGetAffinityGroup(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listaffinitygroupsresponse": {
 	"affinitygroup": [
 		{
@@ -81,7 +81,7 @@ func TestGetAffinityGroup(t *testing.T) {
 		}
 	],
 	"count": 1
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -98,11 +98,11 @@ func TestGetAffinityGroup(t *testing.T) {
 }
 
 func TestGetAffinityGroupNotFound(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listaffinitygroupsresponse": {
 	"affinitygroup": [],
 	"count": 0
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -115,7 +115,7 @@ func TestGetAffinityGroupNotFound(t *testing.T) {
 }
 
 func TestGetAffinityGroupBadQuery(t *testing.T) {
-	ts := newServer(200, "{}")
+	ts := newServer(response{200, "{}"})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -127,7 +127,7 @@ func TestGetAffinityGroupBadQuery(t *testing.T) {
 }
 
 func TestDelAffinityGroup(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"deleteaffinitygroup": {
 	"jobid": "1",
 	"jobresult": {
@@ -135,7 +135,7 @@ func TestDelAffinityGroup(t *testing.T) {
 		"displaytext": "good job!"
 	},
 	"jobstatus": 1
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")

--- a/client_type.go
+++ b/client_type.go
@@ -1,0 +1,42 @@
+package egoscale
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Gettable represents an Interface that can be "Get" by the client
+type Gettable interface {
+	// Get populates the given resource or throws
+	Get(context context.Context, client *Client) error
+}
+
+// Deletable represents an Interface that can be "Delete" by the client
+type Deletable interface {
+	// Delete removes the given resource(s) or throws
+	Delete(context context.Context, client *Client) error
+}
+
+// Listable represents an Interface that can be "List" by the client
+type Listable interface {
+	// List search the given resources and paginates till the end of time
+	List(context context.Context, client *Client) (<-chan interface{}, <-chan error)
+}
+
+// Client represents the CloudStack API client
+type Client struct {
+	client    *http.Client
+	endpoint  string
+	apiKey    string
+	apiSecret string
+	// PageSize represents the default size for a paginated result
+	PageSize int
+	// Timeout represents the default timeout for the async requests
+	Timeout time.Duration
+	// RetryStrategy represents the waiting strategy for polling the async requests
+	RetryStrategy RetryStrategyFunc
+}
+
+// RetryStrategyFunc represents a how much time to wait between two calls to CloudStack
+type RetryStrategyFunc func(int64) time.Duration

--- a/doc.go
+++ b/doc.go
@@ -100,7 +100,30 @@ See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/lat
 
 Zones
 
-A Zone corresponds to a Data Center. You may list them.
+A Zone corresponds to a Data Center. You may list them. Zone implements the Listable interface, which let you perform a list in two different ways. The first exposes the underlying CloudStack request while the second one hide them and you only manipulate the structs of your interest.
+
+	// Using ListZones request
+	req := &egoscale.ListZones{}
+	resp, err := client.Request(req)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, zone := range resp.(*egoscale.ListZonesResponse) {
+		...
+	}
+
+	// Using client.List
+	zone := &egoscale.Zone{}
+	zones, err := client.List(zone)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, z := range zones {
+		zone := z.(egoscale.Zone)
+		...
+	}
 
 */
 package egoscale

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -53,7 +53,7 @@ func TestListSSHKeyPairs(t *testing.T) {
 }
 
 func TestGetSSHKeyPair(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsshkeypairsresponse": {
 	"count": 1,
 	"sshkeypair": [
@@ -62,7 +62,7 @@ func TestGetSSHKeyPair(t *testing.T) {
 			"name": "yoan@herp"
 		}
 	]
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -79,7 +79,7 @@ func TestGetSSHKeyPair(t *testing.T) {
 }
 
 func TestGetSSHKeyPairToMany(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsshkeypairsresponse": {
 	"count": 2,
 	"sshkeypair": [
@@ -92,7 +92,7 @@ func TestGetSSHKeyPairToMany(t *testing.T) {
 			"name": "yoan@derp"
 		}
 	]
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -105,11 +105,11 @@ func TestGetSSHKeyPairToMany(t *testing.T) {
 }
 
 func TestGetSSHKeyPairNotFound(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsshkeypairsresponse": {
 	"count": 0,
 	"sshkeypair": []
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -122,10 +122,10 @@ func TestGetSSHKeyPairNotFound(t *testing.T) {
 }
 
 func TestDelSSHKeyPair(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"deletesshkeypair": {
 	"success": "true"
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")

--- a/networks_test.go
+++ b/networks_test.go
@@ -1,6 +1,7 @@
 package egoscale
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -58,4 +59,20 @@ func TestDeleteNetwork(t *testing.T) {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
+}
+
+func TestCreateNetworkOnBeforeSend(t *testing.T) {
+	req := &CreateNetwork{}
+	params := url.Values{}
+
+	if err := req.onBeforeSend(&params); err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := params["name"]; !ok {
+		t.Errorf("name should have been set")
+	}
+	if _, ok := params["displaytext"]; !ok {
+		t.Errorf("displaytext should have been set")
+	}
 }

--- a/nics_test.go
+++ b/nics_test.go
@@ -42,3 +42,60 @@ func TestActivateIP6(t *testing.T) {
 	}
 	_ = req.asyncResponse().(*ActivateIP6Response)
 }
+
+func TestListNic(t *testing.T) {
+	ts := newServer(response{200, `
+{"listnicsresponse": {
+	"count": 1,
+	"nic": [
+		{
+			"gateway": "165.150.8.1",
+			"id": "fed8fa77-c27d-411c-a630-2ce787161ad6",
+			"ipaddress": "165.150.8.20",
+			"isdefault": true,
+			"macaddress": "06:f0:f8:00:00:57",
+			"netmask": "255.255.252.0",
+			"networkid": "2fbc4161-da5a-4be3-b5d8-ee34270cb827",
+			"virtualmachineid": "d7658121-64c8-4c50-96a7-3bb5ceeca7b2"
+		}
+	]
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	nic := &Nic{
+		VirtualMachineID: "d7658121-64c8-4c50-96a7-3bb5ceeca7b2",
+	}
+	nics, err := cs.List(nic)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(nics) != 1 {
+		t.Errorf("One nic was expected, got %d", len(nics))
+	}
+
+	if !nics[0].(Nic).IsDefault {
+		t.Errorf("Nic should be default")
+	}
+}
+
+func TestListNicError(t *testing.T) {
+	ts := newServer(response{431, `
+{"listnicresponse": {
+	"cserrorcode": 9999,
+	"errorcode": 431,
+	"errortext": "Unable to execute API command listnics due to missing parameter virtualmachineid",
+	"uuidList": []
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	nic := new(Nic)
+	_, err := cs.List(nic)
+	if err == nil {
+		t.Error("An error was expected")
+	}
+}

--- a/request_test.go
+++ b/request_test.go
@@ -53,13 +53,13 @@ func TestRequest(t *testing.T) {
 }
 
 func TestRequestSignatureFailure(t *testing.T) {
-	ts := newServer(401, `
+	ts := newServer(response{401, `
 {"createsshkeypairresponse" : {
 	"uuidList":[],
 	"errorcode":401,
 	"errortext":"unable to verify usercredentials and/or request signature"
 }}
-	`)
+	`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "TOKEN", "SECRET")
@@ -236,11 +236,18 @@ func TestBooleanRequestWithContextAndTimeout(t *testing.T) {
 	<-done
 }
 
-func newServer(code int, response string) *httptest.Server {
+type response struct {
+	code int
+	body string
+}
+
+func newServer(responses ...response) *httptest.Server {
+	i := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(code)
-		w.Write([]byte(response))
+		w.WriteHeader(responses[i].code)
+		w.Write([]byte(responses[i].body))
+		i += 1
 	})
 	return httptest.NewServer(mux)
 }

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -81,7 +81,7 @@ func TestRevokeSecurityGroupIngress(t *testing.T) {
 }
 
 func TestGetSecurityGroup(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsecuritygroupsresponse": {
 	"count": 1,
 	"securitygroup": [
@@ -107,7 +107,7 @@ func TestGetSecurityGroup(t *testing.T) {
 			"tags": []
 		}
 	]
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -124,11 +124,11 @@ func TestGetSecurityGroup(t *testing.T) {
 }
 
 func TestGetSecurityGroupMissing(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsecuritygroupsresponse": {
 	"count": 0,
 	"securitygroup": []
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -141,13 +141,13 @@ func TestGetSecurityGroupMissing(t *testing.T) {
 }
 
 func TestGetSecurityGroupError(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listsecuritygroupsresponse": {
 	"cserrorcode": 9999,
 	"errorcode": 431,
 	"errortext": "Unable to execute API command listsecuritygroups due to invalid value. Invalid parameter id value=4bfe1073-a6d4-48bd-8f24-2ab5866740 due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.",
 	"uuidList": []
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -1,6 +1,7 @@
 package egoscale
 
 import (
+	"net/url"
 	"testing"
 )
 
@@ -78,6 +79,24 @@ func TestRevokeSecurityGroupIngress(t *testing.T) {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
+}
+
+func TestAuthorizeSecurityGroupEgressOnBeforeSend(t *testing.T) {
+	req := &AuthorizeSecurityGroupEgress{
+		Protocol: "ICMP",
+	}
+	params := url.Values{}
+
+	if err := req.onBeforeSend(&params); err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := params["icmpcode"]; !ok {
+		t.Errorf("icmpcode should have been set")
+	}
+	if _, ok := params["icmptype"]; !ok {
+		t.Errorf("icmptype should have been set")
+	}
 }
 
 func TestGetSecurityGroup(t *testing.T) {

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -216,7 +216,7 @@ func TestDeployOnBeforeSendBothAG(t *testing.T) {
 }
 
 func TestGetVirtualMachine(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listvirtualmachinesresponse": {
 	"count": 1,
 	"virtualmachine": [
@@ -285,8 +285,7 @@ func TestGetVirtualMachine(t *testing.T) {
 			"zonename": "ch-dk-2"
 		}
 	]
-}}`)
-
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -303,11 +302,11 @@ func TestGetVirtualMachine(t *testing.T) {
 }
 
 func TestGetVirtualMachineNotFound(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listvirtualmachinesresponse": {
 	"count": 0,
 	"virtualmachine": []
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -320,11 +319,11 @@ func TestGetVirtualMachineNotFound(t *testing.T) {
 }
 
 func TestGetVirtualMachineBadQuery(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"listvirtualmachinesresponse": {
 	"count": 0,
 	"virtualmachine": []
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -335,7 +334,7 @@ func TestGetVirtualMachineBadQuery(t *testing.T) {
 }
 
 func TestDelVirtualMachine(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"destroyvirtualmachineresponse": {
 	"jobid": "1",
 	"jobresult": {
@@ -343,7 +342,7 @@ func TestDelVirtualMachine(t *testing.T) {
 		"displaytext": "good job!"
 	},
 	"jobstatus": 1
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -356,12 +355,12 @@ func TestDelVirtualMachine(t *testing.T) {
 }
 
 func TestGetVirtualMachinePassword(t *testing.T) {
-	ts := newServer(200, `
+	ts := newServer(response{200, `
 {"getvmresponse": {
 	"password": {
 		"encryptedpassword": "test"
 	}
-}}`)
+}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -32,3 +32,80 @@ func TestResizeVolume(t *testing.T) {
 	}
 	_ = req.asyncResponse().(*ResizeVolumeResponse)
 }
+
+func TestListVolume(t *testing.T) {
+	ts := newServer(response{200, `
+{"listvolumesresponse": {
+	"count": 1,
+	"volume": [
+		{
+			"account": "test",
+			"created": "2018-03-23T00:41:14+0100",
+			"destroyed": false,
+			"deviceid": 0,
+			"domain": "test",
+			"domainid": "2083e04d-500f-48ef-8e3d-bae6805416cd",
+			"id": "3613a751-5822-4d1d-b312-3036ef1acf86",
+			"isextractable": true,
+			"name": "ROOT-246634",
+			"quiescevm": false,
+			"serviceofferingdisplaytext": "Medium 4096mb 2cpu",
+			"serviceofferingid": "5e5fb3c6-e076-429d-9b6c-b71f7b26760b",
+			"serviceofferingname": "Medium",
+			"size": 10737418240,
+			"state": "Ready",
+			"storagetype": "local",
+			"tags": [],
+			"templatedisplaytext": "Linux Ubuntu 16.04 LTS 64-bit 10G Disk (2018-03-02-5858e9)",
+			"templateid": "4a0c4d65-8d88-40a5-b1be-549b211620b6",
+			"templatename": "Linux Ubuntu 16.04 LTS 64-bit",
+			"type": "ROOT",
+			"virtualmachineid": "9ccc3d5b-9dce-4302-a955-24b80b402f88",
+			"vmdisplayname": "test",
+			"vmname": "test",
+			"vmstate": "Running",
+			"zoneid": "1747ef5e-5451-41fd-9f1a-58913bae9702",
+			"zonename": "ch-gva-2"
+		}
+	]
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	volume := &Volume{
+		VirtualMachineID: "9ccc3d5b-9dce-4302-a955-24b80b402f88",
+		Type:             "ROOT",
+	}
+	volumes, err := cs.List(volume)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(volumes) != 1 {
+		t.Errorf("One volume was expected, got %d", len(volumes))
+	}
+
+	if volumes[0].(Volume).Type != "ROOT" {
+		t.Errorf("Volume should be root")
+	}
+}
+
+func TestListVolumeError(t *testing.T) {
+	ts := newServer(response{431, `
+{"listvolumeresponse": {
+	"cserrorcode": 9999,
+	"errorcode": 431,
+	"errortext": "Unable to execute API command listvolumes due to invalid value. Invalid parameter virtualmachineid value=9ccc3d5b-9dce-4302-a955-24b80b402f87 due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.",
+	"uuidList": []
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	volume := new(Volume)
+	_, err := cs.List(volume)
+	if err == nil {
+		t.Error("An error was expected")
+	}
+}

--- a/zones_test.go
+++ b/zones_test.go
@@ -2,6 +2,7 @@ package egoscale
 
 import (
 	"testing"
+	"time"
 )
 
 func TestZones(t *testing.T) {
@@ -14,4 +15,212 @@ func TestListZones(t *testing.T) {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListZonesResponse)
+}
+
+func TestListZone(t *testing.T) {
+	ts := newServer(response{200, `
+{"listzonesresponse": {
+	"count": 4,
+	"zone": [
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "1747ef5e-5451-41fd-9f1a-58913bae9702",
+			"localstorageenabled": true,
+			"name": "ch-gva-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "f9a2983b-42e5-3b12-ae74-0b1f54cd6204"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "381d0a95-ed4a-4ad9-b41c-b97073c1a433",
+			"localstorageenabled": true,
+			"name": "ch-dk-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "23a24359-121a-38af-a938-e225c97c397b"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "b0fcd72f-47ad-4779-a64f-fe4de007ec72",
+			"localstorageenabled": true,
+			"name": "at-vie-1",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "a2a8345d-7daa-3316-8d90-5b8e49706764"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "de88c980-78f6-467c-a431-71bcc88e437f",
+			"localstorageenabled": true,
+			"name": "de-fra-1",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "c4bdb9f2-c28d-36a3-bbc5-f91fc69527e6"
+		}
+	]
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	zone := new(Zone)
+	zones, err := cs.List(zone)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) != 4 {
+		t.Errorf("Four zones were expected, got %d", len(zones))
+	}
+
+	if zones[2].(Zone).Name != "at-vie-1" {
+		t.Errorf("Expected VIE1 to be third, got %#v", zones[2])
+	}
+}
+
+func TestListZoneTwoPages(t *testing.T) {
+	ts := newServer(response{200, `
+{"listzonesresponse": {
+	"count": 4,
+	"zone": [
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "1747ef5e-5451-41fd-9f1a-58913bae9702",
+			"localstorageenabled": true,
+			"name": "ch-gva-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "f9a2983b-42e5-3b12-ae74-0b1f54cd6204"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "381d0a95-ed4a-4ad9-b41c-b97073c1a433",
+			"localstorageenabled": true,
+			"name": "ch-dk-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "23a24359-121a-38af-a938-e225c97c397b"
+		}
+	]
+}}`}, response{200, `
+{"listzonesresponse": {
+	"count": 4,
+	"zone": [
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "b0fcd72f-47ad-4779-a64f-fe4de007ec72",
+			"localstorageenabled": true,
+			"name": "at-vie-1",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "a2a8345d-7daa-3316-8d90-5b8e49706764"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "de88c980-78f6-467c-a431-71bcc88e437f",
+			"localstorageenabled": true,
+			"name": "de-fra-1",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "c4bdb9f2-c28d-36a3-bbc5-f91fc69527e6"
+		}
+	]
+}}`}, response{200, `
+{"listzonesresponse": {
+	"count": 4
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs.PageSize = 2
+
+	zone := new(Zone)
+	zones, err := cs.List(zone)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) != 4 {
+		t.Errorf("Four zones were expected, got %d", len(zones))
+	}
+}
+
+func TestListZoneError(t *testing.T) {
+	ts := newServer(response{200, `
+{"listzonesresponse": {
+	"count": 4,
+	"zone": [
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "1747ef5e-5451-41fd-9f1a-58913bae9702",
+			"localstorageenabled": true,
+			"name": "ch-gva-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "f9a2983b-42e5-3b12-ae74-0b1f54cd6204"
+		},
+		{
+			"allocationstate": "Enabled",
+			"dhcpprovider": "VirtualRouter",
+			"id": "381d0a95-ed4a-4ad9-b41c-b97073c1a433",
+			"localstorageenabled": true,
+			"name": "ch-dk-2",
+			"networktype": "Basic",
+			"securitygroupsenabled": true,
+			"tags": [],
+			"zonetoken": "23a24359-121a-38af-a938-e225c97c397b"
+		}
+	]
+}}`}, response{400, `
+{"listzonesresponse": {
+	"cserrorcode": 9999,
+	"errorcode": 431,
+	"errortext": "Unable to execute API command listzones",
+	"uuidList": []
+}}`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs.PageSize = 2
+
+	zone := new(Zone)
+	_, err := cs.List(zone)
+	if err == nil {
+		t.Error("An error was expected")
+	}
+}
+
+func TestListZoneTimeout(t *testing.T) {
+	ts := newSleepyServer(time.Second, 200, `
+{"listzonesresponse": {
+	"count": 4
+}}`)
+	defer ts.Close()
+
+	cs := NewClientWithTimeout(ts.URL, "KEY", "SECRET", time.Millisecond)
+
+	zone := new(Zone)
+	_, err := cs.List(zone)
+	if err == nil {
+		t.Errorf("An error was expected")
+	}
 }


### PR DESCRIPTION
In a nutshell

```go
vm := &egoscale.VirtualMachine{ZoneID: ...}
vms, err := client.List(vm)
if err != nil {
    panic(err)
}
for _, i := range vms {
    vm := i.(egoscale.VirtualMachine)
    ...
}
```

other calls:
- `ListWithContext(ctx, vm) ([]interface{}, error)`
- `AsyncList(vm) (<-chan interface{}, <-chan error)`
- `AsyncListWithContext(ctx, vm) (<-chan interface{}, <-chan error)`

**TODO**:

- [x] replace `ListNics`
- [x] replace `GetRootVolumeForVirtualMachine`