### PR TITLE
global: promote APIName into the client (nicer godoc)

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -83,8 +83,8 @@ type ListAccounts struct {
 	State             string `json:"state,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListAccounts) APIName() string {
+// name returns the CloudStack API command name
+func (*ListAccounts) name() string {
 	return "listAccounts"
 }
 

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -10,7 +10,7 @@ func TestAccounts(t *testing.T) {
 
 func TestListAccounts(t *testing.T) {
 	req := &ListAccounts{}
-	if req.APIName() != "listAccounts" {
+	if req.name() != "listAccounts" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAccountsResponse)

--- a/addresses.go
+++ b/addresses.go
@@ -61,8 +61,8 @@ func (*IPAddress) ResourceType() string {
 	return "PublicIpAddress"
 }
 
-// APIName returns the CloudStack API command name
-func (*AssociateIPAddress) APIName() string {
+// name returns the CloudStack API command name
+func (*AssociateIPAddress) name() string {
 	return "associateIpAddress"
 }
 
@@ -70,24 +70,24 @@ func (*AssociateIPAddress) asyncResponse() interface{} {
 	return new(AssociateIPAddressResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DisassociateIPAddress) APIName() string {
+// name returns the CloudStack API command name
+func (*DisassociateIPAddress) name() string {
 	return "disassociateIpAddress"
 }
 func (*DisassociateIPAddress) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateIPAddress) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateIPAddress) name() string {
 	return "updateIpAddress"
 }
 func (*UpdateIPAddress) asyncResponse() interface{} {
 	return new(UpdateIPAddressResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListPublicIPAddresses) APIName() string {
+// name returns the CloudStack API command name
+func (*ListPublicIPAddresses) name() string {
 	return "listPublicIpAddresses"
 }
 

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -22,7 +22,7 @@ func TestIPAddress(t *testing.T) {
 
 func TestAssociateIPAddress(t *testing.T) {
 	req := &AssociateIPAddress{}
-	if req.APIName() != "associateIpAddress" {
+	if req.name() != "associateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AssociateIPAddressResponse)
@@ -30,7 +30,7 @@ func TestAssociateIPAddress(t *testing.T) {
 
 func TestDisassociateIPAddress(t *testing.T) {
 	req := &DisassociateIPAddress{}
-	if req.APIName() != "disassociateIpAddress" {
+	if req.name() != "disassociateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -38,7 +38,7 @@ func TestDisassociateIPAddress(t *testing.T) {
 
 func TestListPublicIPAddresses(t *testing.T) {
 	req := &ListPublicIPAddresses{}
-	if req.APIName() != "listPublicIpAddresses" {
+	if req.name() != "listPublicIpAddresses" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListPublicIPAddressesResponse)
@@ -46,7 +46,7 @@ func TestListPublicIPAddresses(t *testing.T) {
 
 func TestUpdateIPAddress(t *testing.T) {
 	req := &UpdateIPAddress{}
-	if req.APIName() != "updateIpAddress" {
+	if req.name() != "updateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateIPAddressResponse)

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -91,8 +91,8 @@ type CreateAffinityGroup struct {
 	DomainID    string `json:"domainid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateAffinityGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateAffinityGroup) name() string {
 	return "createAffinityGroup"
 }
 
@@ -114,8 +114,8 @@ type UpdateVMAffinityGroup struct {
 	AffinityGroupNames []string `json:"affinitygroupnames,omitempty"` // mutually exclusive with ids
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateVMAffinityGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateVMAffinityGroup) name() string {
 	return "updateVMAffinityGroup"
 }
 
@@ -145,8 +145,8 @@ type DeleteAffinityGroup struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteAffinityGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteAffinityGroup) name() string {
 	return "deleteAffinityGroup"
 }
 
