### PR TITLE
check struct from listApis.json

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/exoscale/egoscale"
+)
+
+var cmd = flag.String("cmd", "", "CloudStack command name")
+var source = flag.String("apis", "", "listApis response in JSON")
+
+// fieldInfo represents the inner details of a field
+type fieldInfo struct {
+	Var       *types.Var
+	OmitEmpty bool
+	Doc       string
+}
+
+// command represents a struct within the source code
+type command struct {
+	name     string
+	s        *types.Struct
+	position token.Pos
+	fields   map[string]fieldInfo
+	errors   map[string]error
+}
+
+func main() {
+	flag.Parse()
+
+	sourceFile, _ := os.Open(*source)
+	decoder := json.NewDecoder(sourceFile)
+	apis := new(egoscale.ListAPIsResponse)
+	if err := decoder.Decode(&apis); err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	fset := token.NewFileSet()
+	astFiles := make([]*ast.File, 0)
+	files, err := filepath.Glob("*.go")
+	for _, file := range files {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+		astFiles = append(astFiles, f)
+	}
+
+	info := types.Info{
+		Defs: make(map[*ast.Ident]types.Object),
+	}
+
+	conf := types.Config{
+		Importer: importer.For("source", nil),
+	}
+
+	_, err = conf.Check("egoscale", fset, astFiles, &info)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	commands := make(map[string]*command)
+
+	for id, obj := range info.Defs {
+		if obj == nil || !obj.Exported() {
+			continue
+		}
+
+		typ := obj.Type().Underlying()
+
+		switch typ.(type) {
+		case *types.Struct:
+			commands[strings.ToLower(obj.Name())] = &command{
+				name:     obj.Name(),
+				s:        typ.(*types.Struct),
+				position: id.Pos(),
+			}
+		}
+	}
+
+	re := regexp.MustCompile(`\bjson:"(?P<name>[^,"]+)(?P<omit>,omitempty)?"`)
+	reDoc := regexp.MustCompile(`\bdoc:"(?P<doc>[^"]+)"`)
+
+	for _, a := range apis.API {
+		if cmd, ok := commands[strings.ToLower(a.Name)]; !ok {
+			// too much information
+			//fmt.Fprintf(os.Stderr, "Unknown command: %q\n", a.Name)
+		} else {
+			// mapping from name to field
+			cmd.fields = make(map[string]fieldInfo)
+			cmd.errors = make(map[string]error)
+
+			for i := 0; i < cmd.s.NumFields(); i++ {
+				f := cmd.s.Field(i)
+				if !f.IsField() || !f.Exported() {
+					continue
+				}
+
+				tag := cmd.s.Tag(i)
+				match := re.FindStringSubmatch(tag)
+				if len(match) == 0 {
+					cmd.errors[f.Name()] = fmt.Errorf("Field error: no json annotation found")
+					continue
+				}
+				name := match[1]
+				omitempty := len(match) == 3 && match[2] == ",omitempty"
+
+				doc := ""
+				match = reDoc.FindStringSubmatch(tag)
+				if len(match) == 2 {
+					doc = match[1]
+				}
+
+				cmd.fields[name] = fieldInfo{
+					Var:       f,
+					OmitEmpty: omitempty,
+					Doc:       doc,
+				}
+			}
+
+			for _, p := range a.Params {
+				field, ok := cmd.fields[p.Name]
+
+				if !ok {
+					cmd.errors[p.Name] = fmt.Errorf("Field missing")
+					continue
+				}
+				delete(cmd.fields, p.Name)
+
+				typename := field.Var.Type().String()
+				expected := ""
+				switch p.Type {
+				case "integer":
+					if typename != "int" {
+						expected = "int"
+					}
+				case "long":
+					if typename != "int64" {
+						expected = "int64"
+					}
+				case "boolean":
+					if typename != "bool" && typename != "*bool" {
+						expected = "bool"
+					}
+				case "string":
+				case "uuid":
+					if typename != "string" {
+						expected = "string"
+					}
+				case "map":
+					if !strings.HasPrefix(typename, "[]") {
+						expected = "array"
+					}
+				default:
+					cmd.errors[p.Name] = fmt.Errorf("Unknown type %q <=> %q", p.Type, field.Var.Type().String())
+				}
+
+				if expected != "" {
+					cmd.errors[p.Name] = fmt.Errorf("Expected to be a slice[], got %q", typename)
+				}
+
+				if field.Doc != p.Description {
+					cmd.errors["tag:"+p.Name] = fmt.Errorf("missing `doc:%q`", p.Description)
+				}
+			}
+
+			for name := range cmd.fields {
+				cmd.errors[name] = fmt.Errorf("Extra field found")
+			}
+		}
+	}
+
+	for name, c := range commands {
+		pos := fset.Position(c.position)
+		er := len(c.errors)
+
+		if *cmd == "" {
+			if er != 0 {
+				fmt.Printf("%5d %s: %s\n", er, pos, c.name)
+			}
+		} else if strings.ToLower(*cmd) == name {
+			for k, e := range c.errors {
+				fmt.Printf("%s: %s\n", k, e.Error())
+			}
+			fmt.Printf("\n%s: %s has %d error(s)\n", pos, c.name, er)
+			os.Exit(er)
+		}
+	}
+}


### PR DESCRIPTION
Uses the `listApis` JSON output to verify that all the commands are well translated into Go `struct`.

```console
$ go run generate/main.go -apis listApis.json -cmd listZones
zones_type.go:38:6: ListZones
Field missing: expected to find "networktype"
```

There can be many improvements over this idea, although this early stage seems good enough to be used already.

----

> _original idea_

A quick and dirty struct generation... cf. #26 

```console
$ make generate
(cd /home/yoan/exoscale/egoscale/.gopath/src/github.com/exoscale/egoscale && \
	go generate)
listApis.json cmd=listZones
```

```go
// Code Generated by "foo"; DO NOT EDIT.

// ListZones (Async) Lists zones
//
// URL: ...listZones
type ListZones struct {
    // Page - 
    Page integer `json:"page,omitempty" doc:""`

    // Tags - List zones by resource tags (key/value pairs)
    Tags map `json:"tags,omitempty" doc:"List zones by resource tags (key/value pairs)"`

    // Pagesize - 
    Pagesize integer `json:"pagesize,omitempty" doc:""`

    // Showcapacities - flag to display the capacity of the zones
    Showcapacities boolean `json:"showcapacities,omitempty" doc:"flag to display the capacity of the zones"`

    // Keyword - List by keyword
    Keyword string `json:"keyword,omitempty" doc:"List by keyword"`

    // Name - the name of the zone
    Name string `json:"name,omitempty" doc:"the name of the zone"`

    // Domainid - the ID of the domain associated with the zone
    Domainid uuid `json:"domainid,omitempty" doc:"the ID of the domain associated with the zone"`

    // Networktype - the network type of the zone that the virtual machine belongs to
    Networktype string `json:"networktype,omitempty" doc:"the network type of the zone that the virtual machine belongs to"`

    // Available - true if you want to retrieve all available Zones. False if you only want to return the Zones from which you have at least one VM. Default is false.
    Available boolean `json:"available,omitempty" doc:"true if you want to retrieve all available Zones. False if you only want to return the Zones from which you have at least one VM. Default is false."`

    // Id - the ID of the zone
    Id uuid `json:"id,omitempty" doc:"the ID of the zone"`

}
```

**TODO**:
- [ ] check `APIName()` _(if possible)_
- [x] proper types, https://github.com/golang/example/tree/master/gotypes