### PR TITLE
cs: fix list of uuids

### DIFF
--- a/cmd/cs/main.go
+++ b/cmd/cs/main.go
@@ -508,6 +508,14 @@ func buildFlags(method egoscale.Command) []cli.Flag {
 							value: addr.(*[]egoscale.CIDR),
 						},
 					})
+				case reflect.TypeOf(egoscale.UUID{}):
+					flags = append(flags, cli.GenericFlag{
+						Name:  argName,
+						Usage: description,
+						Value: &uuidListGeneric{
+							value: addr.(*[]egoscale.UUID),
+						},
+					})
 				default:
 					//log.Printf("[SKIP] Slice of %s is not supported!", field.Name)
 				}


### PR DESCRIPTION
```console
% cs -j createTags --resourceids 3a13ad68-63f5-42ab-abea-ffeee3363c57,f79d03f2-f514-4715-baa8-3a519e0c23a8 --resourcetype UserVM --tags a:b --tags foo:bar,hello:world
```

```json
{
  "resourceids": [
    "3a13ad68-63f5-42ab-abea-ffeee3363c57",
    "f79d03f2-f514-4715-baa8-3a519e0c23a8"
  ],
  "resourcetype": "UserVM",
  "tags": [
    {
      "key": "a",
      "value": "b"
    },
    {
      "key": "foo",
      "value": "bar"
    },
    {
      "key": "hello",
      "value": "world"
    }
  ]
}
```