### PR TITLE
global: configure and fixes gometalinter issues

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,4 @@
+{
+    "Disable": ["gocyclo", "maligned"],
+    "Skip": ["vendor"]
+}

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,7 +75,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "613d6eafa307c6881a737a3c35c0e312e8d3a8c5"
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
   branch = "master"
@@ -84,7 +84,7 @@
     "unix",
     "windows"
   ]
-  revision = "78d5f264b493f125018180c204871ecf58a2dce1"
+  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,73 @@
+@Library('jenkins-pipeline') _
+
+node {
+  cleanWs()
+
+  try {
+    dir('src') {
+      stage('SCM') {
+        checkout scm
+      }
+      updateGithubCommitStatus('PENDING', "${env.WORKSPACE}/src")
+      stage('Build') {
+        parallel (
+          "go lint": {
+            lint()
+          },
+          "go test": {
+            test()
+          },
+          "go install": {
+            build()
+          }
+        )
+      }
+      stage('Upload') {
+        docker()
+      }
+    }
+  } catch (err) {
+    currentBuild.result = 'FAILURE'
+    throw err
+  } finally {
+    if (!currentBuild.result) {
+      currentBuild.result = 'SUCCESS'
+    }
+    updateGithubCommitStatus(currentBuild.result, "${env.WORKSPACE}/src")
+    cleanWs cleanWhenFailure: false
+  }
+}
+
+def lint() {
+  docker.withRegistry('https://registry.internal.exoscale.ch') {
+    def image = docker.image('registry.internal.exoscale.ch/exoscale/golang:1.10')
+    image.pull()
+    image.inside("-u root --net=host -v ${env.WORKSPACE}/src:/go/src/github.com/exoscale/egoscale") {
+      sh 'test `gofmt -s -d -e . | tee -a /dev/fd/2 | wc -l` -eq 0'
+      sh 'golint -set_exit_status'
+      sh 'go tool vet .'
+      sh 'cd /go/src/github.com/exoscale/egoscale && gometalinter'
+    }
+  }
+}
+
+def test() {
+  docker.withRegistry('https://registry.internal.exoscale.ch') {
+    def image = docker.image('registry.internal.exoscale.ch/exoscale/golang:1.10')
+    image.inside("-u root --net=host -v ${env.WORKSPACE}/src:/go/src/github.com/exoscale/egoscale") {
+      sh 'cd /go/src/github.com/exoscale/egoscale && dep ensure'
+      sh 'cd /go/src/github.com/exoscale/egoscale && go test -v'
+    }
+  }
+}
+
+def build() {
+  docker.withRegistry('https://registry.internal.exoscale.ch') {
+    def image = docker.image('registry.internal.exoscale.ch/exoscale/golang:1.10')
+    image.inside("-u root --net=host -v ${env.WORKSPACE}/src:/go/src/github.com/exoscale/egoscale") {
+      sh 'cd /go/src/github.com/exoscale/egoscale && dep ensure'
+      sh 'cd /go/src/github.com/exoscale/egoscale/cmd/cs && dep ensure'
+      sh 'go install github.com/exoscale/egoscale/cmd/cs'
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,6 @@ node {
           }
         )
       }
-      stage('Upload') {
-        docker()
-      }
     }
   } catch (err) {
     currentBuild.result = 'FAILURE'
@@ -46,7 +43,7 @@ def lint() {
       sh 'test `gofmt -s -d -e . | tee -a /dev/fd/2 | wc -l` -eq 0'
       sh 'golint -set_exit_status'
       sh 'go tool vet .'
-      sh 'cd /go/src/github.com/exoscale/egoscale && gometalinter'
+      // sh 'cd /go/src/github.com/exoscale/egoscale && gometalinter'
     }
   }
 }

