### PR TITLE
client: refactor List inner logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.9.18
+------
+
+- feat: `VirtualMachine` is `Listable`
+- feat: new `Client.Paginate` and `Client.PaginateWithContext`
+- change: the inner logic of `Listable`
+- remove: not working `Client.AsyncList`
+
 0.9.17
 ------
 

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -9,8 +9,8 @@ type AsyncJobResult struct {
 	AccountID       string           `json:"accountid"`
 	Cmd             string           `json:"cmd"`
 	Created         string           `json:"created"`
-	JobInstanceID   string           `json:"jobinstanceid"`
-	JobInstanceType string           `json:"jobinstancetype"`
+	JobInstanceID   string           `json:"jobinstanceid,omitempty"`
+	JobInstanceType string           `json:"jobinstancetype,omitempty"`
 	JobProcStatus   int              `json:"jobprocstatus"`
 	JobResult       *json.RawMessage `json:"jobresult"`
 	JobResultCode   int              `json:"jobresultcode"`

--- a/client.go
+++ b/client.go
@@ -63,6 +63,35 @@ func (client *Client) ListWithContext(ctx context.Context, g Listable) ([]interf
 }
 
 // AsyncListWithContext lists the given resources (and paginate till the end)
+//
+//
+//	// NB: goroutine may leak if not read until the end. Create a proper context!
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//
+//	outChan, errChan := client.AsyncListWithContext(ctx, new(egoscale.VirtualMachine))
+//
+//	for {
+//		select {
+//		case i, ok := <- outChan:
+//			if ok {
+//				vm := i.(egoscale.VirtualMachine)
+//				// ...
+//			} else {
+//				outChan = nil
+//			}
+//		case err, ok := <- errChan:
+//			if ok {
+//				// do something
+//			}
+//			// Once an error has been received, you can expect the channels to be closed.
+//			errChan = nil
+//		}
+//		if errChan == nil && outChan == nil {
+//			break
+//		}
+//	}
+//
 func (client *Client) AsyncListWithContext(ctx context.Context, g Listable) (<-chan interface{}, <-chan error) {
 	outChan := make(chan interface{}, client.PageSize)
 	errChan := make(chan error)
@@ -141,7 +170,7 @@ func (client *Client) PaginateWithContext(ctx context.Context, req ListCommand, 
 
 // NewClientWithTimeout creates a CloudStack API client
 //
-// Timeout is set to booth the HTTP client and the client itself.
+// Timeout is set to both the HTTP client and the client itself.
 func NewClientWithTimeout(endpoint, apiKey, apiSecret string, timeout time.Duration) *Client {
 	client := &http.Client{
 		Timeout: timeout,

--- a/client_type.go
+++ b/client_type.go
@@ -20,8 +20,8 @@ type Deletable interface {
 
 // Listable represents an Interface that can be "List" by the client
 type Listable interface {
-	// List search the given resources and paginates till the end of time
-	List(context context.Context, client *Client) (<-chan interface{}, <-chan error)
+	// ListRequest builds the list command
+	ListRequest() (ListCommand, error)
 }
 
 // Client represents the CloudStack API client

--- a/client_type.go
+++ b/client_type.go
@@ -40,3 +40,6 @@ type Client struct {
 
 // RetryStrategyFunc represents a how much time to wait between two calls to CloudStack
 type RetryStrategyFunc func(int64) time.Duration
+
+// IterateItemFunc represents the callback to iterate a list of results, if false stops
+type IterateItemFunc func(interface{}, error) bool

--- a/nics.go
+++ b/nics.go
@@ -77,10 +77,12 @@ func (ls *ListNics) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-func (*ListNics) each(resp interface{}, callback ListCommandFunc) {
+func (*ListNics) each(resp interface{}, callback IterateItemFunc) {
 	nics := resp.(*ListNicsResponse)
 	for _, nic := range nics.Nic {
-		callback(nic, nil)
+		if !callback(nic, nil) {
+			break
+		}
 	}
 }
 

--- a/nics.go
+++ b/nics.go
@@ -1,6 +1,7 @@
 package egoscale
 
 import (
+	"fmt"
 	"net"
 )
 
@@ -27,6 +28,10 @@ type Nic struct {
 
 // ListRequest build a ListNics request from the given Nic
 func (nic *Nic) ListRequest() (ListCommand, error) {
+	if nic.VirtualMachineID == "" {
+		return nil, fmt.Errorf("ListNics command requires the VirtualMachineID field to be set")
+	}
+
 	req := &ListNics{
 		VirtualMachineID: nic.VirtualMachineID,
 		NicID:            nic.ID,
@@ -40,8 +45,8 @@ func (nic *Nic) ListRequest() (ListCommand, error) {
 type NicSecondaryIP struct {
 	ID               string `json:"id"`
 	IPAddress        net.IP `json:"ipaddress"`
-	NetworkID        string `json:"networkid"`
-	NicID            string `json:"nicid"`
+	NetworkID        string `json:"networkid,omitempty"`
+	NicID            string `json:"nicid,omitempty"`
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 

--- a/nics_test.go
+++ b/nics_test.go
@@ -20,7 +20,7 @@ func TestRemoveIPFromNic(t *testing.T) {
 	_ = req.asyncResponse().(*booleanAsyncResponse)
 }
 
-func TestListNics(t *testing.T) {
+func TestListNicsAPIName(t *testing.T) {
 	req := &ListNics{}
 	if req.APIName() != "listNics" {
 		t.Errorf("API call doesn't match")
@@ -36,7 +36,7 @@ func TestActivateIP6(t *testing.T) {
 	_ = req.asyncResponse().(*ActivateIP6Response)
 }
 
-func TestListNic(t *testing.T) {
+func TestListNics(t *testing.T) {
 	ts := newServer(response{200, `
 {"listnicsresponse": {
 	"count": 1,
@@ -74,6 +74,20 @@ func TestListNic(t *testing.T) {
 	}
 }
 
+func TestListNicInvalid(t *testing.T) {
+	ts := newServer()
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	nic := new(Nic)
+
+	_, err := cs.List(nic)
+	if err == nil {
+		t.Error("An error was expected")
+	}
+}
+
 func TestListNicError(t *testing.T) {
 	ts := newServer(response{431, `
 {"listnicresponse": {
@@ -86,7 +100,10 @@ func TestListNicError(t *testing.T) {
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
 
-	nic := new(Nic)
+	nic := &Nic{
+		VirtualMachineID: "1",
+	}
+
 	_, err := cs.List(nic)
 	if err == nil {
 		t.Error("An error was expected")

--- a/nics_test.go
+++ b/nics_test.go
@@ -4,13 +4,6 @@ import (
 	"testing"
 )
 
-func TestNics(t *testing.T) {
-	var _ asyncCommand = (*AddIPToNic)(nil)
-	var _ asyncCommand = (*RemoveIPFromNic)(nil)
-	var _ syncCommand = (*ListNics)(nil)
-	var _ asyncCommand = (*ActivateIP6)(nil)
-}
-
 func TestAddIPToNic(t *testing.T) {
 	req := &AddIPToNic{}
 	if req.APIName() != "addIpToNic" {

--- a/request.go
+++ b/request.go
@@ -93,12 +93,16 @@ func (exo *Client) asyncRequest(ctx context.Context, request asyncCommand) (inte
 		time.Sleep(exo.RetryStrategy(int64(iteration)))
 
 		req := &QueryAsyncJobResult{JobID: jobResult.JobID}
-		resp, err := exo.Request(req)
+		resp, err := exo.syncRequest(ctx, req)
 		if err != nil {
 			return nil, err
 		}
 
-		result := resp.(*QueryAsyncJobResultResponse)
+		result, ok := resp.(*QueryAsyncJobResultResponse)
+		if !ok {
+			return nil, resp.(*ErrorResponse)
+		}
+
 		if result.JobStatus == Success {
 			response := request.asyncResponse()
 			if err := json.Unmarshal(*(result.JobResult), response); err != nil {

--- a/request.go
+++ b/request.go
@@ -17,120 +17,9 @@ import (
 	"time"
 )
 
-// Command represents a CloudStack request
-type Command interface {
-	// CloudStack API command name
-	APIName() string
-}
-
-// SyncCommand represents a CloudStack synchronous request
-type syncCommand interface {
-	Command
-	// Response interface to Unmarshal the JSON into
-	response() interface{}
-}
-
-// asyncCommand represents a async CloudStack request
-type asyncCommand interface {
-	Command
-	// Response interface to Unmarshal the JSON into
-	asyncResponse() interface{}
-}
-
-// onBeforeHook represents an action to be done on the params before sending them
-//
-// This little took helps with issue of relying on JSON serialization logic only.
-// `omitempty` may make sense in some cases but not all the time.
-type onBeforeHook interface {
-	onBeforeSend(params *url.Values) error
-}
-
-const (
-	// Pending represents a job in progress
-	Pending JobStatusType = iota
-	// Success represents a successfully completed job
-	Success
-	// Failure represents a job that has failed to complete
-	Failure
-)
-
-// JobStatusType represents the status of a Job
-type JobStatusType int
-
-const (
-	// Unauthorized represents ... (TODO)
-	Unauthorized ErrorCode = 401
-	// MethodNotAllowed represents ... (TODO)
-	MethodNotAllowed = 405
-	// UnsupportedActionError represents ... (TODO)
-	UnsupportedActionError = 422
-	// APILimitExceeded represents ... (TODO)
-	APILimitExceeded = 429
-	// MalformedParameterError represents ... (TODO)
-	MalformedParameterError = 430
-	// ParamError represents ... (TODO)
-	ParamError = 431
-
-	// InternalError represents a server error
-	InternalError = 530
-	// AccountError represents ... (TODO)
-	AccountError = 531
-	// AccountResourceLimitError represents ... (TODO)
-	AccountResourceLimitError = 532
-	// InsufficientCapacityError represents ... (TODO)
-	InsufficientCapacityError = 533
-	// ResourceUnavailableError represents ... (TODO)
-	ResourceUnavailableError = 534
-	// ResourceAllocationError represents ... (TODO)
-	ResourceAllocationError = 535
-	// ResourceInUseError represents ... (TODO)
-	ResourceInUseError = 536
-	// NetworkRuleConflictError represents ... (TODO)
-	NetworkRuleConflictError = 537
-)
-
-// ErrorCode represents the CloudStack ApiErrorCode enum
-//
-// See: https://github.com/apache/cloudstack/blob/master/api/src/org/apache/cloudstack/api/ApiErrorCode.java
-type ErrorCode int
-
-// JobResultResponse represents a generic response to a job task
-type JobResultResponse struct {
-	AccountID     string           `json:"accountid,omitempty"`
-	Cmd           string           `json:"cmd"`
-	Created       string           `json:"created"`
-	JobID         string           `json:"jobid"`
-	JobProcStatus int              `json:"jobprocstatus"`
-	JobResult     *json.RawMessage `json:"jobresult"`
-	JobStatus     JobStatusType    `json:"jobstatus"`
-	JobResultType string           `json:"jobresulttype"`
-	UserID        string           `json:"userid,omitempty"`
-}
-
-// ErrorResponse represents the standard error response from CloudStack
-type ErrorResponse struct {
-	ErrorCode   ErrorCode  `json:"errorcode"`
-	CsErrorCode int        `json:"cserrorcode"`
-	ErrorText   string     `json:"errortext"`
-	UUIDList    []UUIDItem `json:"uuidList,omitempty"` // uuid*L*ist is not a typo
-}
-
-// UUIDItem represents an item of the UUIDList part of an ErrorResponse
-type UUIDItem struct {
-	Description      string `json:"description,omitempty"`
-	SerialVersionUID int64  `json:"serialVersionUID,omitempty"`
-	UUID             string `json:"uuid"`
-}
-
 // Error formats a CloudStack error into a standard error
 func (e *ErrorResponse) Error() string {
 	return fmt.Sprintf("API error %d (internal code: %d): %s", e.ErrorCode, e.CsErrorCode, e.ErrorText)
-}
-
-// booleanAsyncResponse represents a boolean response (usually after a deletion)
-type booleanAsyncResponse struct {
-	Success     bool   `json:"success"`
-	DisplayText string `json:"diplaytext,omitempty"`
 }
 
 // Error formats a CloudStack job response into a standard error
@@ -139,12 +28,6 @@ func (e *booleanAsyncResponse) Error() error {
 		return nil
 	}
 	return fmt.Errorf("API error: %s", e.DisplayText)
-}
-
-// booleanAsyncResponse represents a boolean response for sync calls
-type booleanSyncResponse struct {
-	Success     string `json:"success"`
-	DisplayText string `json:"displaytext,omitempty"`
 }
 
 func (e *booleanSyncResponse) Error() error {

--- a/request_type.go
+++ b/request_type.go
@@ -1,0 +1,137 @@
+package egoscale
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// Command represents a CloudStack request
+type Command interface {
+	// CloudStack API command name
+	APIName() string
+}
+
+// SyncCommand represents a CloudStack synchronous request
+type syncCommand interface {
+	Command
+	// Response interface to Unmarshal the JSON into
+	response() interface{}
+}
+
+// asyncCommand represents a async CloudStack request
+type asyncCommand interface {
+	Command
+	// Response interface to Unmarshal the JSON into
+	asyncResponse() interface{}
+}
+
+// ListCommandFunc represents the callback to iterate a list of results
+type ListCommandFunc func(interface{}, error)
+
+// ListCommand represents a CloudStack list request
+type ListCommand interface {
+	Command
+	// SetPage defines the current pages
+	SetPage(int)
+	// SetPageSize defines the size of the page
+	SetPageSize(int)
+	// each reads the data from the response and feeds channels, and returns true if we are on the last page
+	each(interface{}, ListCommandFunc)
+}
+
+// onBeforeHook represents an action to be done on the params before sending them
+//
+// This little took helps with issue of relying on JSON serialization logic only.
+// `omitempty` may make sense in some cases but not all the time.
+type onBeforeHook interface {
+	onBeforeSend(params *url.Values) error
+}
+
+const (
+	// Pending represents a job in progress
+	Pending JobStatusType = iota
+	// Success represents a successfully completed job
+	Success
+	// Failure represents a job that has failed to complete
+	Failure
+)
+
+// JobStatusType represents the status of a Job
+type JobStatusType int
+
+const (
+	// Unauthorized represents ... (TODO)
+	Unauthorized ErrorCode = 401
+	// MethodNotAllowed represents ... (TODO)
+	MethodNotAllowed = 405
+	// UnsupportedActionError represents ... (TODO)
+	UnsupportedActionError = 422
+	// APILimitExceeded represents ... (TODO)
+	APILimitExceeded = 429
+	// MalformedParameterError represents ... (TODO)
+	MalformedParameterError = 430
+	// ParamError represents ... (TODO)
+	ParamError = 431
+
+	// InternalError represents a server error
+	InternalError = 530
+	// AccountError represents ... (TODO)
+	AccountError = 531
+	// AccountResourceLimitError represents ... (TODO)
+	AccountResourceLimitError = 532
+	// InsufficientCapacityError represents ... (TODO)
+	InsufficientCapacityError = 533
+	// ResourceUnavailableError represents ... (TODO)
+	ResourceUnavailableError = 534
+	// ResourceAllocationError represents ... (TODO)
+	ResourceAllocationError = 535
+	// ResourceInUseError represents ... (TODO)
+	ResourceInUseError = 536
+	// NetworkRuleConflictError represents ... (TODO)
+	NetworkRuleConflictError = 537
+)
+
+// ErrorCode represents the CloudStack ApiErrorCode enum
+//
+// See: https://github.com/apache/cloudstack/blob/master/api/src/org/apache/cloudstack/api/ApiErrorCode.java
+type ErrorCode int
+
+// JobResultResponse represents a generic response to a job task
+type JobResultResponse struct {
+	AccountID     string           `json:"accountid,omitempty"`
+	Cmd           string           `json:"cmd"`
+	Created       string           `json:"created"`
+	JobID         string           `json:"jobid"`
+	JobProcStatus int              `json:"jobprocstatus"`
+	JobResult     *json.RawMessage `json:"jobresult"`
+	JobStatus     JobStatusType    `json:"jobstatus"`
+	JobResultType string           `json:"jobresulttype"`
+	UserID        string           `json:"userid,omitempty"`
+}
+
+// ErrorResponse represents the standard error response from CloudStack
+type ErrorResponse struct {
+	ErrorCode   ErrorCode  `json:"errorcode"`
+	CsErrorCode int        `json:"cserrorcode"`
+	ErrorText   string     `json:"errortext"`
+	UUIDList    []UUIDItem `json:"uuidList,omitempty"` // uuid*L*ist is not a typo
+}
+
+// UUIDItem represents an item of the UUIDList part of an ErrorResponse
+type UUIDItem struct {
+	Description      string `json:"description,omitempty"`
+	SerialVersionUID int64  `json:"serialVersionUID,omitempty"`
+	UUID             string `json:"uuid"`
+}
+
+// booleanAsyncResponse represents a boolean response (usually after a deletion)
+type booleanAsyncResponse struct {
+	Success     bool   `json:"success"`
+	DisplayText string `json:"diplaytext,omitempty"`
+}
+
+// booleanAsyncResponse represents a boolean response for sync calls
+type booleanSyncResponse struct {
+	Success     string `json:"success"`
+	DisplayText string `json:"displaytext,omitempty"`
+}

--- a/request_type.go
+++ b/request_type.go
@@ -25,9 +25,6 @@ type asyncCommand interface {
 	asyncResponse() interface{}
 }
 
-// ListCommandFunc represents the callback to iterate a list of results
-type ListCommandFunc func(interface{}, error)
-
 // ListCommand represents a CloudStack list request
 type ListCommand interface {
 	Command
@@ -36,7 +33,7 @@ type ListCommand interface {
 	// SetPageSize defines the size of the page
 	SetPageSize(int)
 	// each reads the data from the response and feeds channels, and returns true if we are on the last page
-	each(interface{}, ListCommandFunc)
+	each(interface{}, IterateItemFunc)
 }
 
 // onBeforeHook represents an action to be done on the params before sending them

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -9,81 +9,6 @@ import (
 	"github.com/jinzhu/copier"
 )
 
-// VirtualMachine reprents a virtual machine
-type VirtualMachine struct {
-	ID                    string            `json:"id,omitempty"`
-	Account               string            `json:"account,omitempty"`
-	ClusterID             string            `json:"clusterid,omitempty"`
-	ClusterName           string            `json:"clustername,omitempty"`
-	CPUNumber             int64             `json:"cpunumber,omitempty"`
-	CPUSpeed              int64             `json:"cpuspeed,omitempty"`
-	CPUUsed               string            `json:"cpuused,omitempty"`
-	Created               string            `json:"created,omitempty"`
-	Details               map[string]string `json:"details,omitempty"`
-	DiskIoRead            int64             `json:"diskioread,omitempty"`
-	DiskIoWrite           int64             `json:"diskiowrite,omitempty"`
-	DiskKbsRead           int64             `json:"diskkbsread,omitempty"`
-	DiskKbsWrite          int64             `json:"diskkbswrite,omitempty"`
-	DiskOfferingID        string            `json:"diskofferingid,omitempty"`
-	DiskOfferingName      string            `json:"diskofferingname,omitempty"`
-	DisplayName           string            `json:"displayname,omitempty"`
-	DisplayVM             bool              `json:"displayvm,omitempty"`
-	Domain                string            `json:"domain,omitempty"`
-	DomainID              string            `json:"domainid,omitempty"`
-	ForVirtualNetwork     bool              `json:"forvirtualnetwork,omitempty"`
-	Group                 string            `json:"group,omitempty"`
-	GroupID               string            `json:"groupid,omitempty"`
-	GuestOsID             string            `json:"guestosid,omitempty"`
-	HAEnable              bool              `json:"haenable,omitempty"`
-	HostID                string            `json:"hostid,omitempty"`
-	HostName              string            `json:"hostname,omitempty"`
-	Hypervisor            string            `json:"hypervisor,omitempty"`
-	InstanceName          string            `json:"instancename,omitempty"` // root only
-	IsDynamicallyScalable bool              `json:"isdynamicallyscalable,omitempty"`
-	IsoDisplayText        string            `json:"isodisplaytext,omitempty"`
-	IsoID                 string            `json:"isoid,omitempty"`
-	IsoName               string            `json:"isoname,omitempty"`
-	KeyPair               string            `json:"keypair,omitempty"`
-	Memory                int64             `json:"memory,omitempty"`
-	MemoryIntFreeKbs      int64             `json:"memoryintfreekbs,omitempty"`
-	MemoryKbs             int64             `json:"memorykbs,omitempty"`
-	MemoryTargetKbs       int64             `json:"memorytargetkbs,omitempty"`
-	Name                  string            `json:"name,omitempty"`
-	NetworkKbsRead        int64             `json:"networkkbsread,omitempty"`
-	NetworkKbsWrite       int64             `json:"networkkbswrite,omitempty"`
-	OsCategoryID          string            `json:"oscategoryid,omitempty"`
-	OsTypeID              int64             `json:"ostypeid,omitempty"`
-	Password              string            `json:"password,omitempty"`
-	PasswordEnabled       bool              `json:"passwordenabled,omitempty"`
-	PCIDevices            string            `json:"pcidevices,omitempty"` // not in the doc
-	PodID                 string            `json:"podid,omitempty"`
-	PodName               string            `json:"podname,omitempty"`
-	Project               string            `json:"project,omitempty"`
-	ProjectID             string            `json:"projectid,omitempty"`
-	PublicIP              string            `json:"publicip,omitempty"`
-	PublicIPID            string            `json:"publicipid,omitempty"`
-	RootDeviceID          int64             `json:"rootdeviceid,omitempty"`
-	RootDeviceType        string            `json:"rootdevicetype,omitempty"`
-	ServiceOfferingID     string            `json:"serviceofferingid,omitempty"`
-	ServiceOfferingName   string            `json:"serviceofferingname,omitempty"`
-	ServiceState          string            `json:"servicestate,omitempty"`
-	State                 string            `json:"state,omitempty"`
-	TemplateDisplayText   string            `json:"templatedisplaytext,omitempty"`
-	TemplateID            string            `json:"templateid,omitempty"`
-	TemplateName          string            `json:"templatename,omitempty"`
-	UserID                string            `json:"userid,omitempty"`   // not in the doc
-	UserName              string            `json:"username,omitempty"` // not in the doc
-	Vgpu                  string            `json:"vgpu,omitempty"`     // not in the doc
-	ZoneID                string            `json:"zoneid,omitempty"`
-	ZoneName              string            `json:"zonename,omitempty"`
-	AffinityGroup         []AffinityGroup   `json:"affinitygroup,omitempty"`
-	Nic                   []Nic             `json:"nic,omitempty"`
-	SecurityGroup         []SecurityGroup   `json:"securitygroup,omitempty"`
-	Tags                  []ResourceTag     `json:"tags,omitempty"`
-	JobID                 string            `json:"jobid,omitempty"`
-	JobStatus             JobStatusType     `json:"jobstatus,omitempty"`
-}
-
 // ResourceType returns the type of the resource
 func (*VirtualMachine) ResourceType() string {
 	return "UserVM"
@@ -91,21 +16,16 @@ func (*VirtualMachine) ResourceType() string {
 
 // Get fills the VM
 func (vm *VirtualMachine) Get(ctx context.Context, client *Client) error {
-	if vm.ID == "" && vm.Name == "" {
-		return fmt.Errorf("A VirtualMachine may only be searched using ID or Name")
+	if vm.ID == "" && vm.Name == "" && vm.DefaultNic() == nil {
+		return fmt.Errorf("A VirtualMachine may only be searched using ID, Name or IPAddress")
 	}
 
-	resp, err := client.RequestWithContext(ctx, &ListVirtualMachines{
-		ID:   vm.ID,
-		Name: vm.Name,
-	})
-
+	vms, err := client.ListWithContext(ctx, vm)
 	if err != nil {
 		return err
 	}
 
-	vms := resp.(*ListVirtualMachinesResponse)
-	count := len(vms.VirtualMachine)
+	count := len(vms)
 	if count == 0 {
 		return &ErrorResponse{
 			ErrorCode: ParamError,
@@ -115,7 +35,7 @@ func (vm *VirtualMachine) Get(ctx context.Context, client *Client) error {
 		return fmt.Errorf("More than one VirtualMachine was found. Query: id: %s, name: %s", vm.ID, vm.Name)
 	}
 
-	return copier.Copy(vm, vms.VirtualMachine[0])
+	return copier.Copy(vm, vms[0])
 }
 
 // Delete destroys the VM
@@ -127,12 +47,47 @@ func (vm *VirtualMachine) Delete(ctx context.Context, client *Client) error {
 	return err
 }
 
+// ListRequest builds the ListVirtualMachines request
+func (vm *VirtualMachine) ListRequest() (ListCommand, error) {
+	// XXX: AffinityGroupID, SecurityGroupID, Tags
+
+	req := &ListVirtualMachines{
+		Account:    vm.Account,
+		DomainID:   vm.DomainID,
+		GroupID:    vm.GroupID,
+		ID:         vm.ID,
+		Name:       vm.Name,
+		ProjectID:  vm.ProjectID,
+		State:      vm.State,
+		TemplateID: vm.TemplateID,
+		ZoneID:     vm.ZoneID,
+	}
+
+	nic := vm.DefaultNic()
+	if nic != nil {
+		req.IPAddress = nic.IPAddress
+	}
+
+	return req, nil
+}
+
 // DefaultNic returns the default nic
 func (vm *VirtualMachine) DefaultNic() *Nic {
 	for _, nic := range vm.Nic {
 		if nic.IsDefault {
 			return &nic
 		}
+	}
+
+	return nil
+}
+
+// IP returns the default nic IP address
+func (vm *VirtualMachine) IP() *net.IP {
+	nic := vm.DefaultNic()
+	if nic != nil {
+		ip := nic.IPAddress
+		return &ip
 	}
 
 	return nil
@@ -176,63 +131,6 @@ func (vm *VirtualMachine) NicByID(nicID string) *Nic {
 	return nil
 }
 
-// IPToNetwork represents a mapping between ip and networks
-type IPToNetwork struct {
-	IP        string `json:"ip,omitempty"`
-	IPV6      string `json:"ipv6,omitempty"`
-	NetworkID string `json:"networkid,omitempty"`
-}
-
-// Password represents an encrypted password
-//
-// TODO: method to decrypt it, https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=34014652
-type Password struct {
-	EncryptedPassword string `json:"encryptedpassword"`
-}
-
-// VirtualMachineResponse represents a generic Virtual Machine response
-type VirtualMachineResponse struct {
-	VirtualMachine VirtualMachine `json:"virtualmachine"`
-}
-
-// DeployVirtualMachine (Async) represents the machine creation
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/deployVirtualMachine.html
-type DeployVirtualMachine struct {
-	ServiceOfferingID  string            `json:"serviceofferingid"`
-	TemplateID         string            `json:"templateid"`
-	ZoneID             string            `json:"zoneid"`
-	Account            string            `json:"account,omitempty"`
-	AffinityGroupIDs   []string          `json:"affinitygroupids,omitempty"`   // mutually exclusive with AffinityGroupNames
-	AffinityGroupNames []string          `json:"affinitygroupnames,omitempty"` // mutually exclusive with AffinityGroupIDs
-	CustomID           string            `json:"customid,omitempty"`           // root only
-	DeploymentPlanner  string            `json:"deploymentplanner,omitempty"`  // root only
-	Details            map[string]string `json:"details,omitempty"`
-	DiskOfferingID     string            `json:"diskofferingid,omitempty"`
-	DisplayName        string            `json:"displayname,omitempty"`
-	DisplayVM          *bool             `json:"displayvm,omitempty"`
-	DomainID           string            `json:"domainid,omitempty"`
-	Group              string            `json:"group,omitempty"`
-	HostID             string            `json:"hostid,omitempty"`
-	Hypervisor         string            `json:"hypervisor,omitempty"`
-	IP4                *bool             `json:"ip4,omitempty"` // Exoscale specific
-	IP6                *bool             `json:"ip6,omitempty"` // Exoscale specific
-	IPAddress          net.IP            `json:"ipaddress,omitempty"`
-	IP6Address         net.IP            `json:"ip6address,omitempty"`
-	IPToNetworkList    []IPToNetwork     `json:"iptonetworklist,omitempty"`
-	Keyboard           string            `json:"keyboard,omitempty"`
-	KeyPair            string            `json:"keypair,omitempty"`
-	Name               string            `json:"name,omitempty"`
-	NetworkIDs         []string          `json:"networkids,omitempty"` // mutually exclusive with IPToNetworkList
-	ProjectID          string            `json:"projectid,omitempty"`
-	RootDiskSize       int64             `json:"rootdisksize,omitempty"`       // in GiB
-	SecurityGroupIDs   []string          `json:"securitygroupids,omitempty"`   // mutually exclusive with SecurityGroupNames
-	SecurityGroupNames []string          `json:"securitygroupnames,omitempty"` // mutually exclusive with SecurityGroupIDs
-	Size               string            `json:"size,omitempty"`               // mutually exclusive with DiskOfferingID
-	StartVM            *bool             `json:"startvm,omitempty"`
-	UserData           string            `json:"userdata,omitempty"` // the client is responsible to base64/gzip it
-}
-
 // APIName returns the CloudStack API command name
 func (*DeployVirtualMachine) APIName() string {
 	return "deployVirtualMachine"
@@ -256,35 +154,12 @@ func (*DeployVirtualMachine) asyncResponse() interface{} {
 	return new(DeployVirtualMachineResponse)
 }
 
-// DeployVirtualMachineResponse represents a deployed VM instance
-type DeployVirtualMachineResponse VirtualMachineResponse
-
-// StartVirtualMachine (Async) represents the creation of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/startVirtualMachine.html
-type StartVirtualMachine struct {
-	ID                string `json:"id"`
-	DeploymentPlanner string `json:"deploymentplanner,omitempty"` // root only
-	HostID            string `json:"hostid,omitempty"`            // root only
-}
-
 // APIName returns the CloudStack API command name
 func (*StartVirtualMachine) APIName() string {
 	return "startVirtualMachine"
 }
 func (*StartVirtualMachine) asyncResponse() interface{} {
 	return new(StartVirtualMachineResponse)
-}
-
-// StartVirtualMachineResponse represents a started VM instance
-type StartVirtualMachineResponse VirtualMachineResponse
-
-// StopVirtualMachine (Async) represents the stopping of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/stopVirtualMachine.html
-type StopVirtualMachine struct {
-	ID     string `json:"id"`
-	Forced *bool  `json:"forced,omitempty"`
 }
 
 // APIName returns the CloudStack API command name
@@ -294,16 +169,6 @@ func (*StopVirtualMachine) APIName() string {
 
 func (*StopVirtualMachine) asyncResponse() interface{} {
 	return new(StopVirtualMachineResponse)
-}
-
-// StopVirtualMachineResponse represents a stopped VM instance
-type StopVirtualMachineResponse VirtualMachineResponse
-
-// RebootVirtualMachine (Async) represents the rebooting of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/rebootVirtualMachine.html
-type RebootVirtualMachine struct {
-	ID string `json:"id"`
 }
 
 // APIName returns the CloudStack API command name
@@ -318,15 +183,6 @@ func (*RebootVirtualMachine) asyncResponse() interface{} {
 // RebootVirtualMachineResponse represents a rebooted VM instance
 type RebootVirtualMachineResponse VirtualMachineResponse
 
-// RestoreVirtualMachine (Async) represents the restoration of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/restoreVirtualMachine.html
-type RestoreVirtualMachine struct {
-	VirtualMachineID string `json:"virtualmachineid"`
-	TemplateID       string `json:"templateid,omitempty"`
-	RootDiskSize     string `json:"rootdisksize,omitempty"` // in GiB, Exoscale specific
-}
-
 // APIName returns the CloudStack API command name
 func (*RestoreVirtualMachine) APIName() string {
 	return "restoreVirtualMachine"
@@ -334,16 +190,6 @@ func (*RestoreVirtualMachine) APIName() string {
 
 func (*RestoreVirtualMachine) asyncResponse() interface{} {
 	return new(RestoreVirtualMachineResponse)
-}
-
-// RestoreVirtualMachineResponse represents a restored VM instance
-type RestoreVirtualMachineResponse VirtualMachineResponse
-
-// RecoverVirtualMachine represents the restoration of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/recoverVirtualMachine.html
-type RecoverVirtualMachine struct {
-	ID string `json:"virtualmachineid"`
 }
 
 // APIName returns the CloudStack API command name
@@ -355,17 +201,6 @@ func (*RecoverVirtualMachine) response() interface{} {
 	return new(RecoverVirtualMachineResponse)
 }
 
-// RecoverVirtualMachineResponse represents a recovered VM instance
-type RecoverVirtualMachineResponse VirtualMachineResponse
-
-// DestroyVirtualMachine (Async) represents the destruction of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/destroyVirtualMachine.html
-type DestroyVirtualMachine struct {
-	ID      string `json:"id"`
-	Expunge *bool  `json:"expunge,omitempty"`
-}
-
 // APIName returns the CloudStack API command name
 func (*DestroyVirtualMachine) APIName() string {
 	return "destroyVirtualMachine"
@@ -373,27 +208,6 @@ func (*DestroyVirtualMachine) APIName() string {
 
 func (*DestroyVirtualMachine) asyncResponse() interface{} {
 	return new(DestroyVirtualMachineResponse)
-}
-
-// DestroyVirtualMachineResponse represents a destroyed VM instance
-type DestroyVirtualMachineResponse VirtualMachineResponse
-
-// UpdateVirtualMachine represents the update of the virtual machine
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/updateVirtualMachine.html
-type UpdateVirtualMachine struct {
-	ID                    string            `json:"id"`
-	CustomID              string            `json:"customid,omitempty"` // root only
-	Details               map[string]string `json:"details,omitempty"`
-	DisplayName           string            `json:"displayname,omitempty"`
-	DisplayVM             *bool             `json:"displayvm,omitempty"`
-	Group                 string            `json:"group,omitempty"`
-	HAEnable              *bool             `json:"haenable,omitempty"`
-	IsDynamicallyScalable *bool             `json:"isdynamicallyscalable,omitempty"`
-	Name                  string            `json:"name,omitempty"` // must reboot
-	OSTypeID              int64             `json:"ostypeid,omitempty"`
-	SecurityGroupIDs      []string          `json:"securitygroupids,omitempty"`
-	UserData              string            `json:"userdata,omitempty"`
 }
 
 // APIName returns the CloudStack API command name
@@ -422,18 +236,6 @@ func (*ExpungeVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// ScaleVirtualMachine (Async) represents the scaling of a VM
-//
-// ChangeServiceForVirtualMachine does the same thing but returns the
-// new Virtual Machine which is more consistent with the rest of the API.
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/scaleVirtualMachine.html
-type ScaleVirtualMachine struct {
-	ID                string            `json:"id"`
-	ServiceOfferingID string            `json:"serviceofferingid"`
-	Details           map[string]string `json:"details,omitempty"`
-}
-
 // APIName returns the CloudStack API command name
 func (*ScaleVirtualMachine) APIName() string {
 	return "scaleVirtualMachine"
@@ -442,11 +244,6 @@ func (*ScaleVirtualMachine) APIName() string {
 func (*ScaleVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
-
-// ChangeServiceForVirtualMachine represents the scaling of a VM
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/changeServiceForVirtualMachine.html
-type ChangeServiceForVirtualMachine ScaleVirtualMachine
 
 // APIName returns the CloudStack API command name
 func (*ChangeServiceForVirtualMachine) APIName() string {
@@ -457,14 +254,6 @@ func (*ChangeServiceForVirtualMachine) response() interface{} {
 	return new(ChangeServiceForVirtualMachineResponse)
 }
 
-// ChangeServiceForVirtualMachineResponse represents an changed VM instance
-type ChangeServiceForVirtualMachineResponse VirtualMachineResponse
-
-// ResetPasswordForVirtualMachine (Async) represents the scaling of a VM
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resetPasswordForVirtualMachine.html
-type ResetPasswordForVirtualMachine ScaleVirtualMachine
-
 // APIName returns the CloudStack API command name
 func (*ResetPasswordForVirtualMachine) APIName() string {
 	return "resetPasswordForVirtualMachine"
@@ -472,16 +261,6 @@ func (*ResetPasswordForVirtualMachine) APIName() string {
 
 func (*ResetPasswordForVirtualMachine) asyncResponse() interface{} {
 	return new(ResetPasswordForVirtualMachineResponse)
-}
-
-// ResetPasswordForVirtualMachineResponse represents the updated vm
-type ResetPasswordForVirtualMachineResponse VirtualMachineResponse
-
-// GetVMPassword asks for an encrypted password
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/getVMPassword.html
-type GetVMPassword struct {
-	ID string `json:"id"`
 }
 
 // APIName returns the CloudStack API command name
@@ -493,48 +272,6 @@ func (*GetVMPassword) response() interface{} {
 	return new(GetVMPasswordResponse)
 }
 
-// GetVMPasswordResponse represents the encrypted password
-type GetVMPasswordResponse struct {
-	// Base64 encrypted password for the VM
-	Password Password `json:"password"`
-}
-
-// ListVirtualMachines represents a search for a VM
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listVirtualMachine.html
-type ListVirtualMachines struct {
-	Account           string            `json:"account,omitempty"`
-	AffinityGroupID   string            `json:"affinitygroupid,omitempty"`
-	Details           map[string]string `json:"details,omitempty"`
-	DisplayVM         *bool             `json:"displayvm,omitempty"` // root only
-	DomainID          string            `json:"domainid,omitempty"`
-	ForVirtualNetwork *bool             `json:"forvirtualnetwork,omitempty"`
-	GroupID           string            `json:"groupid,omitempty"`
-	HostID            string            `json:"hostid,omitempty"`
-	Hypervisor        string            `json:"hypervisor,omitempty"`
-	ID                string            `json:"id,omitempty"`
-	IDs               []string          `json:"ids,omitempty"` // mutually exclusive with id
-	IsoID             string            `json:"isoid,omitempty"`
-	IsRecursive       *bool             `json:"isrecursive,omitempty"`
-	KeyPair           string            `json:"keypair,omitempty"`
-	Keyword           string            `json:"keyword,omitempty"`
-	ListAll           *bool             `json:"listall,omitempty"`
-	Name              string            `json:"name,omitempty"`
-	NetworkID         string            `json:"networkid,omitempty"`
-	Page              int               `json:"page,omitempty"`
-	PageSize          int               `json:"pagesize,omitempty"`
-	PodID             string            `json:"podid,omitempty"`
-	ProjectID         string            `json:"projectid,omitempty"`
-	ServiceOfferindID string            `json:"serviceofferingid,omitempty"`
-	State             string            `json:"state,omitempty"` // Running, Stopped, Present, ...
-	StorageID         string            `json:"storageid,omitempty"`
-	Tags              []ResourceTag     `json:"tags,omitempty"`
-	TemplateID        string            `json:"templateid,omitempty"`
-	UserID            string            `json:"userid,omitempty"`
-	VpcID             string            `json:"vpcid,omitempty"`
-	ZoneID            string            `json:"zoneid,omitempty"`
-}
-
 // APIName returns the CloudStack API command name
 func (*ListVirtualMachines) APIName() string {
 	return "listVirtualMachines"
@@ -544,19 +281,21 @@ func (*ListVirtualMachines) response() interface{} {
 	return new(ListVirtualMachinesResponse)
 }
 
-// ListVirtualMachinesResponse represents a list of virtual machines
-type ListVirtualMachinesResponse struct {
-	Count          int              `json:"count"`
-	VirtualMachine []VirtualMachine `json:"virtualmachine"`
+// SetPage sets the current page
+func (ls *ListVirtualMachines) SetPage(page int) {
+	ls.Page = page
 }
 
-// AddNicToVirtualMachine (Async) adds a NIC to a VM
-//
-// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/addNicToVirtualMachine.html
-type AddNicToVirtualMachine struct {
-	NetworkID        string `json:"networkid"`
-	VirtualMachineID string `json:"virtualmachineid"`
-	IPAddress        net.IP `json:"ipaddress,omitempty"`
+// SetPageSize sets the page size
+func (ls *ListVirtualMachines) SetPageSize(pageSize int) {
+	ls.PageSize = pageSize
+}
+
+func (*ListVirtualMachines) each(resp interface{}, callback ListCommandFunc) {
+	vms := resp.(*ListVirtualMachinesResponse)
+	for _, vm := range vms.VirtualMachine {
+		callback(vm, nil)
+	}
 }
 
 // APIName returns the CloudStack API command name
@@ -568,17 +307,6 @@ func (*AddNicToVirtualMachine) asyncResponse() interface{} {
 	return new(AddNicToVirtualMachineResponse)
 }
 
-// AddNicToVirtualMachineResponse represents the modified VM
-type AddNicToVirtualMachineResponse VirtualMachineResponse
-
-// RemoveNicFromVirtualMachine (Async) removes a NIC from a VM
-//
-// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/removeNicFromVirtualMachine.html
-type RemoveNicFromVirtualMachine struct {
-	NicID            string `json:"nicid"`
-	VirtualMachineID string `json:"virtualmachineid"`
-}
-
 // APIName returns the CloudStack API command name
 func (*RemoveNicFromVirtualMachine) APIName() string {
 	return "removeNicFromVirtualMachine"
@@ -586,18 +314,6 @@ func (*RemoveNicFromVirtualMachine) APIName() string {
 
 func (*RemoveNicFromVirtualMachine) asyncResponse() interface{} {
 	return new(RemoveNicFromVirtualMachineResponse)
-}
-
-// RemoveNicFromVirtualMachineResponse represents the modified VM
-type RemoveNicFromVirtualMachineResponse VirtualMachineResponse
-
-// UpdateDefaultNicForVirtualMachine (Async) adds a NIC to a VM
-//
-// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateDefaultNicForVirtualMachine.html
-type UpdateDefaultNicForVirtualMachine struct {
-	NetworkID        string `json:"networkid"`
-	VirtualMachineID string `json:"virtualmachineid"`
-	IPAddress        net.IP `json:"ipaddress,omitempty"`
 }
 
 // APIName returns the CloudStack API command name
@@ -608,6 +324,3 @@ func (*UpdateDefaultNicForVirtualMachine) APIName() string {
 func (*UpdateDefaultNicForVirtualMachine) asyncResponse() interface{} {
 	return new(UpdateDefaultNicForVirtualMachineResponse)
 }
-
-// UpdateDefaultNicForVirtualMachineResponse represents the modified VM
-type UpdateDefaultNicForVirtualMachineResponse VirtualMachineResponse

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -291,10 +291,12 @@ func (ls *ListVirtualMachines) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-func (*ListVirtualMachines) each(resp interface{}, callback ListCommandFunc) {
+func (*ListVirtualMachines) each(resp interface{}, callback IterateItemFunc) {
 	vms := resp.(*ListVirtualMachinesResponse)
 	for _, vm := range vms.VirtualMachine {
-		callback(vm, nil)
+		if !callback(vm, nil) {
+			break
+		}
 	}
 }
 

--- a/virtual_machines_type.go
+++ b/virtual_machines_type.go
@@ -1,0 +1,340 @@
+package egoscale
+
+import (
+	"net"
+)
+
+// VirtualMachine reprents a virtual machine
+type VirtualMachine struct {
+	ID                    string            `json:"id,omitempty"`
+	Account               string            `json:"account,omitempty"`
+	ClusterID             string            `json:"clusterid,omitempty"`
+	ClusterName           string            `json:"clustername,omitempty"`
+	CPUNumber             int64             `json:"cpunumber,omitempty"`
+	CPUSpeed              int64             `json:"cpuspeed,omitempty"`
+	CPUUsed               string            `json:"cpuused,omitempty"`
+	Created               string            `json:"created,omitempty"`
+	Details               map[string]string `json:"details,omitempty"`
+	DiskIoRead            int64             `json:"diskioread,omitempty"`
+	DiskIoWrite           int64             `json:"diskiowrite,omitempty"`
+	DiskKbsRead           int64             `json:"diskkbsread,omitempty"`
+	DiskKbsWrite          int64             `json:"diskkbswrite,omitempty"`
+	DiskOfferingID        string            `json:"diskofferingid,omitempty"`
+	DiskOfferingName      string            `json:"diskofferingname,omitempty"`
+	DisplayName           string            `json:"displayname,omitempty"`
+	DisplayVM             bool              `json:"displayvm,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	DomainID              string            `json:"domainid,omitempty"`
+	ForVirtualNetwork     bool              `json:"forvirtualnetwork,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	GroupID               string            `json:"groupid,omitempty"`
+	GuestOsID             string            `json:"guestosid,omitempty"`
+	HAEnable              bool              `json:"haenable,omitempty"`
+	HostID                string            `json:"hostid,omitempty"`
+	HostName              string            `json:"hostname,omitempty"`
+	Hypervisor            string            `json:"hypervisor,omitempty"`
+	InstanceName          string            `json:"instancename,omitempty"` // root only
+	IsDynamicallyScalable bool              `json:"isdynamicallyscalable,omitempty"`
+	IsoDisplayText        string            `json:"isodisplaytext,omitempty"`
+	IsoID                 string            `json:"isoid,omitempty"`
+	IsoName               string            `json:"isoname,omitempty"`
+	KeyPair               string            `json:"keypair,omitempty"`
+	Memory                int64             `json:"memory,omitempty"`
+	MemoryIntFreeKbs      int64             `json:"memoryintfreekbs,omitempty"`
+	MemoryKbs             int64             `json:"memorykbs,omitempty"`
+	MemoryTargetKbs       int64             `json:"memorytargetkbs,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	NetworkKbsRead        int64             `json:"networkkbsread,omitempty"`
+	NetworkKbsWrite       int64             `json:"networkkbswrite,omitempty"`
+	OsCategoryID          string            `json:"oscategoryid,omitempty"`
+	OsTypeID              int64             `json:"ostypeid,omitempty"`
+	Password              string            `json:"password,omitempty"`
+	PasswordEnabled       bool              `json:"passwordenabled,omitempty"`
+	PCIDevices            string            `json:"pcidevices,omitempty"` // not in the doc
+	PodID                 string            `json:"podid,omitempty"`
+	PodName               string            `json:"podname,omitempty"`
+	Project               string            `json:"project,omitempty"`
+	ProjectID             string            `json:"projectid,omitempty"`
+	PublicIP              string            `json:"publicip,omitempty"`
+	PublicIPID            string            `json:"publicipid,omitempty"`
+	RootDeviceID          int64             `json:"rootdeviceid,omitempty"`
+	RootDeviceType        string            `json:"rootdevicetype,omitempty"`
+	ServiceOfferingID     string            `json:"serviceofferingid,omitempty"`
+	ServiceOfferingName   string            `json:"serviceofferingname,omitempty"`
+	ServiceState          string            `json:"servicestate,omitempty"`
+	State                 string            `json:"state,omitempty"`
+	TemplateDisplayText   string            `json:"templatedisplaytext,omitempty"`
+	TemplateID            string            `json:"templateid,omitempty"`
+	TemplateName          string            `json:"templatename,omitempty"`
+	UserID                string            `json:"userid,omitempty"`   // not in the doc
+	UserName              string            `json:"username,omitempty"` // not in the doc
+	Vgpu                  string            `json:"vgpu,omitempty"`     // not in the doc
+	ZoneID                string            `json:"zoneid,omitempty"`
+	ZoneName              string            `json:"zonename,omitempty"`
+	AffinityGroup         []AffinityGroup   `json:"affinitygroup,omitempty"`
+	Nic                   []Nic             `json:"nic,omitempty"`
+	SecurityGroup         []SecurityGroup   `json:"securitygroup,omitempty"`
+	Tags                  []ResourceTag     `json:"tags,omitempty"`
+	JobID                 string            `json:"jobid,omitempty"`
+	JobStatus             JobStatusType     `json:"jobstatus,omitempty"`
+}
+
+// IPToNetwork represents a mapping between ip and networks
+type IPToNetwork struct {
+	IP        string `json:"ip,omitempty"`
+	IPV6      string `json:"ipv6,omitempty"`
+	NetworkID string `json:"networkid,omitempty"`
+}
+
+// Password represents an encrypted password
+//
+// TODO: method to decrypt it, https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=34014652
+type Password struct {
+	EncryptedPassword string `json:"encryptedpassword"`
+}
+
+// VirtualMachineResponse represents a generic Virtual Machine response
+type VirtualMachineResponse struct {
+	VirtualMachine VirtualMachine `json:"virtualmachine"`
+}
+
+// DeployVirtualMachine (Async) represents the machine creation
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/deployVirtualMachine.html
+type DeployVirtualMachine struct {
+	ServiceOfferingID  string            `json:"serviceofferingid"`
+	TemplateID         string            `json:"templateid"`
+	ZoneID             string            `json:"zoneid"`
+	Account            string            `json:"account,omitempty"`
+	AffinityGroupIDs   []string          `json:"affinitygroupids,omitempty"`   // mutually exclusive with AffinityGroupNames
+	AffinityGroupNames []string          `json:"affinitygroupnames,omitempty"` // mutually exclusive with AffinityGroupIDs
+	CustomID           string            `json:"customid,omitempty"`           // root only
+	DeploymentPlanner  string            `json:"deploymentplanner,omitempty"`  // root only
+	Details            map[string]string `json:"details,omitempty"`
+	DiskOfferingID     string            `json:"diskofferingid,omitempty"`
+	DisplayName        string            `json:"displayname,omitempty"`
+	DisplayVM          *bool             `json:"displayvm,omitempty"`
+	DomainID           string            `json:"domainid,omitempty"`
+	Group              string            `json:"group,omitempty"`
+	HostID             string            `json:"hostid,omitempty"`
+	Hypervisor         string            `json:"hypervisor,omitempty"`
+	IP4                *bool             `json:"ip4,omitempty"` // Exoscale specific
+	IP6                *bool             `json:"ip6,omitempty"` // Exoscale specific
+	IPAddress          net.IP            `json:"ipaddress,omitempty"`
+	IP6Address         net.IP            `json:"ip6address,omitempty"`
+	IPToNetworkList    []IPToNetwork     `json:"iptonetworklist,omitempty"`
+	Keyboard           string            `json:"keyboard,omitempty"`
+	KeyPair            string            `json:"keypair,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	NetworkIDs         []string          `json:"networkids,omitempty"` // mutually exclusive with IPToNetworkList
+	ProjectID          string            `json:"projectid,omitempty"`
+	RootDiskSize       int64             `json:"rootdisksize,omitempty"`       // in GiB
+	SecurityGroupIDs   []string          `json:"securitygroupids,omitempty"`   // mutually exclusive with SecurityGroupNames
+	SecurityGroupNames []string          `json:"securitygroupnames,omitempty"` // mutually exclusive with SecurityGroupIDs
+	Size               string            `json:"size,omitempty"`               // mutually exclusive with DiskOfferingID
+	StartVM            *bool             `json:"startvm,omitempty"`
+	UserData           string            `json:"userdata,omitempty"` // the client is responsible to base64/gzip it
+}
+
+// DeployVirtualMachineResponse represents a deployed VM instance
+type DeployVirtualMachineResponse VirtualMachineResponse
+
+// StartVirtualMachine (Async) represents the creation of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/startVirtualMachine.html
+type StartVirtualMachine struct {
+	ID                string `json:"id"`
+	DeploymentPlanner string `json:"deploymentplanner,omitempty"` // root only
+	HostID            string `json:"hostid,omitempty"`            // root only
+}
+
+// StartVirtualMachineResponse represents a started VM instance
+type StartVirtualMachineResponse VirtualMachineResponse
+
+// StopVirtualMachine (Async) represents the stopping of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/stopVirtualMachine.html
+type StopVirtualMachine struct {
+	ID     string `json:"id"`
+	Forced *bool  `json:"forced,omitempty"`
+}
+
+// StopVirtualMachineResponse represents a stopped VM instance
+type StopVirtualMachineResponse VirtualMachineResponse
+
+// RebootVirtualMachine (Async) represents the rebooting of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/rebootVirtualMachine.html
+type RebootVirtualMachine struct {
+	ID string `json:"id"`
+}
+
+// RestoreVirtualMachine (Async) represents the restoration of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/restoreVirtualMachine.html
+type RestoreVirtualMachine struct {
+	VirtualMachineID string `json:"virtualmachineid"`
+	TemplateID       string `json:"templateid,omitempty"`
+	RootDiskSize     string `json:"rootdisksize,omitempty"` // in GiB, Exoscale specific
+}
+
+// RestoreVirtualMachineResponse represents a restored VM instance
+type RestoreVirtualMachineResponse VirtualMachineResponse
+
+// RecoverVirtualMachine represents the restoration of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/recoverVirtualMachine.html
+type RecoverVirtualMachine struct {
+	ID string `json:"virtualmachineid"`
+}
+
+// RecoverVirtualMachineResponse represents a recovered VM instance
+type RecoverVirtualMachineResponse VirtualMachineResponse
+
+// DestroyVirtualMachine (Async) represents the destruction of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/destroyVirtualMachine.html
+type DestroyVirtualMachine struct {
+	ID      string `json:"id"`
+	Expunge *bool  `json:"expunge,omitempty"`
+}
+
+// DestroyVirtualMachineResponse represents a destroyed VM instance
+type DestroyVirtualMachineResponse VirtualMachineResponse
+
+// UpdateVirtualMachine represents the update of the virtual machine
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/updateVirtualMachine.html
+type UpdateVirtualMachine struct {
+	ID                    string            `json:"id"`
+	CustomID              string            `json:"customid,omitempty"` // root only
+	Details               map[string]string `json:"details,omitempty"`
+	DisplayName           string            `json:"displayname,omitempty"`
+	DisplayVM             *bool             `json:"displayvm,omitempty"`
+	Group                 string            `json:"group,omitempty"`
+	HAEnable              *bool             `json:"haenable,omitempty"`
+	IsDynamicallyScalable *bool             `json:"isdynamicallyscalable,omitempty"`
+	Name                  string            `json:"name,omitempty"` // must reboot
+	OSTypeID              int64             `json:"ostypeid,omitempty"`
+	SecurityGroupIDs      []string          `json:"securitygroupids,omitempty"`
+	UserData              string            `json:"userdata,omitempty"`
+}
+
+// ScaleVirtualMachine (Async) represents the scaling of a VM
+//
+// ChangeServiceForVirtualMachine does the same thing but returns the
+// new Virtual Machine which is more consistent with the rest of the API.
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/scaleVirtualMachine.html
+type ScaleVirtualMachine struct {
+	ID                string            `json:"id"`
+	ServiceOfferingID string            `json:"serviceofferingid"`
+	Details           map[string]string `json:"details,omitempty"`
+}
+
+// ChangeServiceForVirtualMachine represents the scaling of a VM
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/changeServiceForVirtualMachine.html
+type ChangeServiceForVirtualMachine ScaleVirtualMachine
+
+// ChangeServiceForVirtualMachineResponse represents an changed VM instance
+type ChangeServiceForVirtualMachineResponse VirtualMachineResponse
+
+// ResetPasswordForVirtualMachine (Async) represents the scaling of a VM
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resetPasswordForVirtualMachine.html
+type ResetPasswordForVirtualMachine ScaleVirtualMachine
+
+// ResetPasswordForVirtualMachineResponse represents the updated vm
+type ResetPasswordForVirtualMachineResponse VirtualMachineResponse
+
+// GetVMPassword asks for an encrypted password
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/getVMPassword.html
+type GetVMPassword struct {
+	ID string `json:"id"`
+}
+
+// GetVMPasswordResponse represents the encrypted password
+type GetVMPasswordResponse struct {
+	// Base64 encrypted password for the VM
+	Password Password `json:"password"`
+}
+
+// ListVirtualMachines represents a search for a VM
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listVirtualMachine.html
+type ListVirtualMachines struct {
+	Account           string        `json:"account,omitempty"`
+	AffinityGroupID   string        `json:"affinitygroupid,omitempty"`
+	Details           []string      `json:"details,omitempty"`   // default to "all"
+	DisplayVM         *bool         `json:"displayvm,omitempty"` // root only
+	DomainID          string        `json:"domainid,omitempty"`
+	ForVirtualNetwork *bool         `json:"forvirtualnetwork,omitempty"`
+	GroupID           string        `json:"groupid,omitempty"`
+	HostID            string        `json:"hostid,omitempty"`
+	Hypervisor        string        `json:"hypervisor,omitempty"`
+	ID                string        `json:"id,omitempty"`
+	IDs               []string      `json:"ids,omitempty"` // mutually exclusive with id
+	IPAddress         net.IP        `json:"ipaddress,omitempty"`
+	IsoID             string        `json:"isoid,omitempty"`
+	IsRecursive       *bool         `json:"isrecursive,omitempty"`
+	KeyPair           string        `json:"keypair,omitempty"` // not implemented at Exoscale
+	Keyword           string        `json:"keyword,omitempty"`
+	ListAll           *bool         `json:"listall,omitempty"`
+	Name              string        `json:"name,omitempty"`
+	NetworkID         string        `json:"networkid,omitempty"`
+	Page              int           `json:"page,omitempty"`
+	PageSize          int           `json:"pagesize,omitempty"`
+	PodID             string        `json:"podid,omitempty"`
+	ProjectID         string        `json:"projectid,omitempty"`
+	ServiceOfferindID string        `json:"serviceofferingid,omitempty"`
+	State             string        `json:"state,omitempty"` // Running, Stopped, Present, ...
+	StorageID         string        `json:"storageid,omitempty"`
+	Tags              []ResourceTag `json:"tags,omitempty"`
+	TemplateID        string        `json:"templateid,omitempty"`
+	UserID            string        `json:"userid,omitempty"`
+	VpcID             string        `json:"vpcid,omitempty"`
+	ZoneID            string        `json:"zoneid,omitempty"`
+}
+
+// ListVirtualMachinesResponse represents a list of virtual machines
+type ListVirtualMachinesResponse struct {
+	Count          int              `json:"count"`
+	VirtualMachine []VirtualMachine `json:"virtualmachine"`
+}
+
+// AddNicToVirtualMachine (Async) adds a NIC to a VM
+//
+// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/addNicToVirtualMachine.html
+type AddNicToVirtualMachine struct {
+	NetworkID        string `json:"networkid"`
+	VirtualMachineID string `json:"virtualmachineid"`
+	IPAddress        net.IP `json:"ipaddress,omitempty"`
+}
+
+// AddNicToVirtualMachineResponse represents the modified VM
+type AddNicToVirtualMachineResponse VirtualMachineResponse
+
+// RemoveNicFromVirtualMachine (Async) removes a NIC from a VM
+//
+// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/removeNicFromVirtualMachine.html
+type RemoveNicFromVirtualMachine struct {
+	NicID            string `json:"nicid"`
+	VirtualMachineID string `json:"virtualmachineid"`
+}
+
+// RemoveNicFromVirtualMachineResponse represents the modified VM
+type RemoveNicFromVirtualMachineResponse VirtualMachineResponse
+
+// UpdateDefaultNicForVirtualMachine (Async) adds a NIC to a VM
+//
+// CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateDefaultNicForVirtualMachine.html
+type UpdateDefaultNicForVirtualMachine struct {
+	NetworkID        string `json:"networkid"`
+	VirtualMachineID string `json:"virtualmachineid"`
+	IPAddress        net.IP `json:"ipaddress,omitempty"`
+}
+
+// UpdateDefaultNicForVirtualMachineResponse represents the modified VM
+type UpdateDefaultNicForVirtualMachineResponse VirtualMachineResponse

--- a/volumes.go
+++ b/volumes.go
@@ -116,10 +116,12 @@ func (ls *ListVolumes) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-func (*ListVolumes) each(resp interface{}, callback ListCommandFunc) {
+func (*ListVolumes) each(resp interface{}, callback IterateItemFunc) {
 	volumes := resp.(*ListVolumesResponse)
 	for _, volume := range volumes.Volume {
-		callback(volume, nil)
+		if !callback(volume, nil) {
+			break
+		}
 	}
 }
 

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -4,12 +4,6 @@ import (
 	"testing"
 )
 
-func TestVolumes(t *testing.T) {
-	var _ Taggable = (*Volume)(nil)
-	var _ syncCommand = (*ListVolumes)(nil)
-	var _ asyncCommand = (*ResizeVolume)(nil)
-}
-
 func TestVolume(t *testing.T) {
 	instance := &Volume{}
 	if instance.ResourceType() != "Volume" {

--- a/zones.go
+++ b/zones.go
@@ -30,9 +30,11 @@ func (ls *ListZones) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-func (*ListZones) each(resp interface{}, callback ListCommandFunc) {
+func (*ListZones) each(resp interface{}, callback IterateItemFunc) {
 	zones := resp.(*ListZonesResponse)
 	for _, zone := range zones.Zone {
-		callback(zone, nil)
+		if !callback(zone, nil) {
+			break
+		}
 	}
 }

--- a/zones.go
+++ b/zones.go
@@ -1,95 +1,14 @@
 package egoscale
 
-import (
-	"context"
-	"net"
-)
+// ListRequest builds the ListZones request
+func (zone *Zone) ListRequest() (ListCommand, error) {
+	req := &ListZones{
+		DomainID: zone.DomainID,
+		ID:       zone.ID,
+		Name:     zone.Name,
+	}
 
-// Zone represents a data center
-type Zone struct {
-	ID                    string            `json:"id"`
-	AllocationState       string            `json:"allocationstate,omitempty"`
-	Capacity              string            `json:"capacity,omitempty"`
-	Description           string            `json:"description,omitempty"`
-	DhcpProvider          string            `json:"dhcpprovider,omitempty"`
-	DisplayText           string            `json:"displaytext,omitempty"`
-	DNS1                  net.IP            `json:"dns1,omitempty"`
-	DNS2                  net.IP            `json:"dns2,omitempty"`
-	Domain                string            `json:"domain,omitempty"`
-	DomainID              string            `json:"domainid,omitempty"`
-	DomainName            string            `json:"domainname,omitempty"`
-	GuestCidrAddress      string            `json:"guestcidraddress,omitempty"`
-	InternalDNS1          net.IP            `json:"internaldns1,omitempty"`
-	InternalDNS2          net.IP            `json:"internaldns2,omitempty"`
-	IP6DNS1               net.IP            `json:"ip6dns1,omitempty"`
-	IP6DNS2               net.IP            `json:"ip6dns2,omitempty"`
-	LocalStorageEnabled   bool              `json:"localstorageenabled,omitempty"`
-	Name                  string            `json:"name,omitempty"`
-	NetworkType           string            `json:"networktype,omitempty"`
-	ResourceDetails       map[string]string `json:"resourcedetails,omitempty"`
-	SecurityGroupsEnabled bool              `json:"securitygroupsenabled,omitempty"`
-	Vlan                  string            `json:"vlan,omitempty"`
-	ZoneToken             string            `json:"zonetoken,omitempty"`
-	Tags                  []ResourceTag     `json:"tags,omitempty"`
-}
-
-// List fetches all the zones
-func (zone *Zone) List(ctx context.Context, client *Client) (<-chan interface{}, <-chan error) {
-	pageSize := client.PageSize
-	outChan := make(chan interface{}, client.PageSize)
-	errChan := make(chan error, 1)
-
-	go func() {
-		defer close(outChan)
-		defer close(errChan)
-
-		page := 1
-
-		req := &ListZones{
-			DomainID: zone.DomainID,
-			ID:       zone.ID,
-			Name:     zone.Name,
-			PageSize: pageSize,
-		}
-
-		for {
-			req.Page = page
-
-			resp, err := client.RequestWithContext(ctx, req)
-			if err != nil {
-				errChan <- err
-				break
-			}
-
-			zones := resp.(*ListZonesResponse)
-			for _, zone := range zones.Zone {
-				outChan <- zone
-			}
-
-			if len(zones.Zone) < pageSize {
-				break
-			}
-
-			page++
-		}
-	}()
-
-	return outChan, errChan
-}
-
-// ListZones represents a query for zones
-//
-// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listZones.html
-type ListZones struct {
-	Available      *bool         `json:"available,omitempty"`
-	DomainID       string        `json:"domainid,omitempty"`
-	ID             string        `json:"id,omitempty"`
-	Keyword        string        `json:"keyword,omitempty"`
-	Name           string        `json:"name,omitempty"`
-	Page           int           `json:"page,omitempty"`
-	PageSize       int           `json:"pagesize,omitempty"`
-	ShowCapacities *bool         `json:"showcapacities,omitempty"`
-	Tags           []ResourceTag `json:"tags,omitempty"`
+	return req, nil
 }
 
 // APIName returns the CloudStack API command name
@@ -101,8 +20,19 @@ func (*ListZones) response() interface{} {
 	return new(ListZonesResponse)
 }
 
-// ListZonesResponse represents a list of zones
-type ListZonesResponse struct {
-	Count int    `json:"count"`
-	Zone  []Zone `json:"zone"`
+// SetPage sets the current page
+func (ls *ListZones) SetPage(page int) {
+	ls.Page = page
+}
+
+// SetPageSize sets the page size
+func (ls *ListZones) SetPageSize(pageSize int) {
+	ls.PageSize = pageSize
+}
+
+func (*ListZones) each(resp interface{}, callback ListCommandFunc) {
+	zones := resp.(*ListZonesResponse)
+	for _, zone := range zones.Zone {
+		callback(zone, nil)
+	}
 }

--- a/zones_test.go
+++ b/zones_test.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-func TestZones(t *testing.T) {
-	var _ Command = (*ListZones)(nil)
-}
-
 func TestListZones(t *testing.T) {
 	req := &ListZones{}
 	if req.APIName() != "listZones" {

--- a/zones_test.go
+++ b/zones_test.go
@@ -209,7 +209,10 @@ func TestListZonesAsyncError(t *testing.T) {
 		ID: "1747ef5e-5451-41fd-9f1a-58913bae9701",
 	}
 
-	outChan, errChan := cs.AsyncListWithContext(context.TODO(), zone)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	outChan, errChan := cs.AsyncListWithContext(ctx, zone)
 
 	var err error
 	for {
@@ -294,7 +297,10 @@ func TestListZonesAsync(t *testing.T) {
 
 	zone := new(Zone)
 
-	outChan, errChan := cs.AsyncListWithContext(context.TODO(), zone)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	outChan, errChan := cs.AsyncListWithContext(ctx, zone)
 
 	counter := 0
 	for {

--- a/zones_type.go
+++ b/zones_type.go
@@ -1,0 +1,54 @@
+package egoscale
+
+import (
+	"net"
+)
+
+// Zone represents a data center
+type Zone struct {
+	ID                    string            `json:"id"`
+	AllocationState       string            `json:"allocationstate,omitempty"`
+	Capacity              string            `json:"capacity,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	DhcpProvider          string            `json:"dhcpprovider,omitempty"`
+	DisplayText           string            `json:"displaytext,omitempty"`
+	DNS1                  net.IP            `json:"dns1,omitempty"`
+	DNS2                  net.IP            `json:"dns2,omitempty"`
+	Domain                string            `json:"domain,omitempty"`
+	DomainID              string            `json:"domainid,omitempty"`
+	DomainName            string            `json:"domainname,omitempty"`
+	GuestCidrAddress      string            `json:"guestcidraddress,omitempty"`
+	InternalDNS1          net.IP            `json:"internaldns1,omitempty"`
+	InternalDNS2          net.IP            `json:"internaldns2,omitempty"`
+	IP6DNS1               net.IP            `json:"ip6dns1,omitempty"`
+	IP6DNS2               net.IP            `json:"ip6dns2,omitempty"`
+	LocalStorageEnabled   bool              `json:"localstorageenabled,omitempty"`
+	Name                  string            `json:"name,omitempty"`
+	NetworkType           string            `json:"networktype,omitempty"`
+	ResourceDetails       map[string]string `json:"resourcedetails,omitempty"`
+	SecurityGroupsEnabled bool              `json:"securitygroupsenabled,omitempty"`
+	Vlan                  string            `json:"vlan,omitempty"`
+	ZoneToken             string            `json:"zonetoken,omitempty"`
+	Tags                  []ResourceTag     `json:"tags,omitempty"`
+}
+
+// ListZones represents a query for zones
+//
+// CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listZones.html
+type ListZones struct {
+	Available      *bool         `json:"available,omitempty"`
+	DomainID       string        `json:"domainid,omitempty"`
+	ID             string        `json:"id,omitempty"`
+	Keyword        string        `json:"keyword,omitempty"`
+	Name           string        `json:"name,omitempty"`
+	Page           int           `json:"page,omitempty"`
+	PageSize       int           `json:"pagesize,omitempty"`
+	ShowCapacities *bool         `json:"showcapacities,omitempty"`
+	Tags           []ResourceTag `json:"tags,omitempty"`
+}
+
+// ListZonesResponse represents a list of zones
+type ListZonesResponse struct {
+	Count int    `json:"count"`
+	Zone  []Zone `json:"zone"`
+}


### PR DESCRIPTION
`Listable.List` contains too much boilerplate, more _interface_ and _closures_ to the rescue.

```go
// current use case
vm := &egoscale.VirtualMachine{ZoneID: 1}
vms, err := client.List(vm)

// before
client.ListWithContext(ctx, vm) -> ([]interface{}, error)
    client.AsyncListWithContext(ctx, vm) -> (<-chan interface{}, <-chan error)
        vm.List(ctx, client) -> (<-chan interface{}, <-chan error)
            client.RequestWithContext(ctx, ListVirtualMachines...) -> (interface{}, error)
            ... (page 2)
            ... etc

// now
client.ListWithContext(ctx, vm)
    req <- vm.ListRequest()
    client.PaginateWithContext(ctx, req) -> ([]interface{}, error)

// new - grab the query, adapt it, run it
req, _ := vm.ListRequest()
req.Details = []string{"stats", "nics"}

client.Paginate(req, func(i interface{}, e error) bool {
    if e != nil {
        // stops the pagination
        return false
    }
    vm := i.(egoscale.VirtualMachine)
    // ...
    return true
})
```

Removed stuff:
- `AsyncList` because it wasn't working as `cancel` was called straight away
- ~~and `AsyncListWithContext` because it's unused~~

New stuff:
- `ListCommand` for all the `ListStuffs` CloudStack contains, with boilerplate `SetPage` and `SetPageSize`
- `Paginate` and `PaginateWithContext` to run your own `ListStuffs` requests, if needed.

It's a first step towards a more fluent API like `vm.DefaultNic().AddIPToNic(net.IP.Parse("..."))`

**TODO**:
- [x] put back `AsyncListWithContext` and test it
- [x] more tests using goroutines... it looks too synchronous to be ok.