### PR TITLE
website: avoid confusion

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -36,12 +36,6 @@ identifier = "cli"
 url = "/cli/"
 
 [[menu.main]]
-name = "cs in go"
-weight = 2
-identifier = "cs"
-url = "/cs/"
-
-[[menu.main]]
 name = "source"
 weight = 3
 url = "https://github.com/exoscale/egoscale/"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,13 +1,13 @@
 ---
 title: Egoscale
-description: the Go library for Exoscale / CloudStack
+description: the Go library for Exoscale
 ---
 
 <a href="https://gopherize.me/gopher/9c1bc7cfe1d84cf43e477dbfc4aa86332065f1fd"><img src="gopher.png" align="right" alt=""></a>
 
 [![Build Status](https://travis-ci.org/exoscale/egoscale.svg?branch=master)](https://travis-ci.org/exoscale/egoscale) [![Maintainability](https://api.codeclimate.com/v1/badges/fcab3b624b7d3ca96a9d/maintainability)](https://codeclimate.com/github/exoscale/egoscale/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/fcab3b624b7d3ca96a9d/test_coverage)](https://codeclimate.com/github/exoscale/egoscale/test_coverage) [![GoDoc](https://godoc.org/github.com/exoscale/egoscale?status.svg)](https://godoc.org/github.com/exoscale/egoscale) [![Go Report Card](https://goreportcard.com/badge/github.com/exoscale/egoscale)](https://goreportcard.com/report/github.com/exoscale/egoscale)
 
-An API wrapper for the CloudStack based [Exoscale public cloud](https://www.exoscale.com).
+An wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
 ## License
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -7,7 +7,7 @@ description: the Go library for Exoscale
 
 [![Build Status](https://travis-ci.org/exoscale/egoscale.svg?branch=master)](https://travis-ci.org/exoscale/egoscale) [![Maintainability](https://api.codeclimate.com/v1/badges/fcab3b624b7d3ca96a9d/maintainability)](https://codeclimate.com/github/exoscale/egoscale/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/fcab3b624b7d3ca96a9d/test_coverage)](https://codeclimate.com/github/exoscale/egoscale/test_coverage) [![GoDoc](https://godoc.org/github.com/exoscale/egoscale?status.svg)](https://godoc.org/github.com/exoscale/egoscale) [![Go Report Card](https://goreportcard.com/badge/github.com/exoscale/egoscale)](https://goreportcard.com/report/github.com/exoscale/egoscale)
 
-An wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
+A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
 ## License
 

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -55,22 +55,7 @@
             </footer>
         </div>
     </div>
-    <div class="column">
-        <div class="card">
-            <div class="card-content">
-                <h2 class="title">cs</h2>
-                <p>
-                    Yet another Command-Line Interface (CLI) for CloudStack
-                    with auto-completion, colors and YAML.
-                </p>
-            </div>
-            <footer class="card-footer">
-                <p class="card-footer-item">
-                    <a href="cs">help</a>
-                </p>
-            </footer>
-        </div>
-    </div>
+
 </div>
 </div>
 </section>


### PR DESCRIPTION
We are now taking liberties with the Cloudstack API, this
adapts our wording to reflect it.