### PR TITLE
Sync request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,28 @@ env:
 
 cache: apt
 
-before_install:
-  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
-  - chmod +x $GOPATH/bin/dep
-  - wget https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_amd64.deb
-  - sudo dpkg -i goreleaser_amd64.deb
-  - wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.deb
-  - sudo dpkg -i hugo_${HUGO_VERSION}_Linux-64bit.deb
-  - wget https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_amd64.deb
-  - sudo dpkg -i nfpm_amd64.deb
 addons:
   apt:
     update: true
     packages:
     - rpm
 
+install: |
+  curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  chmod +x $GOPATH/bin/dep
+  wget https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/goreleaser_amd64.deb
+  sudo dpkg -i goreleaser_amd64.deb
+  wget https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_amd64.deb
+  sudo dpkg -i nfpm_amd64.deb
+  npm i codeclimate-test-reporter
+
+script: |
+  dep ensure -v -vendor-only
+  go test -race -coverprofile=coverage.out -covermode=atomic .
+  npx codeclimate-test-reporter < coverage.out
+
 jobs:
   include:
-  - stage: test
-    if: type = pr
-    script: |
-      dep ensure -v -vendor-only
-      go test -race .
   - stage: goreleaser
     if: type = push
     script: |
@@ -49,12 +49,10 @@ jobs:
   - stage: gh-pages
     if: branch = master AND type = push
     script: |
-      dep ensure -v -vendor-only
-      go test -coverprofile=coverage.out -covermode=atomic .
-      npm i codeclimate-test-reporter
-      npx codeclimate-test-reporter < coverage.out
       cd website
       sh prepare.sh
+      wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.deb
+      sudo dpkg -i hugo_${HUGO_VERSION}_Linux-64bit.deb
       hugo
       cd public
       git init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 Changelog
 =========
 
-0.10.0 (unreleased)
+0.10.1
+------
+
+- feat: expose `SyncRequest` and `SyncRequestWithContext`
+
+0.10.0
 ------
 
 - global: cloudstack documentation links are moved into cs

--- a/cmd/exo/cmd/vm_create.go
+++ b/cmd/exo/cmd/vm_create.go
@@ -248,6 +248,7 @@ func createVM(vmInfos *egoscale.DeployVirtualMachine) (*egoscale.VirtualMachine,
 	var errorReq error
 	fmt.Printf("Deploying %q", vmInfos.Name)
 	cs.AsyncRequest(vmInfos, func(jobResult *egoscale.AsyncJobResult, err error) bool {
+		fmt.Printf(".")
 
 		if err != nil {
 			errorReq = err
@@ -255,17 +256,14 @@ func createVM(vmInfos *egoscale.DeployVirtualMachine) (*egoscale.VirtualMachine,
 		}
 
 		if jobResult.JobStatus == egoscale.Success {
-
-			if err := jobResult.Response(virtualMachine); err != nil {
-				errorReq = err
+			if errR := jobResult.Result(virtualMachine); errR != nil {
+				errorReq = errR
 			}
-
-			println("")
 			return false
 		}
-		fmt.Printf(".")
 		return true
 	})
+	fmt.Println("")
 
 	if errorReq != nil {
 		return nil, errorReq


### PR DESCRIPTION
this exposes two methods:
- `SyncRequest`
- `SyncRequestWithContext`

because there was not way to perform a fire and forget on an asynchronous command.

Another change.

```
// was
err := jobResult.Response(virtualMachine)
// now
err := jobResult.Result(virtualMachine)
```

But, I'm unhappy with it. Should it be called `jobResult.Unmarshal(virtualMachine)`, `Load`, `Hydrate` ?