### PR TITLE
firewall: use is-uuid

### DIFF
--- a/cmd/exo/cmd/firewall.go
+++ b/cmd/exo/cmd/firewall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
@@ -101,8 +102,17 @@ func getMyCIDR(isIpv6 bool) (*net.IPNet, error) {
 }
 
 func isAFirewallID(cs *egoscale.Client, id string) bool {
+	if !isUUID(id) {
+		return false
+	}
 	req := &egoscale.SecurityGroup{ID: id}
 	return cs.Get(req) == nil
+}
+
+// isUUID matches a UUIDv4
+func isUUID(uuid string) bool {
+	re := regexp.MustCompile(`(?i)^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$`)
+	return re.MatchString(uuid)
 }
 
 func init() {


### PR DESCRIPTION
One less call.

**before**

```
API error ParamError 431 (ServerAPIException 9999): Unable to execute API command listsecuritygroups due to invalid value. Invalid parameter id value=mycluster due to incorrect long value format, or entity does not exist or due to incorrect parameter annotation for the field in api cmd class.
more than one element found: apikey=EXO9f5db99c785d5821b58627d1, command=listSecurityGroups, response=json                                   
Security group not found wrong ID or Name, got  more than one element found: apikey=EXO9f5db99c785d5821b58627d1, command=listSecurityGroups, response=json
```

**after**

```
Security group not found wrong ID or Name, got  more than one element found: apikey=EXO9f5db99c785d5821b58627d1, command=listSecurityGroups, response=json
```