### PR TITLE
request: send user-agent

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -219,6 +219,7 @@ func (exo *Client) dnsRequest(uri string, params string, method string) (json.Ra
 
 	var hdr = make(http.Header)
 	hdr.Add("X-DNS-TOKEN", exo.APIKey+":"+exo.apiSecret)
+	hdr.Add("User-Agent", fmt.Sprintf("exoscale/egoscale (%v)", Version))
 	hdr.Add("Accept", "application/json")
 	if params != "" {
 		hdr.Add("Content-Type", "application/json")

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package egoscale
+
+// Version of the library
+const Version = "0.9.22"


### PR DESCRIPTION
Sends:
- request as GET by default
- User-Agent containing exoscale/egoscale and a version number