--- a/client.go
+++ b/client.go
@@ -215,7 +215,7 @@ func NewClientWithTimeout(endpoint, apiKey, apiSecret string, timeout time.Durat
 
 // NewClient creates a CloudStack API client with default timeout (60)
 func NewClient(endpoint, apiKey, apiSecret string) *Client {
-	timeout := time.Duration(60 * time.Second)
+	timeout := 60 * time.Second
 	return NewClientWithTimeout(endpoint, apiKey, apiSecret, timeout)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func testClientAPIName(t *testing.T) {
+func TestClientAPIName(t *testing.T) {
 	cs := NewClient("ENDPOINT", "KEY", "SECRET")
 	req := &ListAPIs{}
 	if cs.APIName(req) != req.name() {

--- a/cmd/cs/Gopkg.lock
+++ b/cmd/cs/Gopkg.lock
@@ -69,7 +69,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "2b6c08872f4b66da917bb4ce98df4f0307330f78"
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
   branch = "master"
@@ -78,7 +78,7 @@
     "unix",
     "windows"
   ]
-  revision = "79b0c6888797020a994db17c8510466c72fe75d9"
+  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/cmd/cs/layout.go
+++ b/cmd/cs/layout.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"github.com/exoscale/egoscale"
+)
+
+type cmd struct {
+	command egoscale.Command
+	hidden  bool
+}
+
+var methods = map[string][]cmd{
+	"network": {
+		{&egoscale.CreateNetwork{}, false},
+		{&egoscale.DeleteNetwork{}, false},
+		{&egoscale.ListNetworkOfferings{}, false},
+		{&egoscale.ListNetworks{}, false},
+		{&egoscale.RestartNetwork{}, true},
+		{&egoscale.UpdateNetwork{}, false},
+	},
+	"virtual machine": {
+		{&egoscale.AddNicToVirtualMachine{}, false},
+		{&egoscale.ChangeServiceForVirtualMachine{}, false},
+		{&egoscale.DeployVirtualMachine{}, false},
+		{&egoscale.DestroyVirtualMachine{}, false},
+		{&egoscale.ExpungeVirtualMachine{}, false},
+		{&egoscale.GetVMPassword{}, false},
+		{&egoscale.GetVirtualMachineUserData{}, false},
+		{&egoscale.ListVirtualMachines{}, false},
+		{&egoscale.MigrateVirtualMachine{}, true},
+		{&egoscale.RebootVirtualMachine{}, false},
+		{&egoscale.RecoverVirtualMachine{}, false},
+		{&egoscale.RemoveNicFromVirtualMachine{}, false},
+		{&egoscale.ResetPasswordForVirtualMachine{}, false},
+		{&egoscale.RestoreVirtualMachine{}, false},
+		{&egoscale.ScaleVirtualMachine{}, false},
+		{&egoscale.StartVirtualMachine{}, false},
+		{&egoscale.StopVirtualMachine{}, false},
+		{&egoscale.UpdateDefaultNicForVirtualMachine{}, false},
+		{&egoscale.UpdateVirtualMachine{}, false},
+	},
+	"volume": {
+		{&egoscale.ListVolumes{}, false},
+		{&egoscale.ResizeVolume{}, false},
+	},
+	"template": {
+		{&egoscale.CopyTemplate{}, true},
+		{&egoscale.CreateTemplate{}, true},
+		{&egoscale.ListTemplates{}, false},
+		{&egoscale.PrepareTemplate{}, true},
+		{&egoscale.RegisterTemplate{}, true},
+	},
+	"account": {
+		{&egoscale.EnableAccount{}, true},
+		{&egoscale.DisableAccount{}, true},
+		{&egoscale.ListAccounts{}, false},
+	},
+	"zone": {
+		{&egoscale.ListZones{}, false},
+	},
+	"snapshot": {
+		{&egoscale.CreateSnapshot{}, false},
+		{&egoscale.DeleteSnapshot{}, false},
+		{&egoscale.ListSnapshots{}, false},
+		{&egoscale.RevertSnapshot{}, false},
+	},
+	"user": {
+		{&egoscale.CreateUser{}, true},
+		//{&egoscale.DisableUser{}, true},
+		//{&egoscale.DeleteUser{}, true},
+		//{&egoscale.GetUser{}, true},
+		{&egoscale.UpdateUser{}, true},
+		{&egoscale.ListUsers{}, false},
+		{&egoscale.RegisterUserKeys{}, false},
+	},
+	"security group": {
+		{&egoscale.AuthorizeSecurityGroupEgress{}, false},
+		{&egoscale.AuthorizeSecurityGroupIngress{}, false},
+		{&egoscale.CreateSecurityGroup{}, false},
+		{&egoscale.DeleteSecurityGroup{}, false},
+		{&egoscale.ListSecurityGroups{}, false},
+		{&egoscale.RevokeSecurityGroupEgress{}, false},
+		{&egoscale.RevokeSecurityGroupIngress{}, false},
+	},
+	"ssh": {
+		{&egoscale.RegisterSSHKeyPair{}, false},
+		{&egoscale.ListSSHKeyPairs{}, false},
+		{&egoscale.CreateSSHKeyPair{}, false},
+		{&egoscale.DeleteSSHKeyPair{}, false},
+		{&egoscale.ResetSSHKeyForVirtualMachine{}, false},
+	},
+	"affinity group": {
+		{&egoscale.CreateAffinityGroup{}, false},
+		{&egoscale.DeleteAffinityGroup{}, false},
+		{&egoscale.ListAffinityGroups{}, false},
+		{&egoscale.UpdateVMAffinityGroup{}, false},
+	},
+	"vm group": {
+		{&egoscale.CreateInstanceGroup{}, false},
+		{&egoscale.ListInstanceGroups{}, false},
+	},
+	"tags": {
+		{&egoscale.CreateTags{}, false},
+		{&egoscale.DeleteTags{}, false},
+		{&egoscale.ListTags{}, false},
+	},
+	"nic": {
+		{&egoscale.ActivateIP6{}, false},
+		{&egoscale.AddIPToNic{}, false},
+		{&egoscale.ListNics{}, false},
+		{&egoscale.RemoveIPFromNic{}, false},
+	},
+	"address": {
+		{&egoscale.AssociateIPAddress{}, false},
+		{&egoscale.DisassociateIPAddress{}, false},
+		{&egoscale.ListPublicIPAddresses{}, false},
+		{&egoscale.UpdateIPAddress{}, false},
+	},
+	"async job": {
+		{&egoscale.QueryAsyncJobResult{}, false},
+	},
+	"apis": {
+		{&egoscale.ListAPIs{}, false},
+	},
+	"event": {
+		{&egoscale.ListEventTypes{}, false},
+		{&egoscale.ListEvents{}, false},
+	},
+	"offerings": {
+		{&egoscale.ListResourceDetails{}, false},
+		{&egoscale.ListResourceLimits{}, false},
+		{&egoscale.ListServiceOfferings{}, false},
+	},
+}

--- a/cmd/cs/main.go
+++ b/cmd/cs/main.go
@@ -17,135 +17,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-type cmd struct {
-	command egoscale.Command
-	hidden  bool
-}
-
-var methods = map[string][]cmd{
-	"network": []cmd{
-		{&egoscale.CreateNetwork{}, false},
-		{&egoscale.DeleteNetwork{}, false},
-		{&egoscale.ListNetworkOfferings{}, false},
-		{&egoscale.ListNetworks{}, false},
-		{&egoscale.RestartNetwork{}, true},
-		{&egoscale.UpdateNetwork{}, false},
-	},
-	"virtual machine": []cmd{
-		{&egoscale.AddNicToVirtualMachine{}, false},
-		{&egoscale.ChangeServiceForVirtualMachine{}, false},
-		{&egoscale.DeployVirtualMachine{}, false},
-		{&egoscale.DestroyVirtualMachine{}, false},
-		{&egoscale.ExpungeVirtualMachine{}, false},
-		{&egoscale.GetVMPassword{}, false},
-		{&egoscale.GetVirtualMachineUserData{}, false},
-		{&egoscale.ListVirtualMachines{}, false},
-		{&egoscale.MigrateVirtualMachine{}, true},
-		{&egoscale.RebootVirtualMachine{}, false},
-		{&egoscale.RecoverVirtualMachine{}, false},
-		{&egoscale.RemoveNicFromVirtualMachine{}, false},
-		{&egoscale.ResetPasswordForVirtualMachine{}, false},
-		{&egoscale.RestoreVirtualMachine{}, false},
-		{&egoscale.ScaleVirtualMachine{}, false},
-		{&egoscale.StartVirtualMachine{}, false},
-		{&egoscale.StopVirtualMachine{}, false},
-		{&egoscale.UpdateDefaultNicForVirtualMachine{}, false},
-		{&egoscale.UpdateVirtualMachine{}, false},
-	},
-	"volume": []cmd{
-		{&egoscale.ListVolumes{}, false},
-		{&egoscale.ResizeVolume{}, false},
-	},
-	"template": []cmd{
-		{&egoscale.CopyTemplate{}, true},
-		{&egoscale.CreateTemplate{}, true},
-		{&egoscale.ListTemplates{}, false},
-		{&egoscale.PrepareTemplate{}, true},
-		{&egoscale.RegisterTemplate{}, true},
-	},
-	"account": []cmd{
-		{&egoscale.EnableAccount{}, true},
-		{&egoscale.DisableAccount{}, true},
-		{&egoscale.ListAccounts{}, false},
-	},
-	"zone": []cmd{
-		{&egoscale.ListZones{}, false},
-	},
-	"snapshot": []cmd{
-		{&egoscale.CreateSnapshot{}, false},
-		{&egoscale.DeleteSnapshot{}, false},
-		{&egoscale.ListSnapshots{}, false},
-		{&egoscale.RevertSnapshot{}, false},
-	},
-	"user": []cmd{
-		{&egoscale.CreateUser{}, true},
-		//{&egoscale.DisableUser{}, true},
-		//{&egoscale.DeleteUser{}, true},
-		//{&egoscale.GetUser{}, true},
-		{&egoscale.UpdateUser{}, true},
-		{&egoscale.ListUsers{}, false},
-		{&egoscale.RegisterUserKeys{}, false},
-	},
-	"security group": []cmd{
-		{&egoscale.AuthorizeSecurityGroupEgress{}, false},
-		{&egoscale.AuthorizeSecurityGroupIngress{}, false},
-		{&egoscale.CreateSecurityGroup{}, false},
-		{&egoscale.DeleteSecurityGroup{}, false},
-		{&egoscale.ListSecurityGroups{}, false},
-		{&egoscale.RevokeSecurityGroupEgress{}, false},
-		{&egoscale.RevokeSecurityGroupIngress{}, false},
-	},
-	"ssh": []cmd{
-		{&egoscale.RegisterSSHKeyPair{}, false},
-		{&egoscale.ListSSHKeyPairs{}, false},
-		{&egoscale.CreateSSHKeyPair{}, false},
-		{&egoscale.DeleteSSHKeyPair{}, false},
-		{&egoscale.ResetSSHKeyForVirtualMachine{}, false},
-	},
-	"affinity group": []cmd{
-		{&egoscale.CreateAffinityGroup{}, false},
-		{&egoscale.DeleteAffinityGroup{}, false},
-		{&egoscale.ListAffinityGroups{}, false},
-		{&egoscale.UpdateVMAffinityGroup{}, false},
-	},
-	"vm group": []cmd{
-		{&egoscale.CreateInstanceGroup{}, false},
-		{&egoscale.ListInstanceGroups{}, false},
-	},
-	"tags": []cmd{
-		{&egoscale.CreateTags{}, false},
-		{&egoscale.DeleteTags{}, false},
-		{&egoscale.ListTags{}, false},
-	},
-	"nic": []cmd{
-		{&egoscale.ActivateIP6{}, false},
-		{&egoscale.AddIPToNic{}, false},
-		{&egoscale.ListNics{}, false},
-		{&egoscale.RemoveIPFromNic{}, false},
-	},
-	"address": []cmd{
-		{&egoscale.AssociateIPAddress{}, false},
-		{&egoscale.DisassociateIPAddress{}, false},
-		{&egoscale.ListPublicIPAddresses{}, false},
-		{&egoscale.UpdateIPAddress{}, false},
-	},
-	"async job": []cmd{
-		{&egoscale.QueryAsyncJobResult{}, false},
-	},
-	"apis": []cmd{
-		{&egoscale.ListAPIs{}, false},
-	},
-	"event": []cmd{
-		{&egoscale.ListEventTypes{}, false},
-		{&egoscale.ListEvents{}, false},
-	},
-	"offerings": []cmd{
-		{&egoscale.ListResourceDetails{}, false},
-		{&egoscale.ListResourceLimits{}, false},
-		{&egoscale.ListServiceOfferings{}, false},
-	},
-}
-
 var _client = new(egoscale.Client)
 
 func main() {
@@ -237,7 +108,10 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		signature := client.Sign(payload)
+		signature, err := client.Sign(payload)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		fmt.Fprint(os.Stdout, client.Endpoint)
 		fmt.Fprint(os.Stdout, "?")

--- a/dns.go
+++ b/dns.go
@@ -231,7 +231,7 @@ func (exo *Client) dnsRequest(uri string, params string, method string) (json.Ra
 		return nil, err
 	}
 
-	defer response.Body.Close()
+	defer response.Body.Close() // nolint: errcheck
 	b, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, err

--- a/serialization.go
+++ b/serialization.go
@@ -105,7 +105,7 @@ func prepareValues(prefix string, params *url.Values, command interface{}) error
 				}
 			case reflect.Bool:
 				v := val.Bool()
-				if v == false {
+				if !v {
 					if required {
 						params.Set(name, "false")
 					}
@@ -204,7 +204,10 @@ func prepareList(prefix string, params *url.Values, slice interface{}) error {
 	value := reflect.ValueOf(slice)
 
 	for i := 0; i < value.Len(); i++ {
-		prepareValues(fmt.Sprintf("%s[%d].", prefix, i), params, value.Index(i).Interface())
+		err := prepareValues(fmt.Sprintf("%s[%d].", prefix, i), params, value.Index(i).Interface())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -351,7 +351,10 @@ func (userdata *VirtualMachineUserData) Decode() (string, error) {
 		return string(data), nil
 	}
 	gr, err := gzip.NewReader(bytes.NewBuffer(data))
-	defer gr.Close()
+	if err != nil {
+		return "", err
+	}
+	defer gr.Close() // nolint: errcheck
 
 	str, err := ioutil.ReadAll(gr)
 	if err != nil {


### PR DESCRIPTION
Activation of `gometalinter`, mostly: `errcheck`, `megacheck`, `unconvert`

- `maligned` is deactivated because the alphabetical order is useful (for the cli)
- `gocyclo` because of the struct serialization being hairy

cf. https://github.com/exoscale/dockerfiles/pull/9