### PR TITLE
addresses: list cannot be that magic

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -50,15 +50,23 @@ func (ipaddress *IPAddress) ListRequest() (ListCommand, error) {
 		Account:             ipaddress.Account,
 		AssociatedNetworkID: ipaddress.AssociatedNetworkID,
 		DomainID:            ipaddress.DomainID,
-		ForDisplay:          &ipaddress.ForDisplay,
-		ForVirtualNetwork:   &ipaddress.ForVirtualNetwork,
 		ID:                  ipaddress.ID,
 		IPAddress:           ipaddress.IPAddress,
-		IsElastic:           &ipaddress.IsElastic,
-		IsSourceNat:         &ipaddress.IsSourceNat,
 		PhysicalNetworkID:   ipaddress.PhysicalNetworkID,
 		VlanID:              ipaddress.VlanID,
 		ZoneID:              ipaddress.ZoneID,
+	}
+	if ipaddress.IsElastic {
+		req.IsElastic = &ipaddress.IsElastic
+	}
+	if ipaddress.IsSourceNat {
+		req.IsSourceNat = &ipaddress.IsSourceNat
+	}
+	if ipaddress.ForDisplay {
+		req.ForDisplay = &ipaddress.ForDisplay
+	}
+	if ipaddress.ForVirtualNetwork {
+		req.ForVirtualNetwork = &ipaddress.ForVirtualNetwork
 	}
 
 	return req, nil

--- a/networks.go
+++ b/networks.go
@@ -63,14 +63,19 @@ func (network *Network) ListRequest() (ListCommand, error) {
 	req := &ListNetworks{
 		Account:           network.Account,
 		ACLType:           network.ACLType,
-		CanUseForDeploy:   &network.CanUseForDeploy,
 		DomainID:          network.DomainID,
 		ID:                network.ID,
 		PhysicalNetworkID: network.PhysicalNetworkID,
-		RestartRequired:   &network.RestartRequired,
 		TrafficType:       network.TrafficType,
 		Type:              network.Type,
 		ZoneID:            network.ZoneID,
+	}
+
+	if network.CanUseForDeploy {
+		req.CanUseForDeploy = &network.CanUseForDeploy
+	}
+	if network.RestartRequired {
+		req.RestartRequired = &network.RestartRequired
 	}
 
 	return req, nil

--- a/service_offerings.go
+++ b/service_offerings.go
@@ -46,13 +46,17 @@ type ServiceOffering struct {
 
 // ListRequest builds the ListSecurityGroups request
 func (so *ServiceOffering) ListRequest() (ListCommand, error) {
+	// Restricted cannot be applied here because it really has three states
 	req := &ListServiceOfferings{
 		ID:           so.ID,
 		DomainID:     so.DomainID,
 		IsSystem:     &so.IsSystem,
 		Name:         so.Name,
-		Restricted:   &so.Restricted,
 		SystemVMType: so.SystemVMType,
+	}
+
+	if so.IsSystem {
+		req.IsSystem = &so.IsSystem
 	}
 
 	return req, nil


### PR DESCRIPTION
Since the values don't have `*`, `ListRequest` should take into account what is the default value on the cloudstack side. This fix should probably be adapted to other types as well.