### PR TITLE
dns: better error messages

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -73,13 +73,8 @@ type UpdateDNSRecordResponse struct {
 
 // DNSErrorResponse represents an error in the API
 type DNSErrorResponse struct {
-	Message string    `json:"message,omitempty"`
-	Errors  *DNSError `json:"errors"`
-}
-
-// DNSError represents an error
-type DNSError struct {
-	Name []string `json:"name"`
+	Message string              `json:"message,omitempty"`
+	Errors  map[string][]string `json:"errors"`
 }
 
 // Record represent record type
@@ -119,8 +114,14 @@ const (
 
 // Error formats the DNSerror into a string
 func (req *DNSErrorResponse) Error() string {
-	if req.Errors != nil {
-		return fmt.Sprintf("dns error: %s (%s)", req.Message, strings.Join(req.Errors.Name, ", "))
+	if len(req.Errors) > 0 {
+		errs := []string{}
+		for name, ss := range req.Errors {
+			if len(ss) > 0 {
+				errs = append(errs, fmt.Sprintf("%s: %s", name, strings.Join(ss, ", ")))
+			}
+		}
+		return fmt.Sprintf("dns error: %s (%s)", req.Message, strings.Join(errs, "; "))
 	}
 	return fmt.Sprintf("dns error: %s", req.Message)
 }


### PR DESCRIPTION
**now**

```console
% EXOSCALE_TRACE= ./exo dns add CNAME example.exo -n mx -a ""

2018/08/03 15:17:51 POST /dns/v1/domains/example.exo/records HTTP/1.1
Host: ppapi.exoscale.ch
Accept: application/json
Content-Type: application/json
User-Agent: exoscale/egoscale (0.11.0a0)

{"record":{"domain_id":391861,"name":"mx","ttl":3600,"content":"","record_type":"CNAME"}}
2018/08/03 15:17:52 HTTP/2.0 400 Bad Request
Content-Type: application/json; charset=utf-8
Date: Fri, 03 Aug 2018 13:17:51 GMT
Strict-Transport-Security: max-age=0; includeSubDomains
X-Request-Id: bdb7c70f-28eb-4fbd-96f6-37e8a60a4cab

{"message":"Validation failed","errors":{"content":["can't be blank"]}}

dns error: Validation failed (content: can't be blank)
```

**before**

```
dns error: Validation failed ()
```