@@ -171,8 +171,8 @@ type ListAffinityGroups struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListAffinityGroups) APIName() string {
+// name returns the CloudStack API command name
+func (*ListAffinityGroups) name() string {
 	return "listAffinityGroups"
 }
 
@@ -189,8 +189,8 @@ type ListAffinityGroupTypes struct {
 	PageSize int    `json:"pagesize,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListAffinityGroupTypes) APIName() string {
+// name returns the CloudStack API command name
+func (*ListAffinityGroupTypes) name() string {
 	return "listAffinityGroupTypes"
 }
 

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -15,7 +15,7 @@ func TestAffinityGroups(t *testing.T) {
 
 func TestCreateAffinityGroup(t *testing.T) {
 	req := &CreateAffinityGroup{}
-	if req.APIName() != "createAffinityGroup" {
+	if req.name() != "createAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*CreateAffinityGroupResponse)
@@ -23,7 +23,7 @@ func TestCreateAffinityGroup(t *testing.T) {
 
 func TestDeleteAffinityGroup(t *testing.T) {
 	req := &DeleteAffinityGroup{}
-	if req.APIName() != "deleteAffinityGroup" {
+	if req.name() != "deleteAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -31,7 +31,7 @@ func TestDeleteAffinityGroup(t *testing.T) {
 
 func TestListAffinityGroups(t *testing.T) {
 	req := &ListAffinityGroups{}
-	if req.APIName() != "listAffinityGroups" {
+	if req.name() != "listAffinityGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAffinityGroupsResponse)
@@ -39,7 +39,7 @@ func TestListAffinityGroups(t *testing.T) {
 
 func TestListAffinityGroupTypes(t *testing.T) {
 	req := &ListAffinityGroupTypes{}
-	if req.APIName() != "listAffinityGroupTypes" {
+	if req.name() != "listAffinityGroupTypes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAffinityGroupTypesResponse)
@@ -47,7 +47,7 @@ func TestListAffinityGroupTypes(t *testing.T) {
 
 func TestUpdateVMAffinityGroup(t *testing.T) {
 	req := &UpdateVMAffinityGroup{}
-	if req.APIName() != "updateVMAffinityGroup" {
+	if req.name() != "updateVMAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateVMAffinityGroupResponse)

--- a/apis.go
+++ b/apis.go
@@ -1,7 +1,6 @@
 package egoscale
 
-// APIName returns the CloudStack API command name
-func (*ListAPIs) APIName() string {
+func (*ListAPIs) name() string {
 	return "listApis"
 }
 

--- a/apis_test.go
+++ b/apis_test.go
@@ -10,7 +10,7 @@ func TestApis(t *testing.T) {
 
 func TestListAPIs(t *testing.T) {
 	req := &ListAPIs{}
-	if req.APIName() != "listApis" {
+	if req.name() != "listApis" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAPIsResponse)

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -7,8 +7,8 @@ type QueryAsyncJobResult struct {
 	JobID string `json:"jobid" doc:"the ID of the asychronous job"`
 }
 
-// APIName returns the CloudStack API command name
-func (*QueryAsyncJobResult) APIName() string {
+// name returns the CloudStack API command name
+func (*QueryAsyncJobResult) name() string {
 	return "queryAsyncJobResult"
 }
 
@@ -16,8 +16,8 @@ func (*QueryAsyncJobResult) response() interface{} {
 	return new(QueryAsyncJobResultResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListAsyncJobs) APIName() string {
+// name returns the CloudStack API command name
+func (*ListAsyncJobs) name() string {
 	return "listAsyncJobs"
 }
 

--- a/async_jobs_test.go
+++ b/async_jobs_test.go
@@ -11,7 +11,7 @@ func TestAsyncJobs(t *testing.T) {
 
 func TestQueryAsyncJobResult(t *testing.T) {
 	req := &QueryAsyncJobResult{}
-	if req.APIName() != "queryAsyncJobResult" {
+	if req.name() != "queryAsyncJobResult" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*QueryAsyncJobResultResponse)
@@ -19,7 +19,7 @@ func TestQueryAsyncJobResult(t *testing.T) {
 
 func TestListAsyncJobs(t *testing.T) {
 	req := &ListAsyncJobs{}
-	if req.APIName() != "listAsyncJobs" {
+	if req.name() != "listAsyncJobs" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListAsyncJobsResponse)

--- a/client.go
+++ b/client.go
@@ -168,6 +168,11 @@ func (client *Client) PaginateWithContext(ctx context.Context, req ListCommand, 
 	}
 }
 
+// APIName returns the CloudStack name of the given command
+func (client *Client) APIName(req Command) string {
+	return req.name()
+}
+
 // NewClientWithTimeout creates a CloudStack API client
 //
 // Timeout is set to both the HTTP client and the client itself.

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+func testClientAPIName(t *testing.T) {
+	cs := NewClient("ENDPOINT", "KEY", "SECRET")
+	req := &ListAPIs{}
+	if cs.APIName(req) != req.name() {
+		t.Errorf("APIName is wrong")
+	}
+}
+
 func TestClientSyncDelete(t *testing.T) {
 	resp := response{200, `
 {"deleteresponse": {

--- a/events.go
+++ b/events.go
@@ -43,8 +43,8 @@ type ListEvents struct {
 	Type        string `json:"type,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListEvents) APIName() string {
+// name returns the CloudStack API command name
+func (*ListEvents) name() string {
 	return "listEvents"
 }
 
@@ -63,8 +63,8 @@ type ListEventsResponse struct {
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/listEventTypes.html
 type ListEventTypes struct{}
 
-// APIName returns the CloudStack API command name
-func (*ListEventTypes) APIName() string {
+// name returns the CloudStack API command name
+func (*ListEventTypes) name() string {
 	return "listEventTypes"
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -11,7 +11,7 @@ func TestEvents(t *testing.T) {
 
 func TestListEvents(t *testing.T) {
 	req := &ListEvents{}
-	if req.APIName() != "listEvents" {
+	if req.name() != "listEvents" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListEventsResponse)
@@ -19,7 +19,7 @@ func TestListEvents(t *testing.T) {
 
 func TestListEventTypes(t *testing.T) {
 	req := &ListEventTypes{}
-	if req.APIName() != "listEventTypes" {
+	if req.name() != "listEventTypes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListEventTypesResponse)

--- a/keypairs.go
+++ b/keypairs.go
@@ -54,8 +54,8 @@ func (ssh *SSHKeyPair) ListRequest() (ListCommand, error) {
 	return req, nil
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateSSHKeyPair) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateSSHKeyPair) name() string {
 	return "createSSHKeyPair"
 }
 
@@ -63,8 +63,8 @@ func (*CreateSSHKeyPair) response() interface{} {
 	return new(CreateSSHKeyPairResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteSSHKeyPair) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteSSHKeyPair) name() string {
 	return "deleteSSHKeyPair"
 }
 
@@ -72,8 +72,8 @@ func (*DeleteSSHKeyPair) response() interface{} {
 	return new(booleanSyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RegisterSSHKeyPair) APIName() string {
+// name returns the CloudStack API command name
+func (*RegisterSSHKeyPair) name() string {
 	return "registerSSHKeyPair"
 }
 
@@ -81,8 +81,8 @@ func (*RegisterSSHKeyPair) response() interface{} {
 	return new(RegisterSSHKeyPairResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListSSHKeyPairs) APIName() string {
+// name returns the CloudStack API command name
+func (*ListSSHKeyPairs) name() string {
 	return "listSSHKeyPairs"
 }
 
@@ -114,8 +114,8 @@ func (ls *ListSSHKeyPairs) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-// APIName returns the CloudStack API command name
-func (*ResetSSHKeyForVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*ResetSSHKeyForVirtualMachine) name() string {
 	return "resetSSHKeyForVirtualMachine"
 }
 

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestResetSSHKeyForVirtualMachine(t *testing.T) {
 	req := &ResetSSHKeyForVirtualMachine{}
-	if req.APIName() != "resetSSHKeyForVirtualMachine" {
+	if req.name() != "resetSSHKeyForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResetSSHKeyForVirtualMachineResponse)
@@ -14,7 +14,7 @@ func TestResetSSHKeyForVirtualMachine(t *testing.T) {
 
 func TestRegisterSSHKeyPair(t *testing.T) {
 	req := &RegisterSSHKeyPair{}
-	if req.APIName() != "registerSSHKeyPair" {
+	if req.name() != "registerSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RegisterSSHKeyPairResponse)
@@ -22,7 +22,7 @@ func TestRegisterSSHKeyPair(t *testing.T) {
 
 func TestCreateSSHKeyPair(t *testing.T) {
 	req := &CreateSSHKeyPair{}
-	if req.APIName() != "createSSHKeyPair" {
+	if req.name() != "createSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateSSHKeyPairResponse)
@@ -30,7 +30,7 @@ func TestCreateSSHKeyPair(t *testing.T) {
 
 func TestDeleteSSHKeyPair(t *testing.T) {
 	req := &DeleteSSHKeyPair{}
-	if req.APIName() != "deleteSSHKeyPair" {
+	if req.name() != "deleteSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)
@@ -38,7 +38,7 @@ func TestDeleteSSHKeyPair(t *testing.T) {
 
 func TestListSSHKeyPairsResponse(t *testing.T) {
 	req := &ListSSHKeyPairs{}
-	if req.APIName() != "listSSHKeyPairs" {
+	if req.name() != "listSSHKeyPairs" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSSHKeyPairsResponse)

--- a/limits.go
+++ b/limits.go
@@ -79,8 +79,8 @@ type ListResourceLimits struct {
 	ResourceTypeName ResourceTypeName `json:"resourcetypename,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListResourceLimits) APIName() string {
+// name returns the CloudStack API command name
+func (*ListResourceLimits) name() string {
 	return "listResourceLimits"
 }
 

--- a/limits_test.go
+++ b/limits_test.go
@@ -10,7 +10,7 @@ func TestResourceLimits(t *testing.T) {
 
 func TestListResourceLimits(t *testing.T) {
 	req := &ListResourceLimits{}
-	if req.APIName() != "listResourceLimits" {
+	if req.name() != "listResourceLimits" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListResourceLimitsResponse)

--- a/network_offerings.go
+++ b/network_offerings.go
@@ -53,8 +53,8 @@ type ListNetworkOfferings struct {
 	ZoneID             string        `json:"zoneid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListNetworkOfferings) APIName() string {
+// name returns the CloudStack API command name
+func (*ListNetworkOfferings) name() string {
 	return "listNetworkOfferings"
 }
 

--- a/network_offerings_test.go
+++ b/network_offerings_test.go
@@ -10,7 +10,7 @@ func TestNetworkOfferings(t *testing.T) {
 
 func TestListNetworkOfferings(t *testing.T) {
 	req := &ListNetworkOfferings{}
-	if req.APIName() != "listNetworkOfferings" {
+	if req.name() != "listNetworkOfferings" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNetworkOfferingsResponse)

--- a/networks.go
+++ b/networks.go
@@ -35,8 +35,8 @@ func (*Network) ResourceType() string {
 	return "Network"
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateNetwork) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateNetwork) name() string {
 	return "createNetwork"
 }
 
@@ -55,8 +55,8 @@ func (req *CreateNetwork) onBeforeSend(params *url.Values) error {
 	return nil
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateNetwork) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateNetwork) name() string {
 	return "updateNetwork"
 }
 
@@ -64,8 +64,8 @@ func (*UpdateNetwork) asyncResponse() interface{} {
 	return new(UpdateNetworkResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RestartNetwork) APIName() string {
+// name returns the CloudStack API command name
+func (*RestartNetwork) name() string {
 	return "restartNetwork"
 }
 
@@ -73,8 +73,8 @@ func (*RestartNetwork) asyncResponse() interface{} {
 	return new(RestartNetworkResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteNetwork) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteNetwork) name() string {
 	return "deleteNetwork"
 }
 
@@ -82,8 +82,8 @@ func (*DeleteNetwork) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListNetworks) APIName() string {
+// name returns the CloudStack API command name
+func (*ListNetworks) name() string {
 	return "listNetworks"
 }
 

--- a/networks_test.go
+++ b/networks_test.go
@@ -23,7 +23,7 @@ func TestNetwork(t *testing.T) {
 
 func TestListNetworks(t *testing.T) {
 	req := &ListNetworks{}
-	if req.APIName() != "listNetworks" {
+	if req.name() != "listNetworks" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNetworksResponse)
@@ -31,7 +31,7 @@ func TestListNetworks(t *testing.T) {
 
 func TestCreateNetwork(t *testing.T) {
 	req := &CreateNetwork{}
-	if req.APIName() != "createNetwork" {
+	if req.name() != "createNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateNetworkResponse)
@@ -39,7 +39,7 @@ func TestCreateNetwork(t *testing.T) {
 
 func TestRestartNetwork(t *testing.T) {
 	req := &RestartNetwork{}
-	if req.APIName() != "restartNetwork" {
+	if req.name() != "restartNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RestartNetworkResponse)
@@ -47,7 +47,7 @@ func TestRestartNetwork(t *testing.T) {
 
 func TestUpdateNetwork(t *testing.T) {
 	req := &UpdateNetwork{}
-	if req.APIName() != "updateNetwork" {
+	if req.name() != "updateNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateNetworkResponse)
@@ -55,7 +55,7 @@ func TestUpdateNetwork(t *testing.T) {
 
 func TestDeleteNetwork(t *testing.T) {
 	req := &DeleteNetwork{}
-	if req.APIName() != "deleteNetwork" {
+	if req.name() != "deleteNetwork" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/nics.go
+++ b/nics.go
@@ -19,8 +19,8 @@ func (nic *Nic) ListRequest() (ListCommand, error) {
 	return req, nil
 }
 
-// APIName returns the CloudStack API command name
-func (*ListNics) APIName() string {
+// name returns the CloudStack API command name
+func (*ListNics) name() string {
 	return "listNics"
 }
 
@@ -47,16 +47,16 @@ func (*ListNics) each(resp interface{}, callback IterateItemFunc) {
 	}
 }
 
-// APIName returns the CloudStack API command name: addIpToNic
-func (*AddIPToNic) APIName() string {
+// name returns the CloudStack API command name: addIpToNic
+func (*AddIPToNic) name() string {
 	return "addIpToNic"
 }
 func (*AddIPToNic) asyncResponse() interface{} {
 	return new(AddIPToNicResponse)
 }
 
-// APIName returns the CloudStack API command name: removeIpFromNic
-func (*RemoveIPFromNic) APIName() string {
+// name returns the CloudStack API command name: removeIpFromNic
+func (*RemoveIPFromNic) name() string {
 	return "removeIpFromNic"
 }
 
@@ -64,8 +64,8 @@ func (*RemoveIPFromNic) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name: activateIp6
-func (*ActivateIP6) APIName() string {
+// name returns the CloudStack API command name: activateIp6
+func (*ActivateIP6) name() string {
 	return "activateIp6"
 }
 

--- a/nics_test.go
+++ b/nics_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestAddIPToNic(t *testing.T) {
 	req := &AddIPToNic{}
-	if req.APIName() != "addIpToNic" {
+	if req.name() != "addIpToNic" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AddIPToNicResponse)
@@ -14,7 +14,7 @@ func TestAddIPToNic(t *testing.T) {
 
 func TestRemoveIPFromNic(t *testing.T) {
 	req := &RemoveIPFromNic{}
-	if req.APIName() != "removeIpFromNic" {
+	if req.name() != "removeIpFromNic" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -22,7 +22,7 @@ func TestRemoveIPFromNic(t *testing.T) {
 
 func TestListNicsAPIName(t *testing.T) {
 	req := &ListNics{}
-	if req.APIName() != "listNics" {
+	if req.name() != "listNics" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListNicsResponse)
@@ -30,7 +30,7 @@ func TestListNicsAPIName(t *testing.T) {
 
 func TestActivateIP6(t *testing.T) {
 	req := &ActivateIP6{}
-	if req.APIName() != "activateIp6" {
+	if req.name() != "activateIp6" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ActivateIP6Response)

--- a/request.go
+++ b/request.go
@@ -155,7 +155,7 @@ func (exo *Client) BooleanRequest(req Command) error {
 		return b.Error()
 	}
 
-	panic(fmt.Errorf("The command %s is not a proper boolean response. %#v", req.APIName(), resp))
+	panic(fmt.Errorf("The command %s is not a proper boolean response. %#v", req.name(), resp))
 }
 
 // BooleanRequestWithContext performs the given boolean command
@@ -173,7 +173,7 @@ func (exo *Client) BooleanRequestWithContext(ctx context.Context, req Command) e
 		return b.Error()
 	}
 
-	panic(fmt.Errorf("The command %s is not a proper boolean response. %#v", req.APIName(), resp))
+	panic(fmt.Errorf("The command %s is not a proper boolean response. %#v", req.name(), resp))
 }
 
 // Request performs the given command
@@ -187,7 +187,7 @@ func (exo *Client) Request(request Command) (interface{}, error) {
 	case asyncCommand:
 		return exo.asyncRequest(ctx, request.(asyncCommand))
 	default:
-		panic(fmt.Errorf("The command %s is not a proper Sync or Async command", request.APIName()))
+		panic(fmt.Errorf("The command %s is not a proper Sync or Async command", request.name()))
 	}
 }
 
@@ -199,7 +199,7 @@ func (exo *Client) RequestWithContext(ctx context.Context, request Command) (int
 	case asyncCommand:
 		return exo.asyncRequest(ctx, request.(asyncCommand))
 	default:
-		panic(fmt.Errorf("The command %s is not a proper Sync or Async command", request.APIName()))
+		panic(fmt.Errorf("The command %s is not a proper Sync or Async command", request.name()))
 	}
 }
 
@@ -214,7 +214,7 @@ func (exo *Client) Payload(request Command) (string, error) {
 		hookReq.onBeforeSend(&params)
 	}
 	params.Set("apikey", exo.apiKey)
-	params.Set("command", request.APIName())
+	params.Set("command", request.name())
 	params.Set("response", "json")
 
 	// This code is borrowed from net/url/url.go

--- a/request_type.go
+++ b/request_type.go
@@ -8,7 +8,7 @@ import (
 // Command represents a CloudStack request
 type Command interface {
 	// CloudStack API command name
-	APIName() string
+	name() string
 }
 
 // SyncCommand represents a CloudStack synchronous request

--- a/resource_metadata.go
+++ b/resource_metadata.go
@@ -1,7 +1,6 @@
 package egoscale
 
-// APIName returns the CloudStack API command name
-func (*ListResourceDetails) APIName() string {
+func (*ListResourceDetails) name() string {
 	return "listResourceDetails"
 }
 

--- a/resource_metadata_test.go
+++ b/resource_metadata_test.go
@@ -10,7 +10,7 @@ func TestResourceMetadata(t *testing.T) {
 
 func TestListResourceDetailss(t *testing.T) {
 	req := &ListResourceDetails{}
-	if req.APIName() != "listResourceDetails" {
+	if req.name() != "listResourceDetails" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListResourceDetailsResponse)

--- a/security_groups.go
+++ b/security_groups.go
@@ -98,8 +98,8 @@ func (sg *SecurityGroup) RuleByID(ruleID string) (*IngressRule, *EgressRule) {
 	return nil, nil
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateSecurityGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateSecurityGroup) name() string {
 	return "createSecurityGroup"
 }
 
@@ -107,8 +107,8 @@ func (*CreateSecurityGroup) response() interface{} {
 	return new(CreateSecurityGroupResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteSecurityGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteSecurityGroup) name() string {
 	return "deleteSecurityGroup"
 }
 
@@ -116,8 +116,8 @@ func (*DeleteSecurityGroup) response() interface{} {
 	return new(booleanSyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*AuthorizeSecurityGroupIngress) APIName() string {
+// name returns the CloudStack API command name
+func (*AuthorizeSecurityGroupIngress) name() string {
 	return "authorizeSecurityGroupIngress"
 }
 
@@ -138,8 +138,8 @@ func (req *AuthorizeSecurityGroupIngress) onBeforeSend(params *url.Values) error
 	return nil
 }
 
-// APIName returns the CloudStack API command name
-func (*AuthorizeSecurityGroupEgress) APIName() string {
+// name returns the CloudStack API command name
+func (*AuthorizeSecurityGroupEgress) name() string {
 	return "authorizeSecurityGroupEgress"
 }
 
@@ -151,8 +151,8 @@ func (req *AuthorizeSecurityGroupEgress) onBeforeSend(params *url.Values) error 
 	return (*AuthorizeSecurityGroupIngress)(req).onBeforeSend(params)
 }
 
-// APIName returns the CloudStack API command name
-func (*RevokeSecurityGroupIngress) APIName() string {
+// name returns the CloudStack API command name
+func (*RevokeSecurityGroupIngress) name() string {
 	return "revokeSecurityGroupIngress"
 }
 
@@ -160,8 +160,8 @@ func (*RevokeSecurityGroupIngress) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RevokeSecurityGroupEgress) APIName() string {
+// name returns the CloudStack API command name
+func (*RevokeSecurityGroupEgress) name() string {
 	return "revokeSecurityGroupEgress"
 }
 
@@ -169,8 +169,8 @@ func (*RevokeSecurityGroupEgress) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListSecurityGroups) APIName() string {
+// name returns the CloudStack API command name
+func (*ListSecurityGroups) name() string {
 	return "listSecurityGroups"
 }
 

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -27,7 +27,7 @@ func TestSecurityGroup(t *testing.T) {
 
 func TestAuthorizeSecurityGroupEgress(t *testing.T) {
 	req := &AuthorizeSecurityGroupEgress{}
-	if req.APIName() != "authorizeSecurityGroupEgress" {
+	if req.name() != "authorizeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AuthorizeSecurityGroupEgressResponse)
@@ -35,7 +35,7 @@ func TestAuthorizeSecurityGroupEgress(t *testing.T) {
 
 func TestAuthorizeSecurityGroupIngress(t *testing.T) {
 	req := &AuthorizeSecurityGroupIngress{}
-	if req.APIName() != "authorizeSecurityGroupIngress" {
+	if req.name() != "authorizeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AuthorizeSecurityGroupIngressResponse)
@@ -43,7 +43,7 @@ func TestAuthorizeSecurityGroupIngress(t *testing.T) {
 
 func TestCreateSecurityGroup(t *testing.T) {
 	req := &CreateSecurityGroup{}
-	if req.APIName() != "createSecurityGroup" {
+	if req.name() != "createSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateSecurityGroupResponse)
@@ -51,7 +51,7 @@ func TestCreateSecurityGroup(t *testing.T) {
 
 func TestDeleteSecurityGroup(t *testing.T) {
 	req := &DeleteSecurityGroup{}
-	if req.APIName() != "deleteSecurityGroup" {
+	if req.name() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)
@@ -59,7 +59,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 
 func TestListSecurityGroupsApiName(t *testing.T) {
 	req := &ListSecurityGroups{}
-	if req.APIName() != "listSecurityGroups" {
+	if req.name() != "listSecurityGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSecurityGroupsResponse)
@@ -67,7 +67,7 @@ func TestListSecurityGroupsApiName(t *testing.T) {
 
 func TestRevokeSecurityGroupEgress(t *testing.T) {
 	req := &RevokeSecurityGroupEgress{}
-	if req.APIName() != "revokeSecurityGroupEgress" {
+	if req.name() != "revokeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -75,7 +75,7 @@ func TestRevokeSecurityGroupEgress(t *testing.T) {
 
 func TestRevokeSecurityGroupIngress(t *testing.T) {
 	req := &RevokeSecurityGroupIngress{}
-	if req.APIName() != "revokeSecurityGroupIngress" {
+	if req.name() != "revokeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/service_offerings.go
+++ b/service_offerings.go
@@ -54,8 +54,8 @@ type ListServiceOfferings struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListServiceOfferings) APIName() string {
+// name returns the CloudStack API command name
+func (*ListServiceOfferings) name() string {
 	return "listServiceOfferings"
 }
 

--- a/service_offerings_test.go
+++ b/service_offerings_test.go
@@ -10,7 +10,7 @@ func TestServiceOfferings(t *testing.T) {
 
 func TestListServiceOfferings(t *testing.T) {
 	req := &ListServiceOfferings{}
-	if req.APIName() != "listServiceOfferings" {
+	if req.name() != "listServiceOfferings" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListServiceOfferingsResponse)

--- a/snapshots.go
+++ b/snapshots.go
@@ -5,8 +5,8 @@ func (*Snapshot) ResourceType() string {
 	return "Snapshot"
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateSnapshot) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateSnapshot) name() string {
 	return "createSnapshot"
 }
 
@@ -19,8 +19,8 @@ type CreateSnapshotResponse struct {
 	Snapshot Snapshot `json:"snapshot"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListSnapshots) APIName() string {
+// name returns the CloudStack API command name
+func (*ListSnapshots) name() string {
 	return "listSnapshots"
 }
 
@@ -34,8 +34,8 @@ type ListSnapshotsResponse struct {
 	Snapshot []Snapshot `json:"snapshot"`
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteSnapshot) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteSnapshot) name() string {
 	return "deleteSnapshot"
 }
 
@@ -43,8 +43,8 @@ func (*DeleteSnapshot) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RevertSnapshot) APIName() string {
+// name returns the CloudStack API command name
+func (*RevertSnapshot) name() string {
 	return "revertSnapshot"
 }
 

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -21,7 +21,7 @@ func TestSnapshot(t *testing.T) {
 
 func TestCreateSnapshot(t *testing.T) {
 	req := &CreateSnapshot{}
-	if req.APIName() != "createSnapshot" {
+	if req.name() != "createSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*CreateSnapshotResponse)
@@ -29,7 +29,7 @@ func TestCreateSnapshot(t *testing.T) {
 
 func TestListSnapshots(t *testing.T) {
 	req := &ListSnapshots{}
-	if req.APIName() != "listSnapshots" {
+	if req.name() != "listSnapshots" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListSnapshotsResponse)
@@ -37,7 +37,7 @@ func TestListSnapshots(t *testing.T) {
 
 func TestDeleteSnapshot(t *testing.T) {
 	req := &DeleteSnapshot{}
-	if req.APIName() != "deleteSnapshot" {
+	if req.name() != "deleteSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -45,7 +45,7 @@ func TestDeleteSnapshot(t *testing.T) {
 
 func TestRevertSnapshot(t *testing.T) {
 	req := &RevertSnapshot{}
-	if req.APIName() != "revertSnapshot" {
+	if req.name() != "revertSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)

--- a/tags.go
+++ b/tags.go
@@ -1,7 +1,7 @@
 package egoscale
 
-// APIName returns the CloudStack API command name
-func (*CreateTags) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateTags) name() string {
 	return "createTags"
 }
 
@@ -9,8 +9,8 @@ func (*CreateTags) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteTags) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteTags) name() string {
 	return "deleteTags"
 }
 
@@ -18,8 +18,8 @@ func (*DeleteTags) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListTags) APIName() string {
+// name returns the CloudStack API command name
+func (*ListTags) name() string {
 	return "listTags"
 }
 

--- a/tags_test.go
+++ b/tags_test.go
@@ -12,7 +12,7 @@ func TestTags(t *testing.T) {
 
 func TestCreateTags(t *testing.T) {
 	req := &CreateTags{}
-	if req.APIName() != "createTags" {
+	if req.name() != "createTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -20,7 +20,7 @@ func TestCreateTags(t *testing.T) {
 
 func TestDeleteTags(t *testing.T) {
 	req := &DeleteTags{}
-	if req.APIName() != "deleteTags" {
+	if req.name() != "deleteTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -28,7 +28,7 @@ func TestDeleteTags(t *testing.T) {
 
 func TestListTags(t *testing.T) {
 	req := &ListTags{}
-	if req.APIName() != "listTags" {
+	if req.name() != "listTags" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListTagsResponse)

--- a/templates.go
+++ b/templates.go
@@ -53,8 +53,8 @@ func (*Template) ResourceType() string {
 	return "Template"
 }
 
-// APIName returns the CloudStack API command name
-func (*ListTemplates) APIName() string {
+// name returns the CloudStack API command name
+func (*ListTemplates) name() string {
 	return "listTemplates"
 }
 

--- a/users.go
+++ b/users.go
@@ -1,7 +1,6 @@
 package egoscale
 
-// APIName returns the CloudStack API command name
-func (*RegisterUserKeys) APIName() string {
+func (*RegisterUserKeys) name() string {
 	return "registerUserKeys"
 }
 
@@ -9,8 +8,7 @@ func (*RegisterUserKeys) response() interface{} {
 	return new(RegisterUserKeysResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateUser) APIName() string {
+func (*CreateUser) name() string {
 	return "createUser"
 }
 
@@ -18,8 +16,7 @@ func (*CreateUser) response() interface{} {
 	return new(CreateUserResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateUser) APIName() string {
+func (*UpdateUser) name() string {
 	return "updateUser"
 }
 
@@ -27,8 +24,7 @@ func (*UpdateUser) response() interface{} {
 	return new(UpdateUserResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListUsers) APIName() string {
+func (*ListUsers) name() string {
 	return "listUsers"
 }
 

--- a/users_test.go
+++ b/users_test.go
@@ -13,7 +13,7 @@ func TestUsers(t *testing.T) {
 
 func TestCreateUser(t *testing.T) {
 	req := &CreateUser{}
-	if req.APIName() != "createUser" {
+	if req.name() != "createUser" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateUserResponse)
@@ -21,7 +21,7 @@ func TestCreateUser(t *testing.T) {
 
 func TestRegisterUserKeys(t *testing.T) {
 	req := &RegisterUserKeys{}
-	if req.APIName() != "registerUserKeys" {
+	if req.name() != "registerUserKeys" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RegisterUserKeysResponse)
@@ -29,7 +29,7 @@ func TestRegisterUserKeys(t *testing.T) {
 
 func TestUpdateUser(t *testing.T) {
 	req := &UpdateUser{}
-	if req.APIName() != "updateUser" {
+	if req.name() != "updateUser" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*UpdateUserResponse)
@@ -37,7 +37,7 @@ func TestUpdateUser(t *testing.T) {
 
 func TestListUsers(t *testing.T) {
 	req := &ListUsers{}
-	if req.APIName() != "listUsers" {
+	if req.name() != "listUsers" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListUsersResponse)

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -131,8 +131,8 @@ func (vm *VirtualMachine) NicByID(nicID string) *Nic {
 	return nil
 }
 
-// APIName returns the CloudStack API command name
-func (*DeployVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*DeployVirtualMachine) name() string {
 	return "deployVirtualMachine"
 }
 
@@ -154,16 +154,16 @@ func (*DeployVirtualMachine) asyncResponse() interface{} {
 	return new(DeployVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*StartVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*StartVirtualMachine) name() string {
 	return "startVirtualMachine"
 }
 func (*StartVirtualMachine) asyncResponse() interface{} {
 	return new(StartVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*StopVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*StopVirtualMachine) name() string {
 	return "stopVirtualMachine"
 }
 
@@ -171,8 +171,8 @@ func (*StopVirtualMachine) asyncResponse() interface{} {
 	return new(StopVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RebootVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*RebootVirtualMachine) name() string {
 	return "rebootVirtualMachine"
 }
 
@@ -183,8 +183,8 @@ func (*RebootVirtualMachine) asyncResponse() interface{} {
 // RebootVirtualMachineResponse represents a rebooted VM instance
 type RebootVirtualMachineResponse VirtualMachineResponse
 
-// APIName returns the CloudStack API command name
-func (*RestoreVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*RestoreVirtualMachine) name() string {
 	return "restoreVirtualMachine"
 }
 
@@ -192,8 +192,8 @@ func (*RestoreVirtualMachine) asyncResponse() interface{} {
 	return new(RestoreVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RecoverVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*RecoverVirtualMachine) name() string {
 	return "recoverVirtualMachine"
 }
 
@@ -201,8 +201,8 @@ func (*RecoverVirtualMachine) response() interface{} {
 	return new(RecoverVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*DestroyVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*DestroyVirtualMachine) name() string {
 	return "destroyVirtualMachine"
 }
 
@@ -210,8 +210,8 @@ func (*DestroyVirtualMachine) asyncResponse() interface{} {
 	return new(DestroyVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateVirtualMachine) name() string {
 	return "updateVirtualMachine"
 }
 
@@ -227,8 +227,8 @@ type ExpungeVirtualMachine struct {
 	ID string `json:"id"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ExpungeVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*ExpungeVirtualMachine) name() string {
 	return "expungeVirtualMachine"
 }
 
@@ -236,8 +236,8 @@ func (*ExpungeVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ScaleVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*ScaleVirtualMachine) name() string {
 	return "scaleVirtualMachine"
 }
 
@@ -245,8 +245,8 @@ func (*ScaleVirtualMachine) asyncResponse() interface{} {
 	return new(booleanAsyncResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ChangeServiceForVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*ChangeServiceForVirtualMachine) name() string {
 	return "changeServiceForVirtualMachine"
 }
 
@@ -254,8 +254,8 @@ func (*ChangeServiceForVirtualMachine) response() interface{} {
 	return new(ChangeServiceForVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ResetPasswordForVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*ResetPasswordForVirtualMachine) name() string {
 	return "resetPasswordForVirtualMachine"
 }
 
@@ -263,8 +263,8 @@ func (*ResetPasswordForVirtualMachine) asyncResponse() interface{} {
 	return new(ResetPasswordForVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*GetVMPassword) APIName() string {
+// name returns the CloudStack API command name
+func (*GetVMPassword) name() string {
 	return "getVMPassword"
 }
 
@@ -272,8 +272,8 @@ func (*GetVMPassword) response() interface{} {
 	return new(GetVMPasswordResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*ListVirtualMachines) APIName() string {
+// name returns the CloudStack API command name
+func (*ListVirtualMachines) name() string {
 	return "listVirtualMachines"
 }
 
@@ -305,8 +305,8 @@ func (*ListVirtualMachines) each(resp interface{}, callback IterateItemFunc) {
 	}
 }
 
-// APIName returns the CloudStack API command name
-func (*AddNicToVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*AddNicToVirtualMachine) name() string {
 	return "addNicToVirtualMachine"
 }
 
@@ -314,8 +314,8 @@ func (*AddNicToVirtualMachine) asyncResponse() interface{} {
 	return new(AddNicToVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*RemoveNicFromVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*RemoveNicFromVirtualMachine) name() string {
 	return "removeNicFromVirtualMachine"
 }
 
@@ -323,8 +323,8 @@ func (*RemoveNicFromVirtualMachine) asyncResponse() interface{} {
 	return new(RemoveNicFromVirtualMachineResponse)
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateDefaultNicForVirtualMachine) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateDefaultNicForVirtualMachine) name() string {
 	return "updateDefaultNicForVirtualMachine"
 }
 

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -15,7 +15,7 @@ func TestVirtualMachine(t *testing.T) {
 
 func TestDeployVirtualMachine(t *testing.T) {
 	req := &DeployVirtualMachine{}
-	if req.APIName() != "deployVirtualMachine" {
+	if req.name() != "deployVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*DeployVirtualMachineResponse)
@@ -23,7 +23,7 @@ func TestDeployVirtualMachine(t *testing.T) {
 
 func TestDestroyVirtualMachine(t *testing.T) {
 	req := &DestroyVirtualMachine{}
-	if req.APIName() != "destroyVirtualMachine" {
+	if req.name() != "destroyVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*DestroyVirtualMachineResponse)
@@ -31,7 +31,7 @@ func TestDestroyVirtualMachine(t *testing.T) {
 
 func TestRebootVirtualMachine(t *testing.T) {
 	req := &RebootVirtualMachine{}
-	if req.APIName() != "rebootVirtualMachine" {
+	if req.name() != "rebootVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RebootVirtualMachineResponse)
@@ -39,7 +39,7 @@ func TestRebootVirtualMachine(t *testing.T) {
 
 func TestStartVirtualMachine(t *testing.T) {
 	req := &StartVirtualMachine{}
-	if req.APIName() != "startVirtualMachine" {
+	if req.name() != "startVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*StartVirtualMachineResponse)
@@ -47,7 +47,7 @@ func TestStartVirtualMachine(t *testing.T) {
 
 func TestStopVirtualMachine(t *testing.T) {
 	req := &StopVirtualMachine{}
-	if req.APIName() != "stopVirtualMachine" {
+	if req.name() != "stopVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*StopVirtualMachineResponse)
@@ -55,7 +55,7 @@ func TestStopVirtualMachine(t *testing.T) {
 
 func TestResetPasswordForVirtualMachine(t *testing.T) {
 	req := &ResetPasswordForVirtualMachine{}
-	if req.APIName() != "resetPasswordForVirtualMachine" {
+	if req.name() != "resetPasswordForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResetPasswordForVirtualMachineResponse)
@@ -63,7 +63,7 @@ func TestResetPasswordForVirtualMachine(t *testing.T) {
 
 func TestUpdateVirtualMachine(t *testing.T) {
 	req := &UpdateVirtualMachine{}
-	if req.APIName() != "updateVirtualMachine" {
+	if req.name() != "updateVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*UpdateVirtualMachineResponse)
@@ -71,7 +71,7 @@ func TestUpdateVirtualMachine(t *testing.T) {
 
 func TestListVirtualMachines(t *testing.T) {
 	req := &ListVirtualMachines{}
-	if req.APIName() != "listVirtualMachines" {
+	if req.name() != "listVirtualMachines" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListVirtualMachinesResponse)
@@ -79,7 +79,7 @@ func TestListVirtualMachines(t *testing.T) {
 
 func TestGetVMPassword(t *testing.T) {
 	req := &GetVMPassword{}
-	if req.APIName() != "getVMPassword" {
+	if req.name() != "getVMPassword" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*GetVMPasswordResponse)
@@ -87,7 +87,7 @@ func TestGetVMPassword(t *testing.T) {
 
 func TestRestoreVirtualMachine(t *testing.T) {
 	req := &RestoreVirtualMachine{}
-	if req.APIName() != "restoreVirtualMachine" {
+	if req.name() != "restoreVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RestoreVirtualMachineResponse)
@@ -95,7 +95,7 @@ func TestRestoreVirtualMachine(t *testing.T) {
 
 func TestChangeServiceForVirtualMachine(t *testing.T) {
 	req := &ChangeServiceForVirtualMachine{}
-	if req.APIName() != "changeServiceForVirtualMachine" {
+	if req.name() != "changeServiceForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ChangeServiceForVirtualMachineResponse)
@@ -103,7 +103,7 @@ func TestChangeServiceForVirtualMachine(t *testing.T) {
 
 func TestScaleVirtualMachine(t *testing.T) {
 	req := &ScaleVirtualMachine{}
-	if req.APIName() != "scaleVirtualMachine" {
+	if req.name() != "scaleVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -111,7 +111,7 @@ func TestScaleVirtualMachine(t *testing.T) {
 
 func TestRecoverVirtualMachine(t *testing.T) {
 	req := &RecoverVirtualMachine{}
-	if req.APIName() != "recoverVirtualMachine" {
+	if req.name() != "recoverVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*RecoverVirtualMachineResponse)
@@ -119,7 +119,7 @@ func TestRecoverVirtualMachine(t *testing.T) {
 
 func TestExpungeVirtualMachine(t *testing.T) {
 	req := &ExpungeVirtualMachine{}
-	if req.APIName() != "expungeVirtualMachine" {
+	if req.name() != "expungeVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*booleanAsyncResponse)
@@ -127,7 +127,7 @@ func TestExpungeVirtualMachine(t *testing.T) {
 
 func TestAddNicToVirtualMachine(t *testing.T) {
 	req := &AddNicToVirtualMachine{}
-	if req.APIName() != "addNicToVirtualMachine" {
+	if req.name() != "addNicToVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*AddNicToVirtualMachineResponse)
@@ -135,7 +135,7 @@ func TestAddNicToVirtualMachine(t *testing.T) {
 
 func TestRemoveNicFromVirtualMachine(t *testing.T) {
 	req := &RemoveNicFromVirtualMachine{}
-	if req.APIName() != "removeNicFromVirtualMachine" {
+	if req.name() != "removeNicFromVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*RemoveNicFromVirtualMachineResponse)
@@ -143,7 +143,7 @@ func TestRemoveNicFromVirtualMachine(t *testing.T) {
 
 func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
 	req := &UpdateDefaultNicForVirtualMachine{}
-	if req.APIName() != "updateDefaultNicForVirtualMachine" {
+	if req.name() != "updateDefaultNicForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*UpdateDefaultNicForVirtualMachineResponse)

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -27,8 +27,8 @@ type CreateInstanceGroup struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*CreateInstanceGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*CreateInstanceGroup) name() string {
 	return "createInstanceGroup"
 }
 
@@ -47,8 +47,8 @@ type UpdateInstanceGroup struct {
 	Name string `json:"name,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*UpdateInstanceGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*UpdateInstanceGroup) name() string {
 	return "updateInstanceGroup"
 }
 
@@ -69,8 +69,8 @@ type DeleteInstanceGroup struct {
 	ProjectID string `json:"projectid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*DeleteInstanceGroup) APIName() string {
+// name returns the CloudStack API command name
+func (*DeleteInstanceGroup) name() string {
 	return "deleteInstanceGroup"
 }
 
@@ -94,8 +94,8 @@ type ListInstanceGroups struct {
 	ProjectID   string `json:"projectid,omitempty"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListInstanceGroups) APIName() string {
+// name returns the CloudStack API command name
+func (*ListInstanceGroups) name() string {
 	return "listInstanceGroups"
 }
 

--- a/vm_groups_test.go
+++ b/vm_groups_test.go
@@ -13,7 +13,7 @@ func TestInstanceGroup(t *testing.T) {
 
 func TestListInstanceGroups(t *testing.T) {
 	req := &ListInstanceGroups{}
-	if req.APIName() != "listInstanceGroups" {
+	if req.name() != "listInstanceGroups" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListInstanceGroupsResponse)
@@ -21,7 +21,7 @@ func TestListInstanceGroups(t *testing.T) {
 
 func TestCreateInstanceGroup(t *testing.T) {
 	req := &CreateInstanceGroup{}
-	if req.APIName() != "createInstanceGroup" {
+	if req.name() != "createInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*CreateInstanceGroupResponse)
@@ -29,7 +29,7 @@ func TestCreateInstanceGroup(t *testing.T) {
 
 func TestUpdateInstanceGroup(t *testing.T) {
 	req := &UpdateInstanceGroup{}
-	if req.APIName() != "updateInstanceGroup" {
+	if req.name() != "updateInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*UpdateInstanceGroupResponse)
@@ -37,7 +37,7 @@ func TestUpdateInstanceGroup(t *testing.T) {
 
 func TestDeleteInstanceGroup(t *testing.T) {
 	req := &DeleteInstanceGroup{}
-	if req.APIName() != "deleteInstanceGroup" {
+	if req.name() != "deleteInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*booleanSyncResponse)

--- a/volumes.go
+++ b/volumes.go
@@ -50,8 +50,8 @@ func (vol *Volume) ListRequest() (ListCommand, error) {
 	return req, nil
 }
 
-// APIName returns the CloudStack API command name
-func (*ResizeVolume) APIName() string {
+// name returns the CloudStack API command name
+func (*ResizeVolume) name() string {
 	return "resizeVolume"
 }
 
@@ -64,8 +64,8 @@ type ResizeVolumeResponse struct {
 	Volume Volume `json:"volume"`
 }
 
-// APIName returns the CloudStack API command name
-func (*ListVolumes) APIName() string {
+// name returns the CloudStack API command name
+func (*ListVolumes) name() string {
 	return "listVolumes"
 }
 

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -13,7 +13,7 @@ func TestVolume(t *testing.T) {
 
 func TestListVolumes(t *testing.T) {
 	req := &ListVolumes{}
-	if req.APIName() != "listVolumes" {
+	if req.name() != "listVolumes" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListVolumesResponse)
@@ -21,7 +21,7 @@ func TestListVolumes(t *testing.T) {
 
 func TestResizeVolume(t *testing.T) {
 	req := &ResizeVolume{}
-	if req.APIName() != "resizeVolume" {
+	if req.name() != "resizeVolume" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.asyncResponse().(*ResizeVolumeResponse)

--- a/zones.go
+++ b/zones.go
@@ -42,8 +42,8 @@ func (zone *Zone) ListRequest() (ListCommand, error) {
 	return req, nil
 }
 
-// APIName returns the CloudStack API command name
-func (*ListZones) APIName() string {
+// name returns the CloudStack API command name
+func (*ListZones) name() string {
 	return "listZones"
 }
 

--- a/zones_test.go
+++ b/zones_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListZonesAPIName(t *testing.T) {
 	req := &ListZones{}
-	if req.APIName() != "listZones" {
+	if req.name() != "listZones" {
 		t.Errorf("API call doesn't match")
 	}
 	_ = req.response().(*ListZonesResponse)


### PR DESCRIPTION
reverts in a way #32 

`Command.APIName` is now `Client.APIName(Command)`, one call in the doc vs quantity of commands

**Before**

![screenshot from 2018-04-23 07-11-35](https://user-images.githubusercontent.com/1388/39107956-e1168302-46c5-11e8-8f8b-3354504e523d.png)

**After**

![screenshot from 2018-04-23 07-11-14](https://user-images.githubusercontent.com/1388/39107957-e13712e8-46c5-11e8-99b0-636439e8d641.png)