### PR TITLE
exo template show

### DIFF
--- a/cmd/exo/cmd/eip_create.go
+++ b/cmd/exo/cmd/eip_create.go
@@ -25,7 +25,7 @@ var eipCreateCmd = &cobra.Command{
 func associateIPAddress(name string) error {
 	ipReq := egoscale.AssociateIPAddress{}
 	var err error
-	ipReq.ZoneID, err = getZoneIDByName(cs, name)
+	ipReq.ZoneID, err = getZoneIDByName(name)
 	if err != nil {
 		return err
 	}

--- a/cmd/exo/cmd/eip_list.go
+++ b/cmd/exo/cmd/eip_list.go
@@ -34,7 +34,7 @@ func listIPs(zone string, table *table.Table) error {
 
 	if zone != "" {
 		var err error
-		zReq.ZoneID, err = getZoneIDByName(cs, zone)
+		zReq.ZoneID, err = getZoneIDByName(zone)
 		if err != nil {
 			return err
 		}

--- a/cmd/exo/cmd/privnet_create.go
+++ b/cmd/exo/cmd/privnet_create.go
@@ -74,7 +74,7 @@ func isEmptyArgs(args ...string) bool {
 
 func privnetCreate(name, desc, zone string) error {
 	var err error
-	zone, err = getZoneIDByName(cs, zone)
+	zone, err = getZoneIDByName(zone)
 	if err != nil {
 		return err
 	}

--- a/cmd/exo/cmd/privnet_list.go
+++ b/cmd/exo/cmd/privnet_list.go
@@ -35,7 +35,7 @@ func listPrivnets(zone string, table *table.Table) error {
 	if zone != "" {
 		var err error
 		pnReq.Type = "Isolated"
-		pnReq.ZoneID, err = getZoneIDByName(cs, zone)
+		pnReq.ZoneID, err = getZoneIDByName(zone)
 		if err != nil {
 			return err
 		}

--- a/cmd/exo/cmd/template_list.go
+++ b/cmd/exo/cmd/template_list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/exoscale/egoscale/cmd/exo/table"
 	"github.com/spf13/cobra"
@@ -41,7 +42,7 @@ func listTemplates(t *table.Table, filters []string) error {
 	t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID"})
 	for _, template := range templates {
 		sz := strconv.FormatInt(template.Size>>30, 10)
-		if sz == "0" {
+		if sz == "10" && strings.HasPrefix(template.Name, "Linux") {
 			sz = ""
 		}
 		t.Append([]string{template.Name, sz, template.Created, template.ID})

--- a/cmd/exo/cmd/template_list.go
+++ b/cmd/exo/cmd/template_list.go
@@ -40,7 +40,7 @@ func listTemplates(t *table.Table, filters []string) error {
 
 	t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID"})
 	for _, template := range templates {
-		sz := strconv.FormatInt(template.Size<<30, 10)
+		sz := strconv.FormatInt(template.Size>>30, 10)
 		if sz == "0" {
 			sz = ""
 		}

--- a/cmd/exo/cmd/template_list.go
+++ b/cmd/exo/cmd/template_list.go
@@ -1,50 +1,51 @@
 package cmd
 
 import (
-	"log"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/exoscale/egoscale/cmd/exo/table"
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
+func init() {
+	templateCmd.AddCommand(templateListCmd)
+}
+
+// templateListCmd represents the list command
 var templateListCmd = &cobra.Command{
 	Use:     "list [keyword]",
 	Short:   "List all available templates",
 	Aliases: gListAlias,
-	Run: func(cmd *cobra.Command, args []string) {
-
-		keyword := ""
-		if len(args) >= 1 {
-			keyword = strings.Join(args, " ")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		t := table.NewTable(os.Stdout)
+		err := listTemplates(t, args)
+		if err == nil {
+			t.Render()
 		}
-
-		templates, err := listTemplates(keyword)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID"})
-
-		for _, t := range templates {
-			sz := strconv.FormatInt(t.Size, 10)
-			if sz == "0" {
-				sz = ""
-			}
-			table.Append([]string{
-				t.Name, sz,
-				t.Created,
-				t.ID,
-			})
-		}
-		table.Render()
+		return err
 	},
 }
 
-func init() {
-	templateCmd.AddCommand(templateListCmd)
+func listTemplates(t *table.Table, filters []string) error {
+	zoneID, err := getZoneIDByName(gCurrentAccount.DefaultZone)
+	if err != nil {
+		return err
+	}
+
+	templates, err := findTemplates(zoneID, filters...)
+	if err != nil {
+		return err
+	}
+
+	t.SetHeader([]string{"Operating System", "Disk", "Release Date", "ID"})
+	for _, template := range templates {
+		sz := strconv.FormatInt(template.Size<<30, 10)
+		if sz == "0" {
+			sz = ""
+		}
+		t.Append([]string{template.Name, sz, template.Created, template.ID})
+	}
+
+	return nil
 }

--- a/cmd/exo/cmd/template_show.go
+++ b/cmd/exo/cmd/template_show.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	templateCmd.AddCommand(templateShowCmd)
+}
+
+// templateShowCmd represents the show command
+var templateShowCmd = &cobra.Command{
+	Use:   "show <template name | id>",
+	Short: "Show a template",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return errors.New("show expects one template by name or id")
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
+		err := showTemplate(w, strings.Join(args, " "))
+		if err == nil {
+			w.Flush()
+		}
+		return err
+	},
+}
+
+func showTemplate(w io.Writer, name string) error {
+	zoneID, err := getZoneIDByName(gCurrentAccount.DefaultZone)
+	if err != nil {
+		return err
+	}
+
+	template, err := getTemplateByName(zoneID, name)
+	if err != nil {
+		return err
+	}
+
+	username, usernameOk := template.Details["username"]
+
+	fmt.Fprintf(w, "ID:\t%s\n", template.ID)              // nolint: errcheck
+	fmt.Fprintf(w, "Name:\t%s\n", template.Name)          // nolint: errcheck
+	fmt.Fprintf(w, "OS Type:\t%s\n", template.OsTypeName) // nolint: errcheck
+	if usernameOk {
+		fmt.Fprintf(w, "Username:\t%s\n", username) // nolint: errcheck
+	}
+	fmt.Fprintf(w, "Size:\t%d GiB\n", template.Size>>30)         // nolint: errcheck
+	fmt.Fprintf(w, "Created:\t%s\n", template.Created)           // nolint: errcheck
+	fmt.Fprintf(w, "Password?:\t%v\n", template.PasswordEnabled) // nolint: errcheck
+
+	return nil
+}

--- a/cmd/exo/cmd/template_show.go
+++ b/cmd/exo/cmd/template_show.go
@@ -27,7 +27,7 @@ var templateShowCmd = &cobra.Command{
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
 		err := showTemplate(w, strings.Join(args, " "))
 		if err == nil {
-			w.Flush()
+			return w.Flush()
 		}
 		return err
 	},

--- a/cmd/exo/cmd/vm_create.go
+++ b/cmd/exo/cmd/vm_create.go
@@ -47,12 +47,12 @@ var vmCreateCmd = &cobra.Command{
 			zone = gCurrentAccount.DefaultZone
 		}
 
-		zone, err = getZoneIDByName(cs, zone)
+		zone, err = getZoneIDByName(zone)
 		if err != nil {
 			return err
 		}
 
-		template, err := cmd.Flags().GetString("template")
+		templateName, err := cmd.Flags().GetString("template")
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ var vmCreateCmd = &cobra.Command{
 			return err
 		}
 
-		template, err = getTemplateIDByName(cs, template, zone)
+		template, err := getTemplateByName(zone, templateName)
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ var vmCreateCmd = &cobra.Command{
 			Name:              args[0],
 			UserData:          userData,
 			ZoneID:            zone,
-			TemplateID:        template,
+			TemplateID:        template.ID,
 			RootDiskSize:      diskSize,
 			KeyPair:           keypair,
 			SecurityGroupIDs:  sgs,

--- a/cmd/exo/cmd/zone.go
+++ b/cmd/exo/cmd/zone.go
@@ -37,8 +37,7 @@ func listZones() error {
 	return nil
 }
 
-func getZoneIDByName(cs *egoscale.Client, name string) (string, error) {
-
+func getZoneIDByName(name string) (string, error) {
 	zoneReq := egoscale.Zone{}
 
 	zones, err := cs.List(&zoneReq)


### PR DESCRIPTION
- release date for everyone
- `template show` command

**then**

```console
% exo template list
```

|         OPERATING SYSTEM          | DISK |   RELEASE DATE    |                  ID                  |
|-----------------------------------|------|-------------------|--------------------------------------|
| FortiGate 64-bit                  | 10   |                   | e84ba6e1-1855-4941-965e-22e00cc43d4e |
| Linux CentOS 7.5 64-bit           |      | 2018-06-06-988151 | f4b895cf-caf7-4455-8e6f-ca3632cb1062 |
| Linux CentOS 7.4 64-bit           |      | 2018-01-08-d617dd | 934b8d48-d82e-42f5-8f14-b34de3af9854 |
| Linux CentOS 6.9 64-bit           |      | 2018-01-08-8856b8 | e1db5519-2055-4b67-91ba-d66550e43b68 |
| Linux Centos Atomic Host 7 64-bit |      |                   | 1e39ce0a-3f51-4f37-83df-5834ba2e6f59 |
| Linux CernVM 3.6.5 64-bit         |      | 2017-09-01-622866 | 24cd53b9-79a1-49cf-b85d-63fdbdb4b6b9 |
| Linux CoreOS 1688 64-bit          |      | 2018-04-03-988151 | a3cb2fe4-052a-4e12-bdb5-7cae95a4471e |
| Linux CoreOS 1409 64-bit          |      | 2017-07-19-5166e9 | 9f3ae564-093c-43ac-8b45-6638fadcfff2 |
| Linux CoreOS stable 1298 64-bit   |      | 2017-04-01-5bcb70 | 0c234867-4cef-4766-aa91-7f5924122777 |
| Linux CoreOS stable 1122 64-bit   |      | 2016-10-21-85bb6c | 61c180e2-05af-4737-95f1-76118ce15b27 |
| Linux Debian 9 64-bit             |      | 2018-01-18-25e9ec | faef9684-9017-48b1-ab1a-41aa1837da84 |
| Linux Fedora Atomic 27 64-bit     |      |                   | de69a964-0695-458b-af23-c1549fd19226 |
| Linux RancherOS 1.4 64-bit        |      |                   | 2d670d4c-bdeb-442b-9c26-48c0f12770b2 |
| Linux RedHat 7.5 64-bit           |      | 2018-04-13-726205 | d2ca94c4-a376-4063-9fc4-c18cbffff843 |
| Linux RedHat 7.4 64-bit           |      | 2017-11-20-48b932 | c51071ce-08c3-4041-ac0a-23d4e73d5ce6 |
| Linux Ubuntu 18.04 64-bit         |      | 2018-04-26-0e6133 | f3bfb04d-4ccb-420c-9540-db95a4aec3ea |
| Linux Ubuntu 17.10 64-bit         |      | 2018-03-03-5858e9 | e328b133-4dbd-4e5c-b407-264a0050b73f |
| Linux Ubuntu 16.04 LTS 64-bit     |      | 2018-03-02-5858e9 | 4a0c4d65-8d88-40a5-b1be-549b211620b6 |
| OpenBSD 6.3 64-bit                | 50   |                   | bcf68814-3da4-4182-b468-7c6d289dddda |
| OpenBSD 6.1 64-bit                | 50   |                   | 6bfc9fd2-cf5b-415e-a7b9-0c211d050896 |
| OpenBSD 6.0 64-bit                | 50   |                   | b160cb1d-e559-49bb-9d86-4eee0faa4385 |
| Pfsense 2.3.4 64-bit              | 10   | 2017-09-12-ef6682 | e01d330a-4bb1-4f5d-a2ac-94748973cfde |
| Windows Server 2016               | 50   | 2018-04-28-f0232  | 500eb7f6-9771-4e89-9a6f-1d9a16f77d87 |
| Windows Server 2012 R2            | 50   | 2018-04-28-ef11f  | 6ed660d9-14b7-4128-b4ae-28656fa22dee |
| netboot.xyz                       | 10   | 2016-12-06-3e9b74 | ccd17050-5421-4e32-bcfa-ad3a6b7d35dd |
| rhel74                            | 10   |                   | fd432804-94de-46ee-86a7-d03ec2c8a61f |


**now**

```console
% exo template list
```

|         OPERATING SYSTEM          | DISK |   RELEASE DATE    |                  ID                  |
|-----------------------------------|------|-------------------|--------------------------------------|
| FortiGate 64-bit                  | 10   | 2017-11-06        | e84ba6e1-1855-4941-965e-22e00cc43d4e |
| Linux CentOS 7.5 64-bit           |      | 2018-06-06-988151 | f4b895cf-caf7-4455-8e6f-ca3632cb1062 |
| Linux CentOS 7.4 64-bit           |      | 2018-01-08-d617dd | 934b8d48-d82e-42f5-8f14-b34de3af9854 |
| Linux CentOS 6.9 64-bit           |      | 2018-01-08-8856b8 | e1db5519-2055-4b67-91ba-d66550e43b68 |
| Linux Centos Atomic Host 7 64-bit |      | 2018-02-06        | 1e39ce0a-3f51-4f37-83df-5834ba2e6f59 |
| Linux CernVM 3.6.5 64-bit         |      | 2017-09-01-622866 | 24cd53b9-79a1-49cf-b85d-63fdbdb4b6b9 |
| Linux CoreOS 1688 64-bit          |      | 2018-04-03-988151 | a3cb2fe4-052a-4e12-bdb5-7cae95a4471e |
| Linux CoreOS 1409 64-bit          |      | 2017-07-19-5166e9 | 9f3ae564-093c-43ac-8b45-6638fadcfff2 |
| Linux CoreOS stable 1298 64-bit   |      | 2017-04-01-5bcb70 | 0c234867-4cef-4766-aa91-7f5924122777 |
| Linux CoreOS stable 1122 64-bit   |      | 2016-10-21-85bb6c | 61c180e2-05af-4737-95f1-76118ce15b27 |
| Linux Debian 9 64-bit             |      | 2018-01-18-25e9ec | faef9684-9017-48b1-ab1a-41aa1837da84 |
| Linux Fedora Atomic 27 64-bit     | 6    | 2018-02-06        | de69a964-0695-458b-af23-c1549fd19226 |
| Linux RancherOS 1.4 64-bit        |      | 2018-06-04        | 2d670d4c-bdeb-442b-9c26-48c0f12770b2 |
| Linux RedHat 7.5 64-bit           |      | 2018-04-13-726205 | d2ca94c4-a376-4063-9fc4-c18cbffff843 |
| Linux RedHat 7.4 64-bit           |      | 2017-11-20-48b932 | c51071ce-08c3-4041-ac0a-23d4e73d5ce6 |
| Linux Ubuntu 18.04 64-bit         |      | 2018-04-26-0e6133 | f3bfb04d-4ccb-420c-9540-db95a4aec3ea |
| Linux Ubuntu 17.10 64-bit         |      | 2018-03-03-5858e9 | e328b133-4dbd-4e5c-b407-264a0050b73f |
| Linux Ubuntu 16.04 LTS 64-bit     |      | 2018-03-02-5858e9 | 4a0c4d65-8d88-40a5-b1be-549b211620b6 |
| OpenBSD 6.3 64-bit                | 50   | 2018-04-13        | bcf68814-3da4-4182-b468-7c6d289dddda |
| OpenBSD 6.1 64-bit                | 50   | 2017-04-18        | 6bfc9fd2-cf5b-415e-a7b9-0c211d050896 |
| OpenBSD 6.0 64-bit                | 50   | 2016-09-02        | b160cb1d-e559-49bb-9d86-4eee0faa4385 |
| Pfsense 2.3.4 64-bit              | 10   | 2017-09-12-ef6682 | e01d330a-4bb1-4f5d-a2ac-94748973cfde |
| Windows Server 2016               | 50   | 2018-04-28-f0232  | 500eb7f6-9771-4e89-9a6f-1d9a16f77d87 |
| Windows Server 2012 R2            | 50   | 2018-04-28-ef11f  | 6ed660d9-14b7-4128-b4ae-28656fa22dee |
| netboot.xyz                       | 10   | 2016-12-06-3e9b74 | ccd17050-5421-4e32-bcfa-ad3a6b7d35dd |
| rhel74                            | 10   | 2017-11-20        | fd432804-94de-46ee-86a7-d03ec2c8a61f |


```console
% exo template show RedHat 7.5
ID:        d2ca94c4-a376-4063-9fc4-c18cbffff843
Name:      Linux RedHat 7.5 64-bit
OS Type:   Linux RedHat (64-bit)
Username:  cloud-user
Size:      10 GiB
Created:   2018-04-13-726205
Password?: true
```