### PR TITLE
goreleaser: add maintainer field to make `dpkg` stop complaining

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ release:
 nfpm:
   vendor: Exoscale
   homepage: https://www.exoscale.com/
+  maintainer: Exoscale Support <support@exoscale.com>
   description: Tools to manage (almost) everything at Exoscale from the command line.
   license: Apache 2.0
   formats:


### PR DESCRIPTION
To avoid this message if egoscale was installed through its `deb` package:

```
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 50951 package 'egoscale':
 missing maintainer
```