### PR TITLE
Less types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.10.0
+------
+
+- global: removal of all the `...Response` types
+
 0.9.26
 ------
 

--- a/accounts.go
+++ b/accounts.go
@@ -13,7 +13,7 @@ func (*EnableAccount) name() string {
 }
 
 func (*EnableAccount) response() interface{} {
-	return new(EnableAccountResponse)
+	return new(Account)
 }
 
 func (*DisableAccount) name() string {
@@ -21,5 +21,5 @@ func (*DisableAccount) name() string {
 }
 
 func (*DisableAccount) asyncResponse() interface{} {
-	return new(DisableAccountResponse)
+	return new(Account)
 }

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -4,12 +4,6 @@ import (
 	"testing"
 )
 
-func TestAccounts(t *testing.T) {
-	var _ Command = (*ListAccounts)(nil)
-	var _ Command = (*EnableAccount)(nil)
-	var _ Command = (*DisableAccount)(nil)
-}
-
 func TestListAccounts(t *testing.T) {
 	req := &ListAccounts{}
 	if req.name() != "listAccounts" {
@@ -23,7 +17,7 @@ func TestEnableAccount(t *testing.T) {
 	if req.name() != "enableAccount" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*EnableAccountResponse)
+	_ = req.response().(*Account)
 }
 
 func TestDisableAccount(t *testing.T) {
@@ -31,5 +25,5 @@ func TestDisableAccount(t *testing.T) {
 	if req.name() != "disableAccount" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*DisableAccountResponse)
+	_ = req.asyncResponse().(*Account)
 }

--- a/accounts_type.go
+++ b/accounts_type.go
@@ -101,11 +101,6 @@ type EnableAccount struct {
 	ID       string `json:"id,omitempty" doc:"Account id"`
 }
 
-// EnableAccountResponse represents the modified account
-type EnableAccountResponse struct {
-	Account Account `json:"account"`
-}
-
 // DisableAccount (Async) represents the deactivation of an account
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/disableAccount.html
@@ -115,6 +110,3 @@ type DisableAccount struct {
 	DomainID string `json:"domainid,omitempty" doc:"Disables specified account in this domain."`
 	ID       string `json:"id,omitempty" doc:"Account id"`
 }
-
-// DisableAccountResponse represents the modified account
-type DisableAccountResponse EnableAccountResponse

--- a/addresses.go
+++ b/addresses.go
@@ -66,7 +66,7 @@ func (*AssociateIPAddress) name() string {
 }
 
 func (*AssociateIPAddress) asyncResponse() interface{} {
-	return new(AssociateIPAddressResponse)
+	return new(IPAddress)
 }
 
 // name returns the CloudStack API command name
@@ -82,7 +82,7 @@ func (*UpdateIPAddress) name() string {
 	return "updateIpAddress"
 }
 func (*UpdateIPAddress) asyncResponse() interface{} {
-	return new(UpdateIPAddressResponse)
+	return new(IPAddress)
 }
 
 // name returns the CloudStack API command name

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -5,14 +5,6 @@ import (
 	"testing"
 )
 
-func TestAddressess(t *testing.T) {
-	var _ Taggable = (*IPAddress)(nil)
-	var _ AsyncCommand = (*AssociateIPAddress)(nil)
-	var _ AsyncCommand = (*DisassociateIPAddress)(nil)
-	var _ syncCommand = (*ListPublicIPAddresses)(nil)
-	var _ AsyncCommand = (*UpdateIPAddress)(nil)
-}
-
 func TestIPAddress(t *testing.T) {
 	instance := &IPAddress{}
 	if instance.ResourceType() != "PublicIpAddress" {
@@ -98,7 +90,7 @@ func TestGetIPAddress(t *testing.T) {
 
 func TestListIPAddress(t *testing.T) {
 	ts := newServer(response{200, `
-		{"listPublicIpAddresses":{
+		{"listpublicipaddressesresponse":{
 			"count": 1,
 			"publicipaddress": [
 			  {
@@ -149,7 +141,7 @@ func TestListIPAddress(t *testing.T) {
 
 func TestListIPAddressPaginate(t *testing.T) {
 	ts := newServer(response{200, `
-		{"listPublicIpAddresses":{
+		{"listpublicipaddressesresponse":{
 			"count": 1,
 			"publicipaddress": [
 			  {
@@ -217,10 +209,10 @@ func TestListIPAddressPaginate(t *testing.T) {
 
 func TestListIPAddressFailure(t *testing.T) {
 	ts := newServer(response{200, `
-		{"listPublicIpAddresses":{
-			"count": 1,
-			"publicipaddress": {}
-		  }}`})
+	{"listpublicipaddressesresponse": {
+		"count": 1,
+		"publicipaddress": {}
+	}`})
 
 	defer ts.Close()
 

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -17,7 +17,7 @@ func TestAssociateIPAddress(t *testing.T) {
 	if req.name() != "associateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*AssociateIPAddressResponse)
+	_ = req.asyncResponse().(*IPAddress)
 }
 
 func TestDisassociateIPAddress(t *testing.T) {
@@ -41,7 +41,7 @@ func TestUpdateIPAddress(t *testing.T) {
 	if req.name() != "updateIpAddress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*UpdateIPAddressResponse)
+	_ = req.asyncResponse().(*IPAddress)
 }
 
 func TestGetIPAddress(t *testing.T) {

--- a/addresses_type.go
+++ b/addresses_type.go
@@ -50,11 +50,6 @@ type AssociateIPAddress struct {
 	ZoneID     string `json:"zoneid,omitempty" doc:"the ID of the availability zone you want to acquire an public IP address from"`
 }
 
-// AssociateIPAddressResponse represents the response to the creation of an IPAddress
-type AssociateIPAddressResponse struct {
-	IPAddress IPAddress `json:"ipaddress"`
-}
-
 // DisassociateIPAddress (Async) represents the IP deletion
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/disassociateIpAddress.html
@@ -70,9 +65,6 @@ type UpdateIPAddress struct {
 	CustomID   string `json:"customid,omitempty" doc:"an optional field, in case you want to set a custom id to the resource. Allowed to Root Admins only"`
 	ForDisplay *bool  `json:"fordisplay,omitempty" doc:"an optional field, whether to the display the ip to the end user or not"`
 }
-
-// UpdateIPAddressResponse represents the modified IP Address
-type UpdateIPAddressResponse AssociateIPAddressResponse
 
 // ListPublicIPAddresses represents a search for public IP addresses
 //

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -63,7 +63,7 @@ func (*CreateAffinityGroup) name() string {
 }
 
 func (*CreateAffinityGroup) asyncResponse() interface{} {
-	return new(CreateAffinityGroupResponse)
+	return new(AffinityGroup)
 }
 
 // name returns the CloudStack API command name
@@ -72,7 +72,7 @@ func (*UpdateVMAffinityGroup) name() string {
 }
 
 func (*UpdateVMAffinityGroup) asyncResponse() interface{} {
-	return new(UpdateVMAffinityGroupResponse)
+	return new(VirtualMachine)
 }
 
 func (req *UpdateVMAffinityGroup) onBeforeSend(params *url.Values) error {

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -5,20 +5,12 @@ import (
 	"testing"
 )
 
-func TestAffinityGroups(t *testing.T) {
-	var _ AsyncCommand = (*CreateAffinityGroup)(nil)
-	var _ AsyncCommand = (*DeleteAffinityGroup)(nil)
-	var _ syncCommand = (*ListAffinityGroupTypes)(nil)
-	var _ syncCommand = (*ListAffinityGroups)(nil)
-	var _ AsyncCommand = (*UpdateVMAffinityGroup)(nil)
-}
-
 func TestCreateAffinityGroup(t *testing.T) {
 	req := &CreateAffinityGroup{}
 	if req.name() != "createAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*CreateAffinityGroupResponse)
+	_ = req.asyncResponse().(*AffinityGroup)
 }
 
 func TestDeleteAffinityGroup(t *testing.T) {
@@ -50,7 +42,7 @@ func TestUpdateVMAffinityGroup(t *testing.T) {
 	if req.name() != "updateVMAffinityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*UpdateVMAffinityGroupResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestUpdateVMOnBeforeSend(t *testing.T) {

--- a/affinity_groups_type.go
+++ b/affinity_groups_type.go
@@ -31,11 +31,6 @@ type CreateAffinityGroup struct {
 	Type        string `json:"type" doc:"Type of the affinity group from the available affinity/anti-affinity group types"`
 }
 
-// CreateAffinityGroupResponse represents the response of the creation of an (anti-)affinity group
-type CreateAffinityGroupResponse struct {
-	AffinityGroup AffinityGroup `json:"affinitygroup"`
-}
-
 // UpdateVMAffinityGroup (Async) represents a modification of a (anti-)affinity group
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateVMAffinityGroup.html
@@ -44,9 +39,6 @@ type UpdateVMAffinityGroup struct {
 	AffinityGroupIDs   []string `json:"affinitygroupids,omitempty" doc:"comma separated list of affinity groups id that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupnames parameter"`
 	AffinityGroupNames []string `json:"affinitygroupnames,omitempty" doc:"comma separated list of affinity groups names that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupids parameter"`
 }
-
-// UpdateVMAffinityGroupResponse represents the new VM
-type UpdateVMAffinityGroupResponse VirtualMachineResponse
 
 // DeleteAffinityGroup (Async) represents an (anti-)affinity group to be deleted
 //

--- a/async_jobs_test.go
+++ b/async_jobs_test.go
@@ -4,17 +4,12 @@ import (
 	"testing"
 )
 
-func TestAsyncJobs(t *testing.T) {
-	var _ Command = (*QueryAsyncJobResult)(nil)
-	var _ Command = (*ListAsyncJobs)(nil)
-}
-
 func TestQueryAsyncJobResult(t *testing.T) {
 	req := &QueryAsyncJobResult{}
 	if req.name() != "queryAsyncJobResult" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*QueryAsyncJobResultResponse)
+	_ = req.response().(*AsyncJobResult)
 }
 
 func TestListAsyncJobs(t *testing.T) {

--- a/async_jobs_type.go
+++ b/async_jobs_type.go
@@ -20,9 +20,6 @@ type AsyncJobResult struct {
 	JobID           string           `json:"jobid"`
 }
 
-// QueryAsyncJobResultResponse represents the current status of an asynchronous job
-type QueryAsyncJobResultResponse AsyncJobResult
-
 // ListAsyncJobs list the asynchronous jobs
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listAsyncJobs.html

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package egoscale
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -16,97 +17,96 @@ func TestClientAPIName(t *testing.T) {
 }
 
 func TestClientSyncDelete(t *testing.T) {
-	respSuccessString := response{200, `
-{"deleteresponse": {
+	bodySuccessString := `
+{"delete%sresponse": {
 	"success": "true"
-}}`}
-	respSuccessBool := response{200, `
-{"deleteresponse": {
+}}`
+	bodySuccessBool := `
+{"delete%sresponse": {
 	"success": true
-}}`}
+}}`
 
-	respError := response{431, `
-{"deleteresponse": {
+	bodyError := `
+{"delete%sresponse": {
 	"errorcode": 431,
 	"cserrorcode": 9999,
 	"errortext": "This is a dummy error",
 	"uuidList": []
-}}`}
-	// those examples are not real as the API should always answer
-	// with the above kind of response
-	respErrorString := response{200, `
-{"deleteresponse": {
-	"success": "false",
-	"displaytext": "herp derp"
-}}`}
-	respErrorBool := response{200, `
-{"deleteresponse": {
-	"success": false,
-	"displaytext": "herp derp"
-}}`}
+}}`
 
-	things := []Deletable{
-		&SecurityGroup{ID: "test"},
-		&SecurityGroup{Name: "test"},
-		&SSHKeyPair{Name: "test"},
+	things := []struct {
+		name      string
+		deletable Deletable
+	}{
+		{"securitygroup", &SecurityGroup{ID: "test"}},
+		{"securitygroup", &SecurityGroup{Name: "test"}},
+		{"sshkeypair", &SSHKeyPair{Name: "test"}},
 	}
 
 	for _, thing := range things {
-		ts := newServer(respSuccessString, respSuccessBool, respError, respErrorString, respErrorBool)
+		ts := newServer(
+			response{200, fmt.Sprintf(bodySuccessString, thing.name)},
+			response{200, fmt.Sprintf(bodySuccessBool, thing.name)},
+			response{431, fmt.Sprintf(bodyError, thing.name)},
+		)
 		defer ts.Close()
 
 		cs := NewClient(ts.URL, "KEY", "SECRET")
 
 		for i := 0; i < 2; i++ {
-			if err := cs.Delete(thing); err != nil {
+			if err := cs.Delete(thing.deletable); err != nil {
 				t.Errorf("Deletion of %#v. Err: %s", thing, err)
 			}
 		}
 
-		for i := 0; i < 3; i++ {
-			if err := cs.Delete(thing); err == nil {
-				t.Errorf("Deletion of %v an error was expected", thing)
-			}
+		if err := cs.Delete(thing.deletable); err == nil {
+			t.Errorf("Deletion of %v an error was expected", thing)
 		}
 	}
 }
 
 func TestClientAsyncDelete(t *testing.T) {
-	resp := response{200, `
-{"deleteresponse": {
+	body := `
+{"%sresponse": {
 	"jobid": "1",
 	"jobresult": {
 		"success": "true"
 	},
 	"jobstatus": 1
-}}`}
-	respError := response{400, `
-{"deleteresponse": {
+}}`
+	bodyError := `
+{"%sresponse": {
 	"jobid": "1",
 	"jobresult": {
 		"success": false,
 		"displaytext": "herp derp",
 	},
 	"jobstatus": 2
-}}`}
+}}`
 
-	things := []Deletable{
-		&AffinityGroup{ID: "affinity group id"},
-		&AffinityGroup{Name: "affinity group name"},
-		&IPAddress{ID: "ip address id"},
-		&VirtualMachine{ID: "virtual machine id"},
+	things := []struct {
+		name      string
+		deletable Deletable
+	}{
+		{"deleteaffinitygroup", &AffinityGroup{ID: "affinity group id"}},
+		{"deleteaffinitygroup", &AffinityGroup{Name: "affinity group name"}},
+		{"disassociateipaddress", &IPAddress{ID: "ip address id"}},
+		{"destroyvirtualmachine", &VirtualMachine{ID: "virtual machine id"}},
 	}
 
 	for _, thing := range things {
-		ts := newServer(resp, respError)
+		ts := newServer(
+			response{200, fmt.Sprintf(body, thing.name)},
+			response{400, fmt.Sprintf(bodyError, thing.name)},
+		)
 		defer ts.Close()
 
 		cs := NewClient(ts.URL, "KEY", "SECRET")
 
-		if err := cs.Delete(thing); err != nil {
+		if err := cs.Delete(thing.deletable); err != nil {
 			t.Errorf("Deletion of %#v. Err: %s", thing, err)
 		}
-		if err := cs.Delete(thing); err == nil {
+		if err := cs.Delete(thing.deletable); err == nil {
 			t.Errorf("Deletion of %#v. An error was expected", thing)
 		}
 	}
@@ -133,39 +133,45 @@ func TestClientDeleteFailure(t *testing.T) {
 }
 
 func TestClientGetNone(t *testing.T) {
-	resp := response{200, `{"listfooresponse": {}}`}
-	respError := response{400, `{"listfooresponse": {
+	body := `{"list%sresponse": {}}`
+	bodyError := `{"list%sresponse": {
 		"cserrorcode": 9999,
 		"errorcode": 431,
 		"errortext": "Unable to execute API command due to invalid value.",
 		"uuidList": []
-	}}`}
+	}}`
 
-	things := []Gettable{
-		&Zone{ID: "1"},
-		&Zone{Name: "test zone"},
-		&IPAddress{ID: "1"},
-		&IPAddress{IPAddress: net.ParseIP("127.0.0.1")},
-		&SSHKeyPair{Name: "1"},
-		&SSHKeyPair{Fingerprint: "test ssh keypair"},
-		&AffinityGroup{ID: "1"},
-		&AffinityGroup{Name: "test affinity group"},
-		&SecurityGroup{ID: "1"},
-		&SecurityGroup{Name: "test affinity group"},
-		&VirtualMachine{ID: "1"},
-		&Volume{ID: "1"},
-		&Template{ID: "1", IsFeatured: true},
-		&ServiceOffering{ID: "1"},
+	things := []struct {
+		name     string
+		gettable Gettable
+	}{
+		{"zones", &Zone{ID: "1"}},
+		{"zones", &Zone{Name: "test zone"}},
+		{"publicipaddresses", &IPAddress{ID: "1"}},
+		{"publicipaddresses", &IPAddress{IPAddress: net.ParseIP("127.0.0.1")}},
+		{"sshkeypairs", &SSHKeyPair{Name: "1"}},
+		{"sshkeypairs", &SSHKeyPair{Fingerprint: "test ssh keypair"}},
+		{"affinitygroups", &AffinityGroup{ID: "1"}},
+		{"affinitygroups", &AffinityGroup{Name: "test affinity group"}},
+		{"securitygroups", &SecurityGroup{ID: "1"}},
+		{"securitygroups", &SecurityGroup{Name: "test affinity group"}},
+		{"virtualmachines", &VirtualMachine{ID: "1"}},
+		{"volumes", &Volume{ID: "1"}},
+		{"templates", &Template{ID: "1", IsFeatured: true}},
+		{"serviceofferings", &ServiceOffering{ID: "1"}},
 	}
 
 	for _, thing := range things {
-		ts := newServer(resp, respError)
+		ts := newServer(
+			response{200, fmt.Sprintf(body, thing.name)},
+			response{431, fmt.Sprintf(bodyError, thing.name)},
+		)
 		defer ts.Close()
 
 		cs := NewClient(ts.URL, "KEY", "SECRET")
 
 		for _, text := range []string{"not found", "due to invalid value"} {
-			err := cs.Get(thing)
+			err := cs.Get(thing.gettable)
 			if err == nil {
 				t.Errorf("An error was expected")
 				continue
@@ -185,7 +191,8 @@ func TestClientGetNone(t *testing.T) {
 }
 
 func TestClientGetTooMany(t *testing.T) {
-	resp := response{200, `{"listfooresponse": {
+	body := `
+	{"list%sresponse": {
 		"count": 2,
 		"affinitygroup": [{}, {}],
 		"publicipaddress": [{}, {}],
@@ -196,33 +203,37 @@ func TestClientGetTooMany(t *testing.T) {
 		"zone": [{}, {}],
 		"template": [{}, {}],
 		"serviceoffering": [{}, {}]
-	}}`}
+	}}`
 
-	things := []Gettable{
-		&Zone{ID: "1"},
-		&Zone{Name: "test zone"},
-		&IPAddress{ID: "1"},
-		&IPAddress{IPAddress: net.ParseIP("127.0.0.1")},
-		&SSHKeyPair{Name: "1"},
-		&SSHKeyPair{Fingerprint: "test ssh keypair"},
-		&AffinityGroup{ID: "1"},
-		&AffinityGroup{Name: "test affinity group"},
-		&SecurityGroup{ID: "1"},
-		&SecurityGroup{Name: "test affinity group"},
-		&VirtualMachine{ID: "1"},
-		&Volume{ID: "1"},
-		&Template{ID: "1", IsFeatured: true},
-		&ServiceOffering{ID: "1"},
+	things := []struct {
+		name     string
+		gettable Gettable
+	}{
+		{"zones", &Zone{ID: "1"}},
+		{"zones", &Zone{Name: "test zone"}},
+		{"publicipaddresses", &IPAddress{ID: "1"}},
+		{"publicipaddresses", &IPAddress{IPAddress: net.ParseIP("127.0.0.1")}},
+		{"sshkeypairs", &SSHKeyPair{Name: "1"}},
+		{"sshkeypairs", &SSHKeyPair{Fingerprint: "test ssh keypair"}},
+		{"affinitygroups", &AffinityGroup{ID: "1"}},
+		{"affinitygroups", &AffinityGroup{Name: "test affinity group"}},
+		{"securitygroups", &SecurityGroup{ID: "1"}},
+		{"securitygroups", &SecurityGroup{Name: "test affinity group"}},
+		{"virtualmachines", &VirtualMachine{ID: "1"}},
+		{"volumes", &Volume{ID: "1"}},
+		{"templates", &Template{ID: "1", IsFeatured: true}},
+		{"serviceofferings", &ServiceOffering{ID: "1"}},
 	}
 
 	for _, thing := range things {
+		resp := response{200, fmt.Sprintf(body, thing.name)}
 		ts := newServer(resp)
 		defer ts.Close()
 
 		cs := NewClient(ts.URL, "KEY", "SECRET")
 
 		// Too many
-		err := cs.Get(thing)
+		err := cs.Get(thing.gettable)
 
 		if err == nil {
 			t.Errorf("An error was expected")

--- a/client_test.go
+++ b/client_test.go
@@ -176,7 +176,7 @@ func TestClientGetFailure(t *testing.T) {
 
 func TestClientGetNone(t *testing.T) {
 	body := `{"list%sresponse": {}}`
-	bodyError := `{"list%sresponse": {
+	bodyError := `{"errorresponse": {
 		"cserrorcode": 9999,
 		"errorcode": 431,
 		"errortext": "Unable to execute API command due to invalid value.",
@@ -206,7 +206,7 @@ func TestClientGetNone(t *testing.T) {
 	for _, thing := range things {
 		ts := newServer(
 			response{200, fmt.Sprintf(body, thing.name)},
-			response{431, fmt.Sprintf(bodyError, thing.name)},
+			response{431, bodyError},
 		)
 		defer ts.Close()
 

--- a/cmd/cs/README.md
+++ b/cmd/cs/README.md
@@ -20,14 +20,30 @@ $ go install github.com/exoscale/egoscale/cmd/cs
 Create a config file `cloudstack.ini` or `$HOME/.cloudstack.ini`.
 
 ```ini
-; Exoscale credentials
+; Default region
 [cloudstack]
+
+; Exoscale credential
 endpoint = https://api.exoscale.ch/compute
 key = EXO...
 secret = ...
 
-; Pygments theme, see: https://xyproto.github.io/splash/docs/
+theme = fruity
+
+
+; Another region
+[cloudstack:production]
+
+endpoint = https://api.exoscale.ch/compute
+key = EXO...
+secret = ...
+
+theme = vim
+
+
+; global config for themes
 [exoscale]
+; Pygments theme, see: https://xyproto.github.io/splash/docs/
 ; dark
 theme = monokai
 ; light
@@ -38,4 +54,19 @@ theme = nocolors
 
 ### Themes
 
-Thanks to [Alec Thomas](http://swapoff.org/)' [chroma](https://github.com/alecthomas/chroma), it supports many themes for your output: <https://xyproto.github.io/splash/docs/>
+Thanks to [Alec Thomas](http://swapoff.org/)' [chroma](https://github.com/alecthomas/chroma), it supports many themes for your output:
+
+- <https://xyproto.github.io/splash/docs/>
+- <https://help.farbox.com/pygments.html>
+
+## Usage
+
+Some of the flags around a command.
+
+```
+$ cs (-h | --help)              global help
+$ cs <command> (-h | --help)    help of a specific command
+$ cs <command> (-d | --debug)   show the command and its expected output
+$ cs <command> (-D | --dry-run) show the signed command
+$ cs (-r | --region) <region>   specify a different region, default `cloudstack`
+```

--- a/cmd/cs/flags.go
+++ b/cmd/cs/flags.go
@@ -214,7 +214,7 @@ func (g *tagGeneric) Set(value string) error {
 
 func (g *tagGeneric) String() string {
 	m := g.value
-	if *m == nil {
+	if m == nil || *m == nil {
 		return ""
 	}
 	vs := make([]string, 0, len(*m))

--- a/dns.go
+++ b/dns.go
@@ -73,7 +73,7 @@ func (req *DNSErrorResponse) Error() error {
 }
 
 // CreateDomain creates a DNS domain
-func (exo *Client) CreateDomain(name string) (*DNSDomain, error) {
+func (client *Client) CreateDomain(name string) (*DNSDomain, error) {
 	m, err := json.Marshal(DNSDomainResponse{
 		Domain: &DNSDomain{
 			Name: name,
@@ -83,7 +83,7 @@ func (exo *Client) CreateDomain(name string) (*DNSDomain, error) {
 		return nil, err
 	}
 
-	resp, err := exo.dnsRequest("/v1/domains", string(m), "POST")
+	resp, err := client.dnsRequest("/v1/domains", string(m), "POST")
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ func (exo *Client) CreateDomain(name string) (*DNSDomain, error) {
 }
 
 // GetDomain gets a DNS domain
-func (exo *Client) GetDomain(name string) (*DNSDomain, error) {
-	resp, err := exo.dnsRequest("/v1/domains/"+name, "", "GET")
+func (client *Client) GetDomain(name string) (*DNSDomain, error) {
+	resp, err := client.dnsRequest("/v1/domains/"+name, "", "GET")
 	if err != nil {
 		return nil, err
 	}
@@ -112,8 +112,8 @@ func (exo *Client) GetDomain(name string) (*DNSDomain, error) {
 }
 
 // DeleteDomain delets a DNS domain
-func (exo *Client) DeleteDomain(name string) error {
-	_, err := exo.dnsRequest("/v1/domains/"+name, "", "DELETE")
+func (client *Client) DeleteDomain(name string) error {
+	_, err := client.dnsRequest("/v1/domains/"+name, "", "DELETE")
 	if err != nil {
 		return err
 	}
@@ -122,9 +122,9 @@ func (exo *Client) DeleteDomain(name string) error {
 }
 
 // GetRecord returns a DNS record
-func (exo *Client) GetRecord(domain string, recordID int64) (*DNSRecord, error) {
+func (client *Client) GetRecord(domain string, recordID int64) (*DNSRecord, error) {
 	id := strconv.FormatInt(recordID, 10)
-	resp, err := exo.dnsRequest("/v1/domains/"+domain+"/records/"+id, "", "GET")
+	resp, err := client.dnsRequest("/v1/domains/"+domain+"/records/"+id, "", "GET")
 	if err != nil {
 		return nil, err
 	}
@@ -138,8 +138,8 @@ func (exo *Client) GetRecord(domain string, recordID int64) (*DNSRecord, error) 
 }
 
 // GetRecords returns the DNS records
-func (exo *Client) GetRecords(name string) ([]DNSRecord, error) {
-	resp, err := exo.dnsRequest("/v1/domains/"+name+"/records", "", "GET")
+func (client *Client) GetRecords(name string) ([]DNSRecord, error) {
+	resp, err := client.dnsRequest("/v1/domains/"+name+"/records", "", "GET")
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (exo *Client) GetRecords(name string) ([]DNSRecord, error) {
 }
 
 // CreateRecord creates a DNS record
-func (exo *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
+func (client *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
 	body, err := json.Marshal(DNSRecordResponse{
 		Record: rec,
 	})
@@ -166,7 +166,7 @@ func (exo *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 		return nil, err
 	}
 
-	resp, err := exo.dnsRequest("/v1/domains/"+name+"/records", string(body), "POST")
+	resp, err := client.dnsRequest("/v1/domains/"+name+"/records", string(body), "POST")
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (exo *Client) CreateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 }
 
 // UpdateRecord updates a DNS record
-func (exo *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
+func (client *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) {
 	body, err := json.Marshal(DNSRecordResponse{
 		Record: rec,
 	})
@@ -189,7 +189,7 @@ func (exo *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 	}
 
 	id := strconv.FormatInt(rec.ID, 10)
-	resp, err := exo.dnsRequest("/v1/domains/"+name+"/records/"+id, string(body), "PUT")
+	resp, err := client.dnsRequest("/v1/domains/"+name+"/records/"+id, string(body), "PUT")
 	if err != nil {
 		return nil, err
 	}
@@ -203,22 +203,22 @@ func (exo *Client) UpdateRecord(name string, rec DNSRecord) (*DNSRecord, error) 
 }
 
 // DeleteRecord deletes a record
-func (exo *Client) DeleteRecord(name string, recordID int64) error {
+func (client *Client) DeleteRecord(name string, recordID int64) error {
 	id := strconv.FormatInt(recordID, 10)
-	_, err := exo.dnsRequest("/v1/domains/"+name+"/records/"+id, "", "DELETE")
+	_, err := client.dnsRequest("/v1/domains/"+name+"/records/"+id, "", "DELETE")
 
 	return err
 }
 
-func (exo *Client) dnsRequest(uri string, params string, method string) (json.RawMessage, error) {
-	url := exo.Endpoint + uri
+func (client *Client) dnsRequest(uri string, params string, method string) (json.RawMessage, error) {
+	url := client.Endpoint + uri
 	req, err := http.NewRequest(method, url, strings.NewReader(params))
 	if err != nil {
 		return nil, err
 	}
 
 	var hdr = make(http.Header)
-	hdr.Add("X-DNS-TOKEN", exo.APIKey+":"+exo.apiSecret)
+	hdr.Add("X-DNS-TOKEN", client.APIKey+":"+client.apiSecret)
 	hdr.Add("User-Agent", fmt.Sprintf("exoscale/egoscale (%v)", Version))
 	hdr.Add("Accept", "application/json")
 	if params != "" {
@@ -226,7 +226,7 @@ func (exo *Client) dnsRequest(uri string, params string, method string) (json.Ra
 	}
 	req.Header = hdr
 
-	response, err := exo.HTTPClient.Do(req)
+	response, err := client.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/doc.go
+++ b/doc.go
@@ -4,7 +4,7 @@ Package egoscale is a mapping for with the CloudStack API (http://cloudstack.apa
 
 Requests and Responses
 
-To build a request, construct the adequate struct. This library expects a pointer for efficiency reasons only. The response is a struct corresponding to the request itself. E.g. DeployVirtualMachine gives DeployVirtualMachineResponse, as a pointer as well to avoid big copies.
+To build a request, construct the adequate struct. This library expects a pointer for efficiency reasons only. The response is a struct corresponding to the data at stake. E.g. DeployVirtualMachine gives a VirtualMachine, as a pointer as well to avoid big copies.
 
 Then everything within the struct is not a pointer. Find below some examples of how egoscale may be used to interact with a CloudStack endpoint, especially Exoscale itself. If anything feels odd or unclear, please let us know: https://github.com/exoscale/egoscale/issues
 
@@ -21,7 +21,7 @@ Then everything within the struct is not a pointer. Find below some examples of 
 		panic(err)
 	}
 
-	vm := resp.(*egoscale.DeployVirtualMachineResponse).VirtualMachine
+	vm := resp.(*egoscale.VirtualMachine)
 	fmt.Printf("Virtual Machine ID: %s\n", vm.ID)
 
 This exemple deploys a virtual machine while controlling the job status as it goes. It enables a finer control over errors, e.g. HTTP timeout, and eventually a way to kill it of (from the client side).
@@ -32,7 +32,7 @@ This exemple deploys a virtual machine while controlling the job status as it go
 		TemplateID:        "...",
 		ZoneID:            "...",
 	}
-	resp := &egoscale.DeployVirtualMachineResponse{}
+	vm := &egoscale.VirtualMachine{}
 
 	fmt.Println("Deployment started")
 	cs.AsyncRequest(req, func(jobResult *egoscale.AsyncJobResult, err error) bool {
@@ -48,7 +48,7 @@ This exemple deploys a virtual machine while controlling the job status as it go
 		}
 
 		// Unmarshal the response into the response struct
-		if err := jobResult.Response(resp); err != nil {
+		if err := jobResult.Response(vm); err != nil {
 			// JSON unmarshaling error
 			panic(err)
 		}
@@ -57,7 +57,7 @@ This exemple deploys a virtual machine while controlling the job status as it go
 		return false
 	})
 
-	fmt.Printf("Virtual Machine ID: %s\n", resp.VirtualMachine.ID)
+	fmt.Printf("Virtual Machine ID: %s\n", vm.ID)
 
 
 APIs
@@ -86,7 +86,7 @@ Security Groups provide a way to isolate traffic to VMs. Rules are added via the
 		Name: "Load balancer",
 		Description: "Opens HTTP/HTTPS ports from the outside world",
 	})
-	securityGroup := resp.(*egoscale.CreateSecurityGroupResponse).SecurityGroup
+	securityGroup := resp.(*egoscale.SecurityGroup)
 
 	resp, err = cs.Request(&egoscale.AuthorizeSecurityGroupIngress{
 		Description:     "SSH traffic",
@@ -97,7 +97,7 @@ Security Groups provide a way to isolate traffic to VMs. Rules are added via the
 		EndPort:         22,
 	})
 	// The modified SecurityGroup is returned
-	securityGroup := resp.(*egoscale.AuthorizeSecurityGroupResponse).SecurityGroup
+	securityGroup := resp.(*egoscale.SecurityGroup)
 
 	// ...
 	err = client.BooleanRequest(&egoscale.DeleteSecurityGroup{

--- a/events_test.go
+++ b/events_test.go
@@ -4,11 +4,6 @@ import (
 	"testing"
 )
 
-func TestEvents(t *testing.T) {
-	var _ Command = (*ListEvents)(nil)
-	var _ Command = (*ListEventTypes)(nil)
-}
-
 func TestListEvents(t *testing.T) {
 	req := &ListEvents{}
 	if req.name() != "listEvents" {

--- a/keypairs.go
+++ b/keypairs.go
@@ -58,7 +58,7 @@ func (*CreateSSHKeyPair) name() string {
 }
 
 func (*CreateSSHKeyPair) response() interface{} {
-	return new(CreateSSHKeyPairResponse)
+	return new(SSHKeyPair)
 }
 
 // name returns the CloudStack API command name
@@ -76,7 +76,7 @@ func (*RegisterSSHKeyPair) name() string {
 }
 
 func (*RegisterSSHKeyPair) response() interface{} {
-	return new(RegisterSSHKeyPairResponse)
+	return new(SSHKeyPair)
 }
 
 // name returns the CloudStack API command name
@@ -118,5 +118,5 @@ func (*ResetSSHKeyForVirtualMachine) name() string {
 }
 
 func (*ResetSSHKeyForVirtualMachine) asyncResponse() interface{} {
-	return new(ResetSSHKeyForVirtualMachineResponse)
+	return new(VirtualMachine)
 }

--- a/keypairs_test.go
+++ b/keypairs_test.go
@@ -9,7 +9,7 @@ func TestResetSSHKeyForVirtualMachine(t *testing.T) {
 	if req.name() != "resetSSHKeyForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*ResetSSHKeyForVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestRegisterSSHKeyPair(t *testing.T) {
@@ -17,7 +17,7 @@ func TestRegisterSSHKeyPair(t *testing.T) {
 	if req.name() != "registerSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*RegisterSSHKeyPairResponse)
+	_ = req.response().(*SSHKeyPair)
 }
 
 func TestCreateSSHKeyPair(t *testing.T) {
@@ -25,7 +25,7 @@ func TestCreateSSHKeyPair(t *testing.T) {
 	if req.name() != "createSSHKeyPair" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*CreateSSHKeyPairResponse)
+	_ = req.response().(*SSHKeyPair)
 }
 
 func TestDeleteSSHKeyPair(t *testing.T) {

--- a/keypairs_type.go
+++ b/keypairs_type.go
@@ -20,11 +20,6 @@ type CreateSSHKeyPair struct {
 	DomainID string `json:"domainid,omitempty" doc:"an optional domainId for the ssh key. If the account parameter is used, domainId must also be used."`
 }
 
-// CreateSSHKeyPairResponse represents the creation of an SSH Key Pair
-type CreateSSHKeyPairResponse struct {
-	KeyPair SSHKeyPair `json:"keypair"`
-}
-
 // DeleteSSHKeyPair represents a new keypair to be created
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/deleteSSHKeyPair.html
@@ -42,11 +37,6 @@ type RegisterSSHKeyPair struct {
 	PublicKey string `json:"publickey" doc:"Public key material of the keypair"`
 	Account   string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainId."`
 	DomainID  string `json:"domainid,omitempty" doc:"an optional domainId for the ssh key. If the account parameter is used, domainId must also be used."`
-}
-
-// RegisterSSHKeyPairResponse represents the creation of an SSH Key Pair
-type RegisterSSHKeyPairResponse struct {
-	KeyPair SSHKeyPair `json:"keypair"`
 }
 
 // ListSSHKeyPairs represents a query for a list of SSH KeyPairs
@@ -79,6 +69,3 @@ type ResetSSHKeyForVirtualMachine struct {
 	Account  string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainId."`
 	DomainID string `json:"domainid,omitempty" doc:"an optional domainId for the virtual machine. If the account parameter is used, domainId must also be used."`
 }
-
-// ResetSSHKeyForVirtualMachineResponse represents the modified VirtualMachine
-type ResetSSHKeyForVirtualMachineResponse VirtualMachineResponse

--- a/network_offerings.go
+++ b/network_offerings.go
@@ -13,5 +13,5 @@ func (*UpdateNetworkOffering) name() string {
 }
 
 func (*UpdateNetworkOffering) response() interface{} {
-	return new(UpdateNetworkOfferingResponse)
+	return new(NetworkOffering)
 }

--- a/network_offerings_test.go
+++ b/network_offerings_test.go
@@ -4,11 +4,6 @@ import (
 	"testing"
 )
 
-func TestNetworkOfferings(t *testing.T) {
-	var _ Command = (*ListNetworkOfferings)(nil)
-	var _ Command = (*UpdateNetworkOffering)(nil)
-}
-
 func TestListNetworkOfferings(t *testing.T) {
 	req := &ListNetworkOfferings{}
 	if req.name() != "listNetworkOfferings" {
@@ -22,5 +17,5 @@ func TestUpdateNetworkOffering(t *testing.T) {
 	if req.name() != "updateNetworkOffering" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*UpdateNetworkOfferingResponse)
+	_ = req.response().(*NetworkOffering)
 }

--- a/network_offerings_type.go
+++ b/network_offerings_type.go
@@ -69,8 +69,3 @@ type UpdateNetworkOffering struct {
 	SortKey          int    `json:"sortkey,omitempty" doc:"sort key of the network offering, integer"`
 	State            string `json:"state,omitempty" doc:"update state for the network offering"`
 }
-
-// UpdateNetworkOfferingResponse represents a newly modified network offering
-type UpdateNetworkOfferingResponse struct {
-	NetworkOffering NetworkOffering `json:"networkoffering"`
-}

--- a/networks.go
+++ b/networks.go
@@ -35,7 +35,7 @@ func (*CreateNetwork) name() string {
 }
 
 func (*CreateNetwork) response() interface{} {
-	return new(CreateNetworkResponse)
+	return new(Network)
 }
 
 func (req *CreateNetwork) onBeforeSend(params *url.Values) error {
@@ -55,7 +55,7 @@ func (*UpdateNetwork) name() string {
 }
 
 func (*UpdateNetwork) asyncResponse() interface{} {
-	return new(UpdateNetworkResponse)
+	return new(Network)
 }
 
 // name returns the CloudStack API command name
@@ -64,7 +64,7 @@ func (*RestartNetwork) name() string {
 }
 
 func (*RestartNetwork) asyncResponse() interface{} {
-	return new(RestartNetworkResponse)
+	return new(Network)
 }
 
 // name returns the CloudStack API command name

--- a/networks_test.go
+++ b/networks_test.go
@@ -25,7 +25,7 @@ func TestCreateNetwork(t *testing.T) {
 	if req.name() != "createNetwork" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*CreateNetworkResponse)
+	_ = req.response().(*Network)
 }
 
 func TestRestartNetwork(t *testing.T) {
@@ -33,7 +33,7 @@ func TestRestartNetwork(t *testing.T) {
 	if req.name() != "restartNetwork" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*RestartNetworkResponse)
+	_ = req.asyncResponse().(*Network)
 }
 
 func TestUpdateNetwork(t *testing.T) {
@@ -41,7 +41,7 @@ func TestUpdateNetwork(t *testing.T) {
 	if req.name() != "updateNetwork" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*UpdateNetworkResponse)
+	_ = req.asyncResponse().(*Network)
 }
 
 func TestDeleteNetwork(t *testing.T) {

--- a/networks_test.go
+++ b/networks_test.go
@@ -5,15 +5,6 @@ import (
 	"testing"
 )
 
-func TestNetworks(t *testing.T) {
-	var _ Taggable = (*Network)(nil)
-	var _ syncCommand = (*CreateNetwork)(nil)
-	var _ AsyncCommand = (*DeleteNetwork)(nil)
-	var _ syncCommand = (*ListNetworks)(nil)
-	var _ AsyncCommand = (*RestartNetwork)(nil)
-	var _ AsyncCommand = (*UpdateNetwork)(nil)
-}
-
 func TestNetwork(t *testing.T) {
 	instance := &Network{}
 	if instance.ResourceType() != "Network" {
@@ -374,7 +365,7 @@ func TestListNetwork(t *testing.T) {
 
 func TestListNetworkEmpty(t *testing.T) {
 	ts := newServer(response{200, `
-{"listNetworksresponse": {
+{"listnetworksresponse": {
 	"count": 0,
 	"network": []
   }}`})
@@ -395,7 +386,7 @@ func TestListNetworkEmpty(t *testing.T) {
 
 func TestListNetworkFailure(t *testing.T) {
 	ts := newServer(response{200, `
-{"listNetworksresponse": {
+{"listnetworksresponse": {
 	"count": 3456,
 	"network": {}
   }}`})
@@ -416,7 +407,7 @@ func TestListNetworkFailure(t *testing.T) {
 
 func TestListNetworkPaginate(t *testing.T) {
 	ts := newServer(response{200, `
-{"listNetworksresponse": {
+{"listnetworksresponse": {
 	"count": 2,
 	"network": [
 	  {
@@ -513,7 +504,7 @@ func TestListNetworkPaginate(t *testing.T) {
 
 func TestFindNetwork(t *testing.T) {
 	ts := newServer(response{200, `
-{"listNetworksresponse": {
+{"listnetworksresponse": {
 	"count": 1,
 	"network": [
 	  {

--- a/networks_type.go
+++ b/networks_type.go
@@ -77,11 +77,6 @@ type ServiceProvider struct {
 	ServiceList                  []string `json:"servicelist,omitempty"`
 }
 
-// NetworkResponse represents a network
-type NetworkResponse struct {
-	Network Network `json:"network"`
-}
-
 // CreateNetwork creates a network
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/createNetwork.html
@@ -110,9 +105,6 @@ type CreateNetwork struct {
 	ZoneID            string `json:"zoneid" doc:"the Zone ID for the network"`
 }
 
-// CreateNetworkResponse represents a freshly created network
-type CreateNetworkResponse NetworkResponse
-
 // UpdateNetwork (Async) updates a network
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateNetwork.html
@@ -128,9 +120,6 @@ type UpdateNetwork struct {
 	NetworkOfferingID string `json:"networkofferingid,omitempty" doc:"network offering ID"`
 }
 
-// UpdateNetworkResponse represents a freshly created network
-type UpdateNetworkResponse NetworkResponse
-
 // RestartNetwork (Async) updates a network
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/restartNetwork.html
@@ -138,9 +127,6 @@ type RestartNetwork struct {
 	ID      string `json:"id" doc:"The id of the network to restart."`
 	Cleanup *bool  `json:"cleanup,omitempty" doc:"If cleanup old network elements"`
 }
-
-// RestartNetworkResponse represents a freshly created network
-type RestartNetworkResponse NetworkResponse
 
 // DeleteNetwork deletes a network
 //

--- a/nics.go
+++ b/nics.go
@@ -47,15 +47,14 @@ func (*ListNics) each(resp interface{}, callback IterateItemFunc) {
 	}
 }
 
-// name returns the CloudStack API command name: addIpToNic
 func (*AddIPToNic) name() string {
 	return "addIpToNic"
 }
+
 func (*AddIPToNic) asyncResponse() interface{} {
-	return new(AddIPToNicResponse)
+	return new(NicSecondaryIP)
 }
 
-// name returns the CloudStack API command name: removeIpFromNic
 func (*RemoveIPFromNic) name() string {
 	return "removeIpFromNic"
 }
@@ -70,5 +69,5 @@ func (*ActivateIP6) name() string {
 }
 
 func (*ActivateIP6) asyncResponse() interface{} {
-	return new(ActivateIP6Response)
+	return new(Nic)
 }

--- a/nics_test.go
+++ b/nics_test.go
@@ -9,7 +9,7 @@ func TestAddIPToNic(t *testing.T) {
 	if req.name() != "addIpToNic" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*AddIPToNicResponse)
+	_ = req.asyncResponse().(*NicSecondaryIP)
 }
 
 func TestRemoveIPFromNic(t *testing.T) {
@@ -33,7 +33,7 @@ func TestActivateIP6(t *testing.T) {
 	if req.name() != "activateIp6" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*ActivateIP6Response)
+	_ = req.asyncResponse().(*Nic)
 }
 
 func TestListNics(t *testing.T) {

--- a/nics_type.go
+++ b/nics_type.go
@@ -64,11 +64,6 @@ type AddIPToNic struct {
 	IPAddress net.IP `json:"ipaddress,omitempty" doc:"Secondary IP Address"`
 }
 
-// AddIPToNicResponse represents the addition of an IP to a NIC
-type AddIPToNicResponse struct {
-	NicSecondaryIP NicSecondaryIP `json:"nicsecondaryip"`
-}
-
 // RemoveIPFromNic (Async) represents a deletion request
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/removeIpFromNic.html
@@ -81,9 +76,4 @@ type RemoveIPFromNic struct {
 // Exoscale specific API: https://community.exoscale.ch/api/compute/#activateip6_GET
 type ActivateIP6 struct {
 	NicID string `json:"nicid" doc:"the ID of the nic to which you want to assign the IPv6"`
-}
-
-// ActivateIP6Response represents the modified NIC
-type ActivateIP6Response struct {
-	Nic Nic `json:"nic"`
 }

--- a/request.go
+++ b/request.go
@@ -66,6 +66,10 @@ func (client *Client) parseResponse(resp *http.Response, key string) (json.RawMe
 		return nil, err
 	}
 
+	if resp.StatusCode >= 400 {
+		key = "errorresponse"
+	}
+
 	response, ok := m[key]
 	if !ok {
 		for k := range m {

--- a/request.go
+++ b/request.go
@@ -92,7 +92,9 @@ func (client *Client) parseResponse(resp *http.Response, key string) (json.RawMe
 
 	if len(n) == 1 {
 		for k := range n {
-			if k == "success" {
+			// boolean response and asyncjob result may also contain
+			// only one key
+			if k == "success" || k == "jobid" {
 				return response, nil
 			}
 			return n[k], nil

--- a/request.go
+++ b/request.go
@@ -257,19 +257,19 @@ func (exo *Client) AsyncRequestWithContext(ctx context.Context, request AsyncCom
 			return
 		}
 
-		result, ok := resp.(*QueryAsyncJobResultResponse)
-		if !ok && !callback(nil, fmt.Errorf("AsyncJobResult expected, got %t", resp)) {
-			return
+		result, ok := resp.(*AsyncJobResult)
+		if !ok {
+			if !callback(nil, fmt.Errorf("AsyncJobResult expected, got %t", resp)) {
+				return
+			}
 		}
 
-		res := (*AsyncJobResult)(result)
-
-		if res.JobStatus == Failure {
-			if !callback(nil, res.Error()) {
+		if result.JobStatus == Failure {
+			if !callback(nil, result.Error()) {
 				return
 			}
 		} else {
-			if !callback(res, nil) {
+			if !callback(result, nil) {
 				return
 			}
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -235,7 +235,7 @@ func TestAsyncRequestWithoutContext(t *testing.T) {
 		TemplateID:        "78c2cbe6-8e11-4722-b01f-bf06f4e28108",
 	}
 
-	resp := &DeployVirtualMachineResponse{}
+	resp := &VirtualMachine{}
 
 	// WithContext
 	cs.AsyncRequest(req, func(j *AsyncJobResult, err error) bool {
@@ -245,7 +245,6 @@ func TestAsyncRequestWithoutContext(t *testing.T) {
 		}
 
 		if j.JobStatus == Success {
-
 			if r := j.Response(resp); r != nil {
 				t.Error(r)
 			}
@@ -254,8 +253,8 @@ func TestAsyncRequestWithoutContext(t *testing.T) {
 		return true
 	})
 
-	if resp.VirtualMachine.ServiceOfferingID != "71004023-bb72-4a97-b1e9-bc66dfce9470" {
-		t.Errorf("Expected ServiceOfferingID %q, got %q", "71004023-bb72-4a97-b1e9-bc66dfce9470", resp.VirtualMachine.ServiceOfferingID)
+	if resp.ServiceOfferingID != "71004023-bb72-4a97-b1e9-bc66dfce9470" {
+		t.Errorf("Expected ServiceOfferingID %q, got %q", "71004023-bb72-4a97-b1e9-bc66dfce9470", resp.ServiceOfferingID)
 	}
 }
 
@@ -288,7 +287,7 @@ func TestAsyncRequestWithoutContextFailure(t *testing.T) {
 		ZoneID:            "1128bd56-b4d9-4ac6-a7b9-c715b187ce11",
 		TemplateID:        "78c2cbe6-8e11-4722-b01f-bf06f4e28108"}
 
-	resp := &DeployVirtualMachineResponse{}
+	resp := &VirtualMachine{}
 
 	// WithContext
 	cs.AsyncRequest(req, func(j *AsyncJobResult, err error) bool {
@@ -370,7 +369,7 @@ func TestAsyncRequestWithoutContextFailureNextNext(t *testing.T) {
 		ZoneID:            "1128bd56-b4d9-4ac6-a7b9-c715b187ce11",
 		TemplateID:        "78c2cbe6-8e11-4722-b01f-bf06f4e28108"}
 
-	resp := &DeployVirtualMachineResponse{}
+	resp := &VirtualMachine{}
 
 	cs.AsyncRequest(req, func(j *AsyncJobResult, err error) bool {
 		if err != nil {

--- a/security_groups.go
+++ b/security_groups.go
@@ -102,7 +102,7 @@ func (*CreateSecurityGroup) name() string {
 }
 
 func (*CreateSecurityGroup) response() interface{} {
-	return new(CreateSecurityGroupResponse)
+	return new(SecurityGroup)
 }
 
 // name returns the CloudStack API command name
@@ -120,7 +120,7 @@ func (*AuthorizeSecurityGroupIngress) name() string {
 }
 
 func (*AuthorizeSecurityGroupIngress) asyncResponse() interface{} {
-	return new(AuthorizeSecurityGroupIngressResponse)
+	return new(SecurityGroup)
 }
 
 func (req *AuthorizeSecurityGroupIngress) onBeforeSend(params *url.Values) error {
@@ -142,7 +142,7 @@ func (*AuthorizeSecurityGroupEgress) name() string {
 }
 
 func (*AuthorizeSecurityGroupEgress) asyncResponse() interface{} {
-	return new(AuthorizeSecurityGroupEgressResponse)
+	return new(SecurityGroup)
 }
 
 func (req *AuthorizeSecurityGroupEgress) onBeforeSend(params *url.Values) error {

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -5,19 +5,6 @@ import (
 	"testing"
 )
 
-func TestGroupsRequests(t *testing.T) {
-	var _ Taggable = (*SecurityGroup)(nil)
-	var _ AsyncCommand = (*AuthorizeSecurityGroupEgress)(nil)
-	var _ onBeforeHook = (*AuthorizeSecurityGroupEgress)(nil)
-	var _ AsyncCommand = (*AuthorizeSecurityGroupIngress)(nil)
-	var _ onBeforeHook = (*AuthorizeSecurityGroupIngress)(nil)
-	var _ syncCommand = (*CreateSecurityGroup)(nil)
-	var _ syncCommand = (*DeleteSecurityGroup)(nil)
-	var _ syncCommand = (*ListSecurityGroups)(nil)
-	var _ AsyncCommand = (*RevokeSecurityGroupEgress)(nil)
-	var _ AsyncCommand = (*RevokeSecurityGroupIngress)(nil)
-}
-
 func TestSecurityGroup(t *testing.T) {
 	instance := &SecurityGroup{}
 	if instance.ResourceType() != "SecurityGroup" {
@@ -30,7 +17,7 @@ func TestAuthorizeSecurityGroupEgress(t *testing.T) {
 	if req.name() != "authorizeSecurityGroupEgress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*AuthorizeSecurityGroupEgressResponse)
+	_ = req.asyncResponse().(*SecurityGroup)
 }
 
 func TestAuthorizeSecurityGroupIngress(t *testing.T) {
@@ -38,7 +25,7 @@ func TestAuthorizeSecurityGroupIngress(t *testing.T) {
 	if req.name() != "authorizeSecurityGroupIngress" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*AuthorizeSecurityGroupIngressResponse)
+	_ = req.asyncResponse().(*SecurityGroup)
 }
 
 func TestCreateSecurityGroup(t *testing.T) {
@@ -46,7 +33,7 @@ func TestCreateSecurityGroup(t *testing.T) {
 	if req.name() != "createSecurityGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*CreateSecurityGroupResponse)
+	_ = req.response().(*SecurityGroup)
 }
 
 func TestDeleteSecurityGroup(t *testing.T) {

--- a/security_groups_type.go
+++ b/security_groups_type.go
@@ -39,11 +39,6 @@ type UserSecurityGroup struct {
 	Account string `json:"account,omitempty"`
 }
 
-// SecurityGroupResponse represents a generic security group response
-type SecurityGroupResponse struct {
-	SecurityGroup SecurityGroup `json:"securitygroup"`
-}
-
 // CreateSecurityGroup represents a security group creation
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/createSecurityGroup.html
@@ -53,9 +48,6 @@ type CreateSecurityGroup struct {
 	Description string `json:"description,omitempty" doc:"the description of the security group"`
 	DomainID    string `json:"domainid,omitempty" doc:"an optional domainId for the security group. If the account parameter is used, domainId must also be used."`
 }
-
-// CreateSecurityGroupResponse represents a new security group
-type CreateSecurityGroupResponse SecurityGroupResponse
 
 // DeleteSecurityGroup represents a security group deletion
 //
@@ -85,18 +77,10 @@ type AuthorizeSecurityGroupIngress struct {
 	UserSecurityGroupList []UserSecurityGroup `json:"usersecuritygrouplist,omitempty" doc:"user to security group mapping"`
 }
 
-// AuthorizeSecurityGroupIngressResponse represents the new egress rule
-// /!\ the Cloud Stack API document is not fully accurate. /!\
-type AuthorizeSecurityGroupIngressResponse SecurityGroupResponse
-
 // AuthorizeSecurityGroupEgress (Async) represents the egress rule creation
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/authorizeSecurityGroupEgress.html
 type AuthorizeSecurityGroupEgress AuthorizeSecurityGroupIngress
-
-// AuthorizeSecurityGroupEgressResponse represents the new egress rule
-// /!\ the Cloud Stack API document is not fully accurate. /!\
-type AuthorizeSecurityGroupEgressResponse CreateSecurityGroupResponse
 
 // RevokeSecurityGroupIngress (Async) represents the ingress/egress rule deletion
 //

--- a/serialization.go
+++ b/serialization.go
@@ -2,7 +2,6 @@ package egoscale
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -21,28 +20,6 @@ func csQuotePlus(s string) string {
 
 func csEncode(s string) string {
 	return csQuotePlus(url.QueryEscape(s))
-}
-
-func rawValue(b json.RawMessage) (json.RawMessage, error) {
-	var m map[string]json.RawMessage
-
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
-	}
-	for _, v := range m {
-		return v, nil
-	}
-	return nil, nil
-}
-
-func rawValues(b json.RawMessage) (json.RawMessage, error) {
-	var i []json.RawMessage
-
-	if err := json.Unmarshal(b, &i); err != nil {
-		return nil, nil
-	}
-
-	return i[0], nil
 }
 
 // prepareValues uses a command to build a POST request

--- a/snapshots.go
+++ b/snapshots.go
@@ -11,12 +11,7 @@ func (*CreateSnapshot) name() string {
 }
 
 func (*CreateSnapshot) asyncResponse() interface{} {
-	return new(CreateSnapshotResponse)
-}
-
-// CreateSnapshotResponse represents a freshly created snapshot
-type CreateSnapshotResponse struct {
-	Snapshot Snapshot `json:"snapshot"`
+	return new(Snapshot)
 }
 
 // name returns the CloudStack API command name
@@ -26,12 +21,6 @@ func (*ListSnapshots) name() string {
 
 func (*ListSnapshots) response() interface{} {
 	return new(ListSnapshotsResponse)
-}
-
-// ListSnapshotsResponse represents a list of volume snapshots
-type ListSnapshotsResponse struct {
-	Count    int        `json:"count"`
-	Snapshot []Snapshot `json:"snapshot"`
 }
 
 // name returns the CloudStack API command name

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -16,7 +16,7 @@ func TestCreateSnapshot(t *testing.T) {
 	if req.name() != "createSnapshot" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*CreateSnapshotResponse)
+	_ = req.asyncResponse().(*Snapshot)
 }
 
 func TestListSnapshots(t *testing.T) {

--- a/snapshots_type.go
+++ b/snapshots_type.go
@@ -81,6 +81,12 @@ type ListSnapshots struct {
 	ZoneID       string        `json:"zoneid,omitempty" doc:"list snapshots by zone id"`
 }
 
+// ListSnapshotsResponse represents a list of volume snapshots
+type ListSnapshotsResponse struct {
+	Count    int        `json:"count"`
+	Snapshot []Snapshot `json:"snapshot"`
+}
+
 // DeleteSnapshot (Async) deletes a snapshot of a disk volume
 //
 // CloudStackAPI: http://cloudstack.apache.org/api/apidocs-4.10/apis/deleteSnapshot.html

--- a/templates.go
+++ b/templates.go
@@ -105,7 +105,7 @@ func (*CreateTemplate) name() string {
 }
 
 func (*CreateTemplate) asyncResponse() interface{} {
-	return new(CreateTemplateResponse)
+	return new(Template)
 }
 
 func (*PrepareTemplate) name() string {
@@ -113,7 +113,7 @@ func (*PrepareTemplate) name() string {
 }
 
 func (*PrepareTemplate) asyncResponse() interface{} {
-	return new(PrepareTemplateResponse)
+	return new(Template)
 }
 
 func (*CopyTemplate) name() string {
@@ -121,7 +121,7 @@ func (*CopyTemplate) name() string {
 }
 
 func (*CopyTemplate) asyncResponse() interface{} {
-	return new(CopyTemplateResponse)
+	return new(Template)
 }
 
 func (*UpdateTemplate) name() string {
@@ -129,7 +129,7 @@ func (*UpdateTemplate) name() string {
 }
 
 func (*UpdateTemplate) asyncResponse() interface{} {
-	return new(UpdateTemplateResponse)
+	return new(Template)
 }
 
 func (*DeleteTemplate) name() string {
@@ -145,5 +145,5 @@ func (*RegisterTemplate) name() string {
 }
 
 func (*RegisterTemplate) response() interface{} {
-	return new(RegisterTemplateResponse)
+	return new(Template)
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -16,7 +16,7 @@ func TestCreateTemplate(t *testing.T) {
 	if req.name() != "createTemplate" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*CreateTemplateResponse)
+	_ = req.asyncResponse().(*Template)
 }
 
 func TestCopyTemplate(t *testing.T) {
@@ -24,7 +24,7 @@ func TestCopyTemplate(t *testing.T) {
 	if req.name() != "copyTemplate" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*CopyTemplateResponse)
+	_ = req.asyncResponse().(*Template)
 }
 
 func TestUpdateTemplate(t *testing.T) {
@@ -32,7 +32,7 @@ func TestUpdateTemplate(t *testing.T) {
 	if req.name() != "updateTemplate" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*UpdateTemplateResponse)
+	_ = req.asyncResponse().(*Template)
 }
 
 func TestListTemplates(t *testing.T) {
@@ -56,7 +56,7 @@ func TestPrepareTemplate(t *testing.T) {
 	if req.name() != "prepareTemplate" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*PrepareTemplateResponse)
+	_ = req.asyncResponse().(*Template)
 }
 
 func TestRegisterTemplate(t *testing.T) {
@@ -64,7 +64,7 @@ func TestRegisterTemplate(t *testing.T) {
 	if req.name() != "registerTemplate" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*RegisterTemplateResponse)
+	_ = req.response().(*Template)
 }
 
 func TestTemplate(t *testing.T) {

--- a/templates_test.go
+++ b/templates_test.go
@@ -77,7 +77,7 @@ func TestTemplate(t *testing.T) {
 func TestTemplateGet(t *testing.T) {
 	ts := newServer(response{200, `
 		
-		{ "listtemplateresponse": {
+		{ "listtemplatesresponse": {
 			"count": 1,
 			"template": [
 			  {
@@ -128,7 +128,7 @@ func TestTemplateGet(t *testing.T) {
 func TestListTemplate(t *testing.T) {
 	ts := newServer(response{200, `
 		
-		{ "listtemplateresponse": {
+		{ "listtemplatesresponse": {
 			"count": 1,
 			"template": [
 			  {
@@ -190,73 +190,73 @@ func TestListTemplate(t *testing.T) {
 }
 
 func TestListTemplatesPaginate(t *testing.T) {
-	ts := newServer(response{200, `
-		
-		{ "listtemplateresponse": {
-			"count": 2,
-			"template": [
-				{
-					"account": "exostack",
-					"checksum": "3c80c71fcfe1e2e88c12ca7d39c294a0",
-					"created": "2018-01-30T09:16:05+0100",
-					"crossZones": false,
-					"details": {
-					  "username": "debian"
-					},
-					"displaytext": "Linux Debian 9 64-bit 200G Disk (2018-01-18-25e9ec)",
-					"domain": "ROOT",
-					"domainid": "4a8857b8-7235-4e31-a7ef-b8b44d180850",
-					"format": "QCOW2",
-					"hypervisor": "KVM",
-					"id": "a8a4b773-32ce-4d1c-a19b-21da055ec5c6",
-					"isdynamicallyscalable": false,
-					"isextractable": false,
-					"isfeatured": true,
-					"ispublic": true,
-					"isready": true,
-					"name": "Linux Debian 9 64-bit",
-					"ostypeid": "113038d0-a8cd-4d20-92be-ea313f87c3ac",
-					"ostypename": "Other PV (64-bit)",
-					"passwordenabled": true,
-					"size": 214748364800,
-					"sshkeyenabled": false,
-					"tags": [],
-					"templatetype": "USER",
-					"zoneid": "4da1b188-dcd6-4ff5-b7fd-bde984055548",
-					"zonename": "at-vie-1"
-				  },
-				  {
-					"account": "exostack",
-					"checksum": "3c80c71fcfe1e2e88c12ca7d39c294a0",
-					"created": "2018-01-30T09:16:05+0100",
-					"crossZones": false,
-					"details": {
-					  "username": "debian"
-					},
-					"displaytext": "Linux Debian 9 64-bit 200G Disk (2018-01-18-25e9ec)",
-					"domain": "ROOT",
-					"domainid": "4a8857b8-7235-4e31-a7ef-b8b44d180850",
-					"format": "QCOW2",
-					"hypervisor": "KVM",
-					"id": "testesteteteteteet",
-					"isdynamicallyscalable": false,
-					"isextractable": false,
-					"isfeatured": true,
-					"ispublic": true,
-					"isready": true,
-					"name": "Linux Debian 9 64-bit",
-					"ostypeid": "113038d0-a8cd-4d20-92be-ea313f87c3ac",
-					"ostypename": "Other PV (64-bit)",
-					"passwordenabled": true,
-					"size": 214748364800,
-					"sshkeyenabled": false,
-					"tags": [],
-					"templatetype": "USER",
-					"zoneid": "4da1b188-dcd6-4ff5-b7fd-bde984055548",
-					"zonename": "at-vie-1"
-				  }
-			]
-		  }}`})
+	ts := newServer(response{200, `{
+	"listtemplatesresponse": {
+		"count": 2,
+		"template": [
+			{
+				"account": "exostack",
+				"checksum": "3c80c71fcfe1e2e88c12ca7d39c294a0",
+				"created": "2018-01-30T09:16:05+0100",
+				"crossZones": false,
+				"details": {
+				  "username": "debian"
+				},
+				"displaytext": "Linux Debian 9 64-bit 200G Disk (2018-01-18-25e9ec)",
+				"domain": "ROOT",
+				"domainid": "4a8857b8-7235-4e31-a7ef-b8b44d180850",
+				"format": "QCOW2",
+				"hypervisor": "KVM",
+				"id": "a8a4b773-32ce-4d1c-a19b-21da055ec5c6",
+				"isdynamicallyscalable": false,
+				"isextractable": false,
+				"isfeatured": true,
+				"ispublic": true,
+				"isready": true,
+				"name": "Linux Debian 9 64-bit",
+				"ostypeid": "113038d0-a8cd-4d20-92be-ea313f87c3ac",
+				"ostypename": "Other PV (64-bit)",
+				"passwordenabled": true,
+				"size": 214748364800,
+				"sshkeyenabled": false,
+				"tags": [],
+				"templatetype": "USER",
+				"zoneid": "4da1b188-dcd6-4ff5-b7fd-bde984055548",
+				"zonename": "at-vie-1"
+			  },
+			  {
+				"account": "exostack",
+				"checksum": "3c80c71fcfe1e2e88c12ca7d39c294a0",
+				"created": "2018-01-30T09:16:05+0100",
+				"crossZones": false,
+				"details": {
+				  "username": "debian"
+				},
+				"displaytext": "Linux Debian 9 64-bit 200G Disk (2018-01-18-25e9ec)",
+				"domain": "ROOT",
+				"domainid": "4a8857b8-7235-4e31-a7ef-b8b44d180850",
+				"format": "QCOW2",
+				"hypervisor": "KVM",
+				"id": "testesteteteteteet",
+				"isdynamicallyscalable": false,
+				"isextractable": false,
+				"isfeatured": true,
+				"ispublic": true,
+				"isready": true,
+				"name": "Linux Debian 9 64-bit",
+				"ostypeid": "113038d0-a8cd-4d20-92be-ea313f87c3ac",
+				"ostypename": "Other PV (64-bit)",
+				"passwordenabled": true,
+				"size": 214748364800,
+				"sshkeyenabled": false,
+				"tags": [],
+				"templatetype": "USER",
+				"zoneid": "4da1b188-dcd6-4ff5-b7fd-bde984055548",
+				"zonename": "at-vie-1"
+			}
+		]
+	}
+}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")
@@ -269,6 +269,9 @@ func TestListTemplatesPaginate(t *testing.T) {
 	}
 
 	cs.Paginate(req, func(i interface{}, err error) bool {
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if i.(*Template).ID != id {
 			t.Errorf("Expected id '%s' but got %s", id, i.(*Template).ID)
@@ -280,7 +283,7 @@ func TestListTemplatesPaginate(t *testing.T) {
 func TestListTemplatesFailure(t *testing.T) {
 	ts := newServer(response{200, `
 		
-		{ "listtemplateresponse": {
+		{ "listtemplatesresponse": {
 			"count": 1,
 			"template": {}
 		  }}`})

--- a/templates_type.go
+++ b/templates_type.go
@@ -89,11 +89,6 @@ type CreateTemplate struct {
 	VolumeID              string            `json:"volumeid,omitempty" doc:"the ID of the disk volume the template is being created from. Either this parameter, or snapshotId has to be passed in"`
 }
 
-// CreateTemplateResponse represents a freshly created template
-type CreateTemplateResponse struct {
-	Template Template `json:"template"`
-}
-
 // CopyTemplate (Async) represents a template copy
 //
 // CloudStackAPI: http://cloudstack.apache.org/api/apidocs-4.10/apis/copyTemplate.html
@@ -102,9 +97,6 @@ type CopyTemplate struct {
 	ID           string `json:"id" doc:"Template ID."`
 	SourceZoneID string `json:"sourcezoneid,omitempty" doc:"ID of the zone the template is currently hosted on. If not specified and template is cross-zone, then we will sync this template to region wide image store."`
 }
-
-// CopyTemplateResponse represents the copied template
-type CopyTemplateResponse CreateTemplateResponse
 
 // UpdateTemplate represents a template change
 //
@@ -123,9 +115,6 @@ type UpdateTemplate struct {
 	SortKey               int               `json:"sortkey,omitempty" doc:"sort key of the template, integer"`
 }
 
-// UpdateTemplateResponse represents the updated template
-type UpdateTemplateResponse CreateTemplateResponse
-
 // DeleteTemplate (Async) represents the deletion of a template
 //
 // CloudStackAPI: http://cloudstack.apache.org/api/apidocs-4.10/apis/deleteTemplate.html
@@ -141,9 +130,6 @@ type PrepareTemplate struct {
 	TemplateID string `json:"templateid" doc:"template ID of the template to be prepared in primary storage(s)."`
 	ZoneID     string `json:"zoneid" doc:"zone ID of the template to be prepared in primary storage(s)."`
 }
-
-// PrepareTemplateResponse represents the prepared template
-type PrepareTemplateResponse CreateTemplateResponse
 
 // RegisterTemplate represents a template registration
 //
@@ -172,6 +158,3 @@ type RegisterTemplate struct {
 	URL                   string            `json:"url" doc:"the URL of where the template is hosted. Possible URL include http:// and https://"`
 	ZoneID                string            `json:"zoneid" doc:"the ID of the zone the template is to be hosted on"`
 }
-
-// RegisterTemplateResponse represents the registered template
-type RegisterTemplateResponse CreateTemplateResponse

--- a/users.go
+++ b/users.go
@@ -5,7 +5,7 @@ func (*RegisterUserKeys) name() string {
 }
 
 func (*RegisterUserKeys) response() interface{} {
-	return new(RegisterUserKeysResponse)
+	return new(User)
 }
 
 func (*CreateUser) name() string {
@@ -13,7 +13,7 @@ func (*CreateUser) name() string {
 }
 
 func (*CreateUser) response() interface{} {
-	return new(CreateUserResponse)
+	return new(User)
 }
 
 func (*UpdateUser) name() string {
@@ -21,7 +21,7 @@ func (*UpdateUser) name() string {
 }
 
 func (*UpdateUser) response() interface{} {
-	return new(UpdateUserResponse)
+	return new(User)
 }
 
 func (*ListUsers) name() string {

--- a/users_test.go
+++ b/users_test.go
@@ -4,19 +4,12 @@ import (
 	"testing"
 )
 
-func TestUsers(t *testing.T) {
-	var _ Command = (*CreateUser)(nil)
-	var _ Command = (*RegisterUserKeys)(nil)
-	var _ Command = (*UpdateUser)(nil)
-	var _ Command = (*ListUsers)(nil)
-}
-
 func TestCreateUser(t *testing.T) {
 	req := &CreateUser{}
 	if req.name() != "createUser" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*CreateUserResponse)
+	_ = req.response().(*User)
 }
 
 func TestRegisterUserKeys(t *testing.T) {
@@ -24,7 +17,7 @@ func TestRegisterUserKeys(t *testing.T) {
 	if req.name() != "registerUserKeys" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*RegisterUserKeysResponse)
+	_ = req.response().(*User)
 }
 
 func TestUpdateUser(t *testing.T) {
@@ -32,7 +25,7 @@ func TestUpdateUser(t *testing.T) {
 	if req.name() != "updateUser" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*UpdateUserResponse)
+	_ = req.response().(*User)
 }
 
 func TestListUsers(t *testing.T) {

--- a/users_type.go
+++ b/users_type.go
@@ -26,16 +26,11 @@ type User struct {
 
 // RegisterUserKeys registers a new set of key of the given user
 //
+// NB: only the APIKey and SecretKey will be filled
+//
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/registerUserKeys.html
 type RegisterUserKeys struct {
 	ID string `json:"id" doc:"User id"`
-}
-
-// RegisterUserKeysResponse represents a new set of UserKeys
-//
-// NB: only the APIKey and SecretKey will be filled, hence the different key name
-type RegisterUserKeysResponse struct {
-	UserKeys User `json:"userkeys"`
 }
 
 // CreateUser represents the creation of a User
@@ -53,11 +48,6 @@ type CreateUser struct {
 	UserID    string `json:"userid,omitempty" doc:"User UUID, required for adding account from external provisioning system"`
 }
 
-// CreateUserResponse represents the freshly created User
-type CreateUserResponse struct {
-	User User `json:"user"`
-}
-
 // UpdateUser represents the modification of a User
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateUser.html
@@ -72,9 +62,6 @@ type UpdateUser struct {
 	UserName      string `json:"username,omitempty" doc:"Unique username"`
 	UserSecretKey string `json:"usersecretkey,omitempty" doc:"The secret key for the user. Must be specified with userApiKey"`
 }
-
-// UpdateUserResponse represents the freshly modified User
-type UpdateUserResponse CreateUserResponse
 
 // ListUsers represents the search for Users
 //

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.9.24"
+const Version = "0.10.0-SNAPSHOT"

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -277,7 +277,7 @@ func (*GetVMPassword) name() string {
 }
 
 func (*GetVMPassword) response() interface{} {
-	return new(GetVMPasswordResponse)
+	return new(Password)
 }
 
 // name returns the CloudStack API command name

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -154,7 +154,7 @@ func (req *DeployVirtualMachine) onBeforeSend(params *url.Values) error {
 }
 
 func (*DeployVirtualMachine) asyncResponse() interface{} {
-	return new(DeployVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -162,7 +162,7 @@ func (*StartVirtualMachine) name() string {
 	return "startVirtualMachine"
 }
 func (*StartVirtualMachine) asyncResponse() interface{} {
-	return new(StartVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -171,7 +171,7 @@ func (*StopVirtualMachine) name() string {
 }
 
 func (*StopVirtualMachine) asyncResponse() interface{} {
-	return new(StopVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -180,7 +180,7 @@ func (*RebootVirtualMachine) name() string {
 }
 
 func (*RebootVirtualMachine) asyncResponse() interface{} {
-	return new(RebootVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -189,7 +189,7 @@ func (*RestoreVirtualMachine) name() string {
 }
 
 func (*RestoreVirtualMachine) asyncResponse() interface{} {
-	return new(RestoreVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -198,7 +198,7 @@ func (*RecoverVirtualMachine) name() string {
 }
 
 func (*RecoverVirtualMachine) response() interface{} {
-	return new(RecoverVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -207,7 +207,7 @@ func (*DestroyVirtualMachine) name() string {
 }
 
 func (*DestroyVirtualMachine) asyncResponse() interface{} {
-	return new(DestroyVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -216,7 +216,7 @@ func (*UpdateVirtualMachine) name() string {
 }
 
 func (*UpdateVirtualMachine) response() interface{} {
-	return new(UpdateVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -243,7 +243,7 @@ func (*ChangeServiceForVirtualMachine) name() string {
 }
 
 func (*ChangeServiceForVirtualMachine) response() interface{} {
-	return new(ChangeServiceForVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -252,7 +252,7 @@ func (*ResetPasswordForVirtualMachine) name() string {
 }
 
 func (*ResetPasswordForVirtualMachine) asyncResponse() interface{} {
-	return new(ResetPasswordForVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 func (*GetVirtualMachineUserData) name() string {
@@ -260,7 +260,7 @@ func (*GetVirtualMachineUserData) name() string {
 }
 
 func (*GetVirtualMachineUserData) response() interface{} {
-	return new(GetVirtualMachineUserDataResponse)
+	return new(VirtualMachineUserData)
 }
 
 func (*MigrateVirtualMachine) name() string {
@@ -268,7 +268,7 @@ func (*MigrateVirtualMachine) name() string {
 }
 
 func (*MigrateVirtualMachine) asyncResponse() interface{} {
-	return new(MigrateVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -319,7 +319,7 @@ func (*AddNicToVirtualMachine) name() string {
 }
 
 func (*AddNicToVirtualMachine) asyncResponse() interface{} {
-	return new(AddNicToVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -328,7 +328,7 @@ func (*RemoveNicFromVirtualMachine) name() string {
 }
 
 func (*RemoveNicFromVirtualMachine) asyncResponse() interface{} {
-	return new(RemoveNicFromVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // name returns the CloudStack API command name
@@ -337,7 +337,7 @@ func (*UpdateDefaultNicForVirtualMachine) name() string {
 }
 
 func (*UpdateDefaultNicForVirtualMachine) asyncResponse() interface{} {
-	return new(UpdateDefaultNicForVirtualMachineResponse)
+	return new(VirtualMachine)
 }
 
 // Decode decodes the base64 / gzipped encoded user data

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -18,7 +18,7 @@ func TestDeployVirtualMachine(t *testing.T) {
 	if req.name() != "deployVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*DeployVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestDestroyVirtualMachine(t *testing.T) {
@@ -26,7 +26,7 @@ func TestDestroyVirtualMachine(t *testing.T) {
 	if req.name() != "destroyVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*DestroyVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestRebootVirtualMachine(t *testing.T) {
@@ -34,7 +34,7 @@ func TestRebootVirtualMachine(t *testing.T) {
 	if req.name() != "rebootVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*RebootVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestStartVirtualMachine(t *testing.T) {
@@ -42,7 +42,7 @@ func TestStartVirtualMachine(t *testing.T) {
 	if req.name() != "startVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*StartVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestStopVirtualMachine(t *testing.T) {
@@ -50,7 +50,7 @@ func TestStopVirtualMachine(t *testing.T) {
 	if req.name() != "stopVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*StopVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestResetPasswordForVirtualMachine(t *testing.T) {
@@ -58,7 +58,7 @@ func TestResetPasswordForVirtualMachine(t *testing.T) {
 	if req.name() != "resetPasswordForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*ResetPasswordForVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestUpdateVirtualMachine(t *testing.T) {
@@ -66,7 +66,7 @@ func TestUpdateVirtualMachine(t *testing.T) {
 	if req.name() != "updateVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*UpdateVirtualMachineResponse)
+	_ = req.response().(*VirtualMachine)
 }
 
 func TestListVirtualMachines(t *testing.T) {
@@ -90,7 +90,7 @@ func TestRestoreVirtualMachine(t *testing.T) {
 	if req.name() != "restoreVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*RestoreVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestChangeServiceForVirtualMachine(t *testing.T) {
@@ -98,7 +98,7 @@ func TestChangeServiceForVirtualMachine(t *testing.T) {
 	if req.name() != "changeServiceForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*ChangeServiceForVirtualMachineResponse)
+	_ = req.response().(*VirtualMachine)
 }
 
 func TestScaleVirtualMachine(t *testing.T) {
@@ -114,7 +114,7 @@ func TestRecoverVirtualMachine(t *testing.T) {
 	if req.name() != "recoverVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*RecoverVirtualMachineResponse)
+	_ = req.response().(*VirtualMachine)
 }
 
 func TestExpungeVirtualMachine(t *testing.T) {
@@ -130,7 +130,7 @@ func TestGetVirtualMachineUserData(t *testing.T) {
 	if req.name() != "getVirtualMachineUserData" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*GetVirtualMachineUserDataResponse)
+	_ = req.response().(*VirtualMachineUserData)
 }
 
 func TestMigrateVirtualMachine(t *testing.T) {
@@ -138,7 +138,7 @@ func TestMigrateVirtualMachine(t *testing.T) {
 	if req.name() != "migrateVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*MigrateVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestAddNicToVirtualMachine(t *testing.T) {
@@ -146,7 +146,7 @@ func TestAddNicToVirtualMachine(t *testing.T) {
 	if req.name() != "addNicToVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*AddNicToVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestRemoveNicFromVirtualMachine(t *testing.T) {
@@ -154,7 +154,7 @@ func TestRemoveNicFromVirtualMachine(t *testing.T) {
 	if req.name() != "removeNicFromVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*RemoveNicFromVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
@@ -162,7 +162,7 @@ func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
 	if req.name() != "updateDefaultNicForVirtualMachine" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*UpdateDefaultNicForVirtualMachineResponse)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestDeployOnBeforeSend(t *testing.T) {

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -82,7 +82,7 @@ func TestGetVMPassword(t *testing.T) {
 	if req.name() != "getVMPassword" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*GetVMPasswordResponse)
+	_ = req.response().(*Password)
 }
 
 func TestRestoreVirtualMachine(t *testing.T) {
@@ -297,7 +297,7 @@ func TestGetVirtualMachine(t *testing.T) {
 
 func TestGetVirtualMachinePassword(t *testing.T) {
 	ts := newServer(response{200, `
-{"getvmresponse": {
+{"getvmpasswordresponse": {
 	"password": {
 		"encryptedpassword": "test"
 	}
@@ -312,7 +312,7 @@ func TestGetVirtualMachinePassword(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if resp.(*GetVMPasswordResponse).Password.EncryptedPassword != "test" {
+	if resp.(*Password).EncryptedPassword != "test" {
 		t.Errorf("Encrypted password missing")
 	}
 }

--- a/virtual_machines_type.go
+++ b/virtual_machines_type.go
@@ -89,11 +89,6 @@ type VirtualMachineUserData struct {
 	VirtualMachineID string `json:"virtualmachineid,omitempty" doc:"the ID of the virtual machine"`
 }
 
-// VirtualMachineResponse represents a generic Virtual Machine response
-type VirtualMachineResponse struct {
-	VirtualMachine VirtualMachine `json:"virtualmachine"`
-}
-
 // DeployVirtualMachine (Async) represents the machine creation
 //
 // Regarding the UserData field, the client is responsible to base64 (and probably gzip) it. Doing it within this library would make the integration with other tools, e.g. Terraform harder.
@@ -133,9 +128,6 @@ type DeployVirtualMachine struct {
 	ZoneID             string            `json:"zoneid" doc:"availability zone for the virtual machine"`
 }
 
-// DeployVirtualMachineResponse represents a deployed VM instance
-type DeployVirtualMachineResponse VirtualMachineResponse
-
 // StartVirtualMachine (Async) represents the creation of the virtual machine
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/startVirtualMachine.html
@@ -145,9 +137,6 @@ type StartVirtualMachine struct {
 	HostID            string `json:"hostid,omitempty" doc:"destination Host ID to deploy the VM to - parameter available for root admin only"`
 }
 
-// StartVirtualMachineResponse represents a started VM instance
-type StartVirtualMachineResponse VirtualMachineResponse
-
 // StopVirtualMachine (Async) represents the stopping of the virtual machine
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/stopVirtualMachine.html
@@ -156,18 +145,12 @@ type StopVirtualMachine struct {
 	Forced *bool  `json:"forced,omitempty" doc:"Force stop the VM (vm is marked as Stopped even when command fails to be send to the backend).  The caller knows the VM is stopped."`
 }
 
-// StopVirtualMachineResponse represents a stopped VM instance
-type StopVirtualMachineResponse VirtualMachineResponse
-
 // RebootVirtualMachine (Async) represents the rebooting of the virtual machine
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/rebootVirtualMachine.html
 type RebootVirtualMachine struct {
 	ID string `json:"id" doc:"The ID of the virtual machine"`
 }
-
-// RebootVirtualMachineResponse represents a rebooted VM instance
-type RebootVirtualMachineResponse VirtualMachineResponse
 
 // RestoreVirtualMachine (Async) represents the restoration of the virtual machine
 //
@@ -178,16 +161,10 @@ type RestoreVirtualMachine struct {
 	RootDiskSize     int64  `json:"rootdisksize,omitempty" doc:"Optional field to resize root disk on restore. Value is in GB. Only applies to template-based deployments."`
 }
 
-// RestoreVirtualMachineResponse represents a restored VM instance
-type RestoreVirtualMachineResponse VirtualMachineResponse
-
 // RecoverVirtualMachine represents the restoration of the virtual machine
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/recoverVirtualMachine.html
 type RecoverVirtualMachine RebootVirtualMachine
-
-// RecoverVirtualMachineResponse represents a recovered VM instance
-type RecoverVirtualMachineResponse VirtualMachineResponse
 
 // DestroyVirtualMachine (Async) represents the destruction of the virtual machine
 //
@@ -196,9 +173,6 @@ type DestroyVirtualMachine struct {
 	ID      string `json:"id" doc:"The ID of the virtual machine"`
 	Expunge *bool  `json:"expunge,omitempty" doc:"If true is passed, the vm is expunged immediately. False by default."`
 }
-
-// DestroyVirtualMachineResponse represents a destroyed VM instance
-type DestroyVirtualMachineResponse VirtualMachineResponse
 
 // UpdateVirtualMachine represents the update of the virtual machine
 //
@@ -216,9 +190,6 @@ type UpdateVirtualMachine struct {
 	SecurityGroupIDs      []string          `json:"securitygroupids,omitempty" doc:"list of security group ids to be applied on the virtual machine."`
 	UserData              string            `json:"userdata,omitempty" doc:"an optional binary data that can be sent to the virtual machine upon a successful deployment. This binary data must be base64 encoded before adding it to the request. Using HTTP GET (via querystring), you can send up to 2KB of data after base64 encoding. Using HTTP POST(via POST body), you can send up to 32K of data after base64 encoding."`
 }
-
-// UpdateVirtualMachineResponse represents an updated VM instance
-type UpdateVirtualMachineResponse VirtualMachineResponse
 
 // ExpungeVirtualMachine represents the annihilation of a VM
 //
@@ -242,16 +213,10 @@ type ScaleVirtualMachine struct {
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/changeServiceForVirtualMachine.html
 type ChangeServiceForVirtualMachine ScaleVirtualMachine
 
-// ChangeServiceForVirtualMachineResponse represents an changed VM instance
-type ChangeServiceForVirtualMachineResponse VirtualMachineResponse
-
 // ResetPasswordForVirtualMachine resets the password for virtual machine. The virtual machine must be in a "Stopped" state...
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/resetPasswordForVirtualMachine.html
 type ResetPasswordForVirtualMachine RebootVirtualMachine
-
-// ResetPasswordForVirtualMachineResponse represents the updated vm
-type ResetPasswordForVirtualMachineResponse VirtualMachineResponse
 
 // GetVMPassword asks for an encrypted password
 //
@@ -306,9 +271,6 @@ type AddNicToVirtualMachine struct {
 	IPAddress        net.IP `json:"ipaddress,omitempty" doc:"IP Address for the new network"`
 }
 
-// AddNicToVirtualMachineResponse represents the modified VM
-type AddNicToVirtualMachineResponse VirtualMachineResponse
-
 // RemoveNicFromVirtualMachine (Async) removes a NIC from a VM
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/removeNicFromVirtualMachine.html
@@ -317,27 +279,16 @@ type RemoveNicFromVirtualMachine struct {
 	VirtualMachineID string `json:"virtualmachineid" doc:"Virtual Machine ID"`
 }
 
-// RemoveNicFromVirtualMachineResponse represents the modified VM
-type RemoveNicFromVirtualMachineResponse VirtualMachineResponse
-
 // UpdateDefaultNicForVirtualMachine (Async) adds a NIC to a VM
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/updateDefaultNicForVirtualMachine.html
 type UpdateDefaultNicForVirtualMachine RemoveNicFromVirtualMachine
-
-// UpdateDefaultNicForVirtualMachineResponse represents the modified VM
-type UpdateDefaultNicForVirtualMachineResponse VirtualMachineResponse
 
 // GetVirtualMachineUserData returns the user-data of the given VM
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/getVirtualMachineUserData.html
 type GetVirtualMachineUserData struct {
 	VirtualMachineID string `json:"virtualmachineid" doc:"The ID of the virtual machine"`
-}
-
-// GetVirtualMachineUserDataResponse represents the base64 encoded user-data
-type GetVirtualMachineUserDataResponse struct {
-	VirtualMachineUserData VirtualMachineUserData `json:"virtualmachineuserdata"`
 }
 
 // MigrateVirtualMachine (Async) attempts migration of a VM to a different host or Root volume of the vm to a different storage pool
@@ -348,6 +299,3 @@ type MigrateVirtualMachine struct {
 	StorageID        string `json:"storageid,omitempty" doc:"Destination storage pool ID to migrate VM volumes to. Required for migrating the root disk volume"`
 	VirtualMachineID string `json:"virtualmachineid" doc:"the ID of the virtual machine"`
 }
-
-// MigrateVirtualMachineResponse represents the migrated VirtualMachine
-type MigrateVirtualMachineResponse VirtualMachineResponse

--- a/virtual_machines_type.go
+++ b/virtual_machines_type.go
@@ -258,12 +258,6 @@ type ResetPasswordForVirtualMachineResponse VirtualMachineResponse
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/getVMPassword.html
 type GetVMPassword RebootVirtualMachine
 
-// GetVMPasswordResponse represents the encrypted password
-type GetVMPasswordResponse struct {
-	// Base64 encrypted password for the VM
-	Password Password `json:"password"`
-}
-
 // ListVirtualMachines represents a search for a VM
 //
 // CloudStack API: https://cloudstack.apache.org/api/apidocs-4.10/apis/listVirtualMachine.html

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -10,11 +10,6 @@ type InstanceGroup struct {
 	Name     string `json:"name,omitempty" doc:"the name of the instance group"`
 }
 
-// InstanceGroupResponse represents a VM group
-type InstanceGroupResponse struct {
-	InstanceGroup InstanceGroup `json:"instancegroup"`
-}
-
 // CreateInstanceGroup creates a VM group
 //
 // CloudStack API: http://cloudstack.apache.org/api/apidocs-4.10/apis/createInstanceGroup.html
@@ -30,11 +25,8 @@ func (*CreateInstanceGroup) name() string {
 }
 
 func (*CreateInstanceGroup) response() interface{} {
-	return new(CreateInstanceGroupResponse)
+	return new(InstanceGroup)
 }
-
-// CreateInstanceGroupResponse represents a freshly created VM group
-type CreateInstanceGroupResponse InstanceGroupResponse
 
 // UpdateInstanceGroup updates a VM group
 //
@@ -50,11 +42,8 @@ func (*UpdateInstanceGroup) name() string {
 }
 
 func (*UpdateInstanceGroup) response() interface{} {
-	return new(UpdateInstanceGroupResponse)
+	return new(InstanceGroup)
 }
-
-// UpdateInstanceGroupResponse represents an updated VM group
-type UpdateInstanceGroupResponse InstanceGroupResponse
 
 // DeleteInstanceGroup deletes a VM group
 //

--- a/vm_groups_test.go
+++ b/vm_groups_test.go
@@ -4,13 +4,6 @@ import (
 	"testing"
 )
 
-func TestInstanceGroup(t *testing.T) {
-	var _ Command = (*CreateInstanceGroup)(nil)
-	var _ Command = (*UpdateInstanceGroup)(nil)
-	var _ Command = (*DeleteInstanceGroup)(nil)
-	var _ Command = (*ListInstanceGroups)(nil)
-}
-
 func TestListInstanceGroups(t *testing.T) {
 	req := &ListInstanceGroups{}
 	if req.name() != "listInstanceGroups" {
@@ -24,7 +17,7 @@ func TestCreateInstanceGroup(t *testing.T) {
 	if req.name() != "createInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*CreateInstanceGroupResponse)
+	_ = req.response().(*InstanceGroup)
 }
 
 func TestUpdateInstanceGroup(t *testing.T) {
@@ -32,7 +25,7 @@ func TestUpdateInstanceGroup(t *testing.T) {
 	if req.name() != "updateInstanceGroup" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.response().(*UpdateInstanceGroupResponse)
+	_ = req.response().(*InstanceGroup)
 }
 
 func TestDeleteInstanceGroup(t *testing.T) {

--- a/volumes.go
+++ b/volumes.go
@@ -56,12 +56,7 @@ func (*ResizeVolume) name() string {
 }
 
 func (*ResizeVolume) asyncResponse() interface{} {
-	return new(ResizeVolumeResponse)
-}
-
-// ResizeVolumeResponse represents the new Volume
-type ResizeVolumeResponse struct {
-	Volume Volume `json:"volume"`
+	return new(Volume)
 }
 
 // name returns the CloudStack API command name

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -24,7 +24,7 @@ func TestResizeVolume(t *testing.T) {
 	if req.name() != "resizeVolume" {
 		t.Errorf("API call doesn't match")
 	}
-	_ = req.asyncResponse().(*ResizeVolumeResponse)
+	_ = req.asyncResponse().(*Volume)
 }
 
 func TestGetVolume(t *testing.T) {

--- a/zones_test.go
+++ b/zones_test.go
@@ -483,7 +483,8 @@ func TestListZonesTwoPages(t *testing.T) {
 	]
 }}`}, response{200, `
 {"listzonesresponse": {
-	"count": 4
+	"count": 4,
+	"zones": null
 }}`})
 	defer ts.Close()
 


### PR DESCRIPTION
An attempt to remove most of the `<Foo>Response` type. We have to keep them for the `List<Foo>s` commands though.

**Old**

https://godoc.org/github.com/exoscale/egoscale#pkg-index

**New**

![screenshot-2018-5-7 egoscale - the go programming language](https://user-images.githubusercontent.com/1388/39686394-139cccc4-51c9-11e8-8107-9364d472f4a3.png)
