### PR TITLE
global: unify sync/async responses

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -75,7 +75,7 @@ func (*DisassociateIPAddress) name() string {
 	return "disassociateIpAddress"
 }
 func (*DisassociateIPAddress) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -33,7 +33,7 @@ func TestDisassociateIPAddress(t *testing.T) {
 	if req.name() != "disassociateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestListPublicIPAddresses(t *testing.T) {

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -151,7 +151,7 @@ func (*DeleteAffinityGroup) name() string {
 }
 
 func (*DeleteAffinityGroup) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // ListAffinityGroups represents an (anti-)affinity groups search

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -26,7 +26,7 @@ func TestDeleteAffinityGroup(t *testing.T) {
 	if req.name() != "deleteAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestListAffinityGroups(t *testing.T) {

--- a/keypairs.go
+++ b/keypairs.go
@@ -69,7 +69,7 @@ func (*DeleteSSHKeyPair) name() string {
 }
 
 func (*DeleteSSHKeyPair) response() interface{} {
-	return new(booleanSyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -33,7 +33,7 @@ func TestDeleteSSHKeyPair(t *testing.T) {
 	if req.name() != "deleteSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*booleanSyncResponse)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestListSSHKeyPairsResponse(t *testing.T) {

--- a/networks.go
+++ b/networks.go
@@ -75,7 +75,7 @@ func (*DeleteNetwork) name() string {
 }
 
 func (*DeleteNetwork) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/networks_test.go
+++ b/networks_test.go
@@ -58,7 +58,7 @@ func TestDeleteNetwork(t *testing.T) {
 	if req.name() != "deleteNetwork" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestCreateNetworkOnBeforeSend(t *testing.T) {

--- a/nics.go
+++ b/nics.go
@@ -61,7 +61,7 @@ func (*RemoveIPFromNic) name() string {
 }
 
 func (*RemoveIPFromNic) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name: activateIp6

--- a/nics_test.go
+++ b/nics_test.go
@@ -17,7 +17,7 @@ func TestRemoveIPFromNic(t *testing.T) {
 	if req.name() != "removeIpFromNic" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestListNicsAPIName(t *testing.T) {

--- a/request_type.go
+++ b/request_type.go
@@ -123,14 +123,8 @@ type UUIDItem struct {
 	UUID             string `json:"uuid"`
 }
 
-// booleanAsyncResponse represents a boolean response (usually after a deletion)
-type booleanAsyncResponse struct {
-	Success     bool   `json:"success"`
-	DisplayText string `json:"diplaytext,omitempty"`
-}
-
-// booleanAsyncResponse represents a boolean response for sync calls
-type booleanSyncResponse struct {
-	Success     string `json:"success"`
-	DisplayText string `json:"displaytext,omitempty"`
+// booleanResponse represents a boolean response (usually after a deletion)
+type booleanResponse struct {
+	Success     json.RawMessage `json:"success"`
+	DisplayText string          `json:"displaytext,omitempty"`
 }

--- a/security_groups.go
+++ b/security_groups.go
@@ -113,7 +113,7 @@ func (*DeleteSecurityGroup) name() string {
 }
 
 func (*DeleteSecurityGroup) response() interface{} {
-	return new(booleanSyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name
@@ -157,7 +157,7 @@ func (*RevokeSecurityGroupIngress) name() string {
 }
 
 func (*RevokeSecurityGroupIngress) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name
@@ -166,7 +166,7 @@ func (*RevokeSecurityGroupEgress) name() string {
 }
 
 func (*RevokeSecurityGroupEgress) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -54,7 +54,7 @@ func TestDeleteSecurityGroup(t *testing.T) {
 	if req.name() != "deleteSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*booleanSyncResponse)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestListSecurityGroupsApiName(t *testing.T) {
@@ -70,7 +70,7 @@ func TestRevokeSecurityGroupEgress(t *testing.T) {
 	if req.name() != "revokeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestRevokeSecurityGroupIngress(t *testing.T) {
@@ -78,7 +78,7 @@ func TestRevokeSecurityGroupIngress(t *testing.T) {
 	if req.name() != "revokeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestAuthorizeSecurityGroupEgressOnBeforeSendICMP(t *testing.T) {

--- a/snapshots.go
+++ b/snapshots.go
@@ -40,7 +40,7 @@ func (*DeleteSnapshot) name() string {
 }
 
 func (*DeleteSnapshot) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name
@@ -49,5 +49,5 @@ func (*RevertSnapshot) name() string {
 }
 
 func (*RevertSnapshot) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -40,7 +40,7 @@ func TestDeleteSnapshot(t *testing.T) {
 	if req.name() != "deleteSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestRevertSnapshot(t *testing.T) {
@@ -48,5 +48,5 @@ func TestRevertSnapshot(t *testing.T) {
 	if req.name() != "revertSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }

--- a/tags.go
+++ b/tags.go
@@ -6,7 +6,7 @@ func (*CreateTags) name() string {
 }
 
 func (*CreateTags) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name
@@ -15,7 +15,7 @@ func (*DeleteTags) name() string {
 }
 
 func (*DeleteTags) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/tags_test.go
+++ b/tags_test.go
@@ -15,7 +15,7 @@ func TestCreateTags(t *testing.T) {
 	if req.name() != "createTags" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestDeleteTags(t *testing.T) {
@@ -23,7 +23,7 @@ func TestDeleteTags(t *testing.T) {
 	if req.name() != "deleteTags" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestListTags(t *testing.T) {

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -222,7 +222,7 @@ func (*ExpungeVirtualMachine) name() string {
 }
 
 func (*ExpungeVirtualMachine) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name
@@ -231,7 +231,7 @@ func (*ScaleVirtualMachine) name() string {
 }
 
 func (*ScaleVirtualMachine) asyncResponse() interface{} {
-	return new(booleanAsyncResponse)
+	return new(booleanResponse)
 }
 
 // name returns the CloudStack API command name

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -106,7 +106,7 @@ func TestScaleVirtualMachine(t *testing.T) {
 	if req.name() != "scaleVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestRecoverVirtualMachine(t *testing.T) {
@@ -122,7 +122,7 @@ func TestExpungeVirtualMachine(t *testing.T) {
 	if req.name() != "expungeVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*booleanAsyncResponse)
+	_ = req.asyncResponse().(*booleanResponse)
 }
 
 func TestGetVirtualMachineUserData(t *testing.T) {

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -75,7 +75,7 @@ func (*DeleteInstanceGroup) name() string {
 }
 
 func (*DeleteInstanceGroup) response() interface{} {
-	return new(booleanSyncResponse)
+	return new(booleanResponse)
 }
 
 // ListInstanceGroups lists VM groups

--- a/vm_groups_test.go
+++ b/vm_groups_test.go
@@ -40,5 +40,5 @@ func TestDeleteInstanceGroup(t *testing.T) {
 	if req.name() != "deleteInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*booleanSyncResponse)
+	_ = req.response().(*booleanResponse)
 }


### PR DESCRIPTION
Apply https://github.com/apache/cloudstack/pull/2428

The trick is to marshal into a `json.RawMessage` with the drawback that is, almost, always works...

https://play.golang.org/p/2AAzw9YwFSr