### PR TITLE
client: expose command expected response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.9.22 (unreleased)
+0.9.22
 ------
 
 - feat: `ListUsers`, `CreateUser`, `UpdateUser`

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package egoscale
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -169,8 +170,20 @@ func (client *Client) PaginateWithContext(ctx context.Context, req ListCommand, 
 }
 
 // APIName returns the CloudStack name of the given command
-func (client *Client) APIName(req Command) string {
-	return req.name()
+func (client *Client) APIName(request Command) string {
+	return request.name()
+}
+
+// Response returns the response structure of the given command
+func (client *Client) Response(request Command) interface{} {
+	switch request.(type) {
+	case syncCommand:
+		return (request.(syncCommand)).response()
+	case AsyncCommand:
+		return (request.(AsyncCommand)).asyncResponse()
+	default:
+		panic(fmt.Errorf("The command %s is not a proper Sync or Async command", request.name()))
+	}
 }
 
 // NewClientWithTimeout creates a CloudStack API client


### PR DESCRIPTION
It enables doing a richer dry mode on the cli exposing the expected output if the command where run for real. (NB: the signature is redacted on purpose)

```
$ ./cs -d listZones
https://api.exoscale.ch/compute\
?apikey=EXO34771c9dad3d915cf1aa559e\
&command=listZones\
&response=json

{ 
  "count": 0,
  "zone": null
}
```