### PR TITLE
Point to cmd installation instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ description: the Go library for Exoscale
 
 A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
+This project also provides an executable CLI client. See [the relevant subtree](https://github.com/exoscale/egoscale/tree/master/cmd/exo) for installation instructions.
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License"); you

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ description: the Go library for Exoscale
 
 A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
-This project also provides an executable CLI client. See [the relevant subtree](https://github.com/exoscale/egoscale/tree/master/cmd/exo) for installation instructions.
+This project also provides an executable CLI client. See [the documetation](http://exoscale.github.io/egoscale/cli/) for installation instructions.
 
 ## License
 

--- a/cmd/exo/README.md
+++ b/cmd/exo/README.md
@@ -25,7 +25,12 @@ $ go install
 ## Configuration
 
 A configuration file holding your credentials is required.
-You can generate one via a guided prompt.
+You can generate one via a guided interactive prompt with:
+
+```
+$ exo config
+```
+
 The following parameters are requested:
 
 - `API Key`

--- a/cmd/exo/README.md
+++ b/cmd/exo/README.md
@@ -36,29 +36,5 @@ $ exo config
 ## Usage
 
 ```shell
-$ exo
-A simple CLI to use CloudStack using egoscale lib
-
-Usage:
-  exo [command]
-
-Available Commands:
-  affinitygroup Affinity groups management
-  config        Generate config file for this cli
-  eip           Elastic IPs management
-  firewall      Security groups management
-  help          Help about any command
-  privnet       Private networks management
-  ssh           SSH into a virtual machine instance
-  sshkey        SSH keys pair management
-  template      List all available templates
-  vm            Virtual machines management
-  zone          List all available zones
-
-Flags:
-      --config string   Specify an alternate config file [env CLOUDSTACK_CONFIG]
-  -h, --help            help for exo
-  -r, --region string   config ini file section name [env CLOUDSTACK_REGION] (default "cloudstack")
-
-Use "exo [command] --help" for more information about a command.
+$ exo --help
 ```

--- a/cmd/exo/README.md
+++ b/cmd/exo/README.md
@@ -24,24 +24,10 @@ $ go install
 
 ## Configuration
 
-A configuration file holding your credentials is required.
-You can generate one via a guided interactive prompt with:
-
-```
-$ exo config
-```
-
-The following parameters are requested:
-
-- `API Key`
-- `Secret Key`
-
-You can find those in our [Exoscale Console](https://portal.exoscale.com/account/profile/api)
-
-### Automatic configuration
-
 The CLI will guide you in the initial configuration.
 The configuration file and all assets created by any `exo` command will be saved in the `~/.exoscale/` folder.
+
+You can find your credentials in our [Exoscale Console](https://portal.exoscale.com/account/profile/api)
 
 ```shell
 $ exo config

--- a/cmd/exo/README.md
+++ b/cmd/exo/README.md
@@ -31,23 +31,7 @@ You can find your credentials in our [Exoscale Console](https://portal.exoscale.
 
 ```shell
 $ exo config
-Hi happy Exoscalian, some configuration is required to use exo
-
-We now need some very important information, find them there.
-<https://portal.exoscale.com/account/profile/api>
-
-[+] Account name [none]: Production
-[+] API Key [none]: EXO...
-[+] Secret Key [none]: ...
-Choose [Production] default zone:
-1: ch-gva-2
-2: ch-dk-2
-3: at-vie-1
-4: de-fra-1
-[+] Select [1]: 1
-[+] Do you wish to add another account? [Yn]: n
 ```
-
 
 ## Usage
 


### PR DESCRIPTION
While installing the CLI, I noticed a couple of small touch-ups that could be made to the READMEs

