### PR TITLE
Boolean response

### DIFF
--- a/cidr.go
+++ b/cidr.go
@@ -32,14 +32,10 @@ func (cidr CIDR) MarshalJSON() ([]byte, error) {
 
 // ParseCIDR parses a CIDR from a string
 func ParseCIDR(s string) (*CIDR, error) {
-	ip, net, err := net.ParseCIDR(s)
+	_, net, err := net.ParseCIDR(s)
 	if err != nil {
 		return nil, err
 	}
-	if net == nil || !ip.Equal(net.IP) {
-		return nil, fmt.Errorf("missmatch between CIDR address %q and network number %q", net.IP, ip)
-	}
-
 	return &CIDR{net}, nil
 }
 

--- a/cidr_test.go
+++ b/cidr_test.go
@@ -32,7 +32,7 @@ func TestCIDRUnmarshalJSONFailure(t *testing.T) {
 	ss := []string{
 		`{"ip6cidr": 123}`,
 		`{"ip6cidr": "123"}`,
-		`{"ip6cidr": "192.168.0.1/24"}`,
+		`{"ip6cidr": "192.168.0.1/33"}`,
 	}
 	nic := &Nic{}
 	for _, s := range ss {

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package egoscale
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -96,7 +95,7 @@ func TestClientAsyncDelete(t *testing.T) {
 {"%sresponse": {
 	"jobid": "1",
 	"jobresult": {
-		"success": "true"
+		"success": true
 	},
 	"jobstatus": 1
 }}`
@@ -295,73 +294,5 @@ func TestClientGetTooMany(t *testing.T) {
 		if !strings.HasPrefix(err.Error(), "more than one") {
 			t.Errorf("bad error %s", err)
 		}
-	}
-}
-
-func TestBooleanResponse(t *testing.T) {
-	body := `{"success": true, "displaytext": "yay!"}`
-	response := new(booleanResponse)
-
-	err := json.Unmarshal([]byte(body), response)
-
-	if err != nil {
-		t.Fatalf("This shouldn't break")
-	}
-
-	success, _ := response.IsSuccess()
-	if !success {
-		t.Errorf("A success was expected")
-	}
-
-	if response.DisplayText != "yay!" {
-		t.Errorf("DisplayText doesn't match %q", response.DisplayText)
-	}
-}
-
-func TestBooleanResponseString(t *testing.T) {
-	body := `{"success": "true"}`
-	response := new(booleanResponse)
-
-	err := json.Unmarshal([]byte(body), response)
-
-	if err != nil {
-		t.Fatalf("This shouldn't break")
-	}
-
-	success, _ := response.IsSuccess()
-	if !success {
-		t.Errorf("A success was expected")
-	}
-}
-
-func TestBooleanResponseEmpty(t *testing.T) {
-	body := `{}`
-	response := new(booleanResponse)
-
-	err := json.Unmarshal([]byte(body), response)
-
-	if err != nil {
-		t.Fatalf("This shouldn't break")
-	}
-
-	err = response.Error()
-	if err == nil {
-		t.Errorf("The booleanResponse is not a valid one")
-	}
-}
-
-func TestBooleanResponseInvalid(t *testing.T) {
-	body := `{"success": 42}`
-	response := new(booleanResponse)
-
-	err := json.Unmarshal([]byte(body), response)
-
-	if err != nil {
-		t.Fatalf("This shouldn't break")
-	}
-
-	err = response.Error()
-	if err == nil {
-		t.Errorf("An error was expected")
 	}
 }

--- a/request.go
+++ b/request.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,36 +23,13 @@ func (e ErrorResponse) Error() string {
 	return fmt.Sprintf("API error %s %d (%s %d): %s", e.ErrorCode, e.ErrorCode, e.CSErrorCode, e.CSErrorCode, e.ErrorText)
 }
 
-// Success computes the values based on the RawMessage, either string or bool
-func (e booleanResponse) IsSuccess() (bool, error) {
-	if e.Success == nil {
-		return false, errors.New("not a valid booleanResponse, Success is missing")
-	}
-
-	str := ""
-	if err := json.Unmarshal(e.Success, &str); err != nil {
-		boolean := false
-		if e := json.Unmarshal(e.Success, &boolean); e != nil {
-			return false, e
-		}
-		return boolean, nil
-	}
-	return str == "true", nil
-}
-
 // Error formats a CloudStack job response into a standard error
 func (e booleanResponse) Error() error {
-	success, err := e.IsSuccess()
-
-	if err != nil {
-		return err
+	if !e.Success {
+		return fmt.Errorf("API error: %s", e.DisplayText)
 	}
 
-	if success {
-		return nil
-	}
-
-	return fmt.Errorf("API error: %s", e.DisplayText)
+	return nil
 }
 
 func (client *Client) parseResponse(resp *http.Response, key string) (json.RawMessage, error) {
@@ -143,22 +119,27 @@ func (client *Client) SyncRequestWithContext(ctx context.Context, command Comman
 	}
 
 	response := command.response()
-	err = json.Unmarshal(body, response)
-
-	// booleanResponse will alway be valid...
-	if err == nil {
-		if br, ok := response.(*booleanResponse); ok {
-			success, e := br.IsSuccess()
-			if e != nil {
-				return nil, e
-			}
-			if !success {
-				err = errors.New("not a valid booleanResponse")
-			}
+	b, ok := response.(*booleanResponse)
+	if ok {
+		m := make(map[string]interface{})
+		if errJson := json.Unmarshal(body, &m); errJson != nil {
+			return nil, errJson
 		}
+
+		b.DisplayText, _ = m["displaytext"].(string)
+
+		if success, okSuccess := m["success"].(string); okSuccess {
+			b.Success = success == "true"
+		}
+
+		if success, okSuccess := m["success"].(bool); okSuccess {
+			b.Success = success
+		}
+
+		return b, nil
 	}
 
-	if err != nil {
+	if err := json.Unmarshal(body, response); err != nil {
 		errResponse := new(ErrorResponse)
 		if e := json.Unmarshal(body, errResponse); e == nil && errResponse.ErrorCode > 0 {
 			return errResponse, nil

--- a/request.go
+++ b/request.go
@@ -122,8 +122,8 @@ func (client *Client) SyncRequestWithContext(ctx context.Context, command Comman
 	b, ok := response.(*booleanResponse)
 	if ok {
 		m := make(map[string]interface{})
-		if errJson := json.Unmarshal(body, &m); errJson != nil {
-			return nil, errJson
+		if errUnmarshal := json.Unmarshal(body, &m); errUnmarshal != nil {
+			return nil, errUnmarshal
 		}
 
 		b.DisplayText, _ = m["displaytext"].(string)

--- a/request_test.go
+++ b/request_test.go
@@ -123,6 +123,46 @@ func TestBooleanAsyncRequest(t *testing.T) {
 	}
 }
 
+func TestBooleanAsyncRequestFailure(t *testing.T) {
+	ts := newServer(response{200, jsonContentType, `
+{
+	"expungevirtualmachineresponse": {
+		"jobid": "1",
+		"jobresult": {},
+		"jobstatus": 0
+	}
+}
+	`}, response{200, jsonContentType, `
+{
+	"queryasyncjobresultresponse": {
+		"accountid": "1",
+		"cmd": "expunge",
+		"created": "2018-04-03T22:40:04+0200",
+		"jobid": "1",
+		"jobprocstatus": 0,
+		"jobresult": {
+			"errorcode": 531,
+			"errortext": "fail",
+			"cserrorcode": 9999
+		},
+		"jobresultcode": 0,
+		"jobresulttype": "object",
+		"jobstatus": 2,
+		"userid": "1"
+	}
+}
+	`})
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	req := &ExpungeVirtualMachine{
+		ID: "123",
+	}
+	if err := cs.BooleanRequest(req); err == nil {
+		t.Error("An error was expected")
+	}
+}
+
 func TestBooleanAsyncRequestWithContext(t *testing.T) {
 	ts := newServer(response{200, jsonContentType, `
 {

--- a/request_type.go
+++ b/request_type.go
@@ -1,7 +1,6 @@
 package egoscale
 
 import (
-	"encoding/json"
 	"net/url"
 )
 
@@ -165,8 +164,8 @@ const (
 
 // ErrorResponse represents the standard error response from CloudStack
 type ErrorResponse struct {
-	ErrorCode   ErrorCode   `json:"errorcode"`
 	CSErrorCode CSErrorCode `json:"cserrorcode"`
+	ErrorCode   ErrorCode   `json:"errorcode"`
 	ErrorText   string      `json:"errortext"`
 	UUIDList    []UUIDItem  `json:"uuidList,omitempty"` // uuid*L*ist is not a typo
 }
@@ -180,6 +179,6 @@ type UUIDItem struct {
 
 // booleanResponse represents a boolean response (usually after a deletion)
 type booleanResponse struct {
-	Success     json.RawMessage `json:"success"`
-	DisplayText string          `json:"displaytext,omitempty"`
+	DisplayText string `json:"displaytext,omitempty"`
+	Success     bool   `json:"success"`
 }

--- a/reversedns.go
+++ b/reversedns.go
@@ -21,7 +21,7 @@ type DeleteReverseDNSFromPublicIPAddress struct {
 }
 
 func (*DeleteReverseDNSFromPublicIPAddress) response() interface{} {
-	return new(IPAddress)
+	return new(booleanResponse)
 }
 
 // DeleteReverseDNSFromVirtualMachine is a command to create/delete the PTR record(s) of a virtual machine
@@ -31,7 +31,7 @@ type DeleteReverseDNSFromVirtualMachine struct {
 }
 
 func (*DeleteReverseDNSFromVirtualMachine) response() interface{} {
-	return new(VirtualMachine)
+	return new(booleanResponse)
 }
 
 // QueryReverseDNSForPublicIPAddress is a command to create/query the PTR record of a public IP address

--- a/reversedns_test.go
+++ b/reversedns_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestDeleteReverseDNSFromVirtualMachine(t *testing.T) {
 	req := &DeleteReverseDNSFromVirtualMachine{}
-	_ = req.response().(*VirtualMachine)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestDeleteReverseDNSFromPublicIPAddress(t *testing.T) {
 	req := &DeleteReverseDNSFromPublicIPAddress{}
-	_ = req.response().(*IPAddress)
+	_ = req.response().(*booleanResponse)
 }
 
 func TestQueryReverseDNSForVirtualMachine(t *testing.T) {


### PR DESCRIPTION
```console
% cs -r testing deleteReverseDnsFromPublicIpAddress --id=97160608-65da-4d4b-903d-bb601da7115a                      
{}
```

_now_

```console
% cs deleteReverseDnsFromPublicIpAddress --id=97160608-65da-4d4b-903d-bb601da7115a                                                          
{
  "displaytext": "brutas.se deleted from publicipaddressid 97160608-65da-4d4b-903d-bb601da7115a",                                            
  "success": true
}
```

svanharmelen's take is nicer than what was done here.
- https://github.com/xanzy/go-cloudstack/pull/98
- https://github.com/xanzy/go-cloudstack/pull/99