### PR TITLE
cs: use listApis for the help

### DIFF
--- a/cmd/cs/flags.go
+++ b/cmd/cs/flags.go
@@ -269,7 +269,7 @@ func (g *mapGeneric) Set(value string) error {
 
 func (g *mapGeneric) String() string {
 	m := g.value
-	if *m == nil {
+	if m == nil {
 		return ""
 	}
 	vs := make([]string, 0, len(*m))

--- a/cmd/cs/main.go
+++ b/cmd/cs/main.go
@@ -168,9 +168,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if _, err := fmt.Fprintln(os.Stdout, string(help)); err != nil {
-			log.Fatal(err)
-		}
+		fmt.Println()
+		printJSON(string(help), client.Theme)
 
 		os.Exit(0)
 	}

--- a/cmd/cs/main.go
+++ b/cmd/cs/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"os"
@@ -148,15 +147,11 @@ func main() {
 	if debug || innerDebug {
 		payload, errP := client.Payload(method)
 		if errP != nil {
-			log.Fatal(errP)
-		}
-
-		if _, err := fmt.Fprintf(os.Stdout, "%s\\\n?%s", client.Endpoint, strings.Replace(payload, "&", "\\\n&", -1)); err != nil {
-			log.Fatal(err)
-		}
-
-		if _, err := fmt.Fprintln(os.Stdout); err != nil {
-			log.Fatal(err)
+			if _, err := fmt.Fprintf(os.Stderr, "cannot build payload: %s\n", errP); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			fmt.Printf("%s\\\n?%s\n", client.Endpoint, strings.Replace(payload, "&", "\\\n&", -1))
 		}
 
 		apiName := client.APIName(method)
@@ -165,7 +160,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		help, err := responseHelp(os.Stdout, resp.(*egoscale.ListAPIsResponse).API[0])
+		help, err := formatHelp(resp.(*egoscale.ListAPIsResponse).API[0])
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -580,7 +575,7 @@ type Client struct {
 	Theme string
 }
 
-func responseHelp(out io.Writer, api egoscale.API) ([]byte, error) {
+func formatHelp(api egoscale.API) ([]byte, error) {
 	response := make(map[string]interface{})
 	gather(response, api.Response)
 

--- a/cmd/cs/main.go
+++ b/cmd/cs/main.go
@@ -146,11 +146,12 @@ func main() {
 
 	// Show request and quit
 	if debug || innerDebug {
-		payload, err := client.Payload(method)
-		if err != nil {
-			log.Fatal(err)
+		payload, errP := client.Payload(method)
+		if errP != nil {
+			log.Fatal(errP)
 		}
-		if _, err = fmt.Fprintf(os.Stdout, "%s\\\n?%s", client.Endpoint, strings.Replace(payload, "&", "\\\n&", -1)); err != nil {
+
+		if _, err := fmt.Fprintf(os.Stdout, "%s\\\n?%s", client.Endpoint, strings.Replace(payload, "&", "\\\n&", -1)); err != nil {
 			log.Fatal(err)
 		}
 

--- a/serialization.go
+++ b/serialization.go
@@ -132,7 +132,7 @@ func prepareValues(prefix string, params url.Values, command interface{}) error 
 			case reflect.Ptr:
 				if val.IsNil() {
 					if required {
-						return fmt.Errorf("%s.%s (%v) is required, got tempty ptr", typeof.Name(), n, val.Kind())
+						return fmt.Errorf("%s.%s (%v) is required, got empty ptr", typeof.Name(), n, val.Kind())
 					}
 				} else {
 					switch field.Type.Elem().Kind() {


### PR DESCRIPTION
fix #289 

```console
% cs -d updateVirtualMachine --id='7d3eea64-6324-464b-b399-3083424e33ab
```

```
https://ppapi.exoscale.ch/compute/\
?apikey=EXOc94bc655ff901b7218a5c3cd\
&command=updateVirtualMachine\
&id=7d3eea64-6324-464b-b399-3083424e33ab\
&response=json
```
```json
{
  "account": "account (string) - the account associated with the virtual machine",
  "accountid": "accountid (string) - the account ID associated with the virtual machine",
  "affinitygroup": [
    {
      "account": "account (string) - the account owning the affinity group",
      "description": "description (string) - the description of the affinity group",
      "domain": "domain (string) - the domain name of the affinity group",
      "domainid": "domainid (string) - the domain ID of the affinity group",
      "id": "id (string) - the ID of the affinity group",
      "name": "name (string) - the name of the affinity group",
      "type": "type (string) - the type of the affinity group",
      "virtualmachineIds": "virtualmachineIds (list) - virtual machine Ids associated with this affinity group "
    }
  ],
  "clusterid": "clusterid (string) - the ID of the vm's cluster",
  "clustername": "clustername (string) - the name of the vm's cluster",
  "cpunumber": "cpunumber (integer) - the number of cpu this virtual machine is running with",
  "cpuspeed": "cpuspeed (integer) - the speed of each cpu",
  "cpuused": "cpuused (string) - the amount of the vm's CPU currently used",
  "created": "created (date) - the date when this virtual machine was created",
  "details": "details (map) - Vm details in key/value pairs.",
  "diskioread": "diskioread (long) - the read (io) of disk on the vm",
  "diskiowrite": "diskiowrite (long) - the write (io) of disk on the vm",
  "diskkbsread": "diskkbsread (long) - the read (bytes) of disk on the vm",
  "diskkbswrite": "diskkbswrite (long) - the write (bytes) of disk on the vm",
  "diskofferingid": "diskofferingid (string) - the ID of the disk offering of the virtual machine",
  "diskofferingname": "diskofferingname (string) - the name of the disk offering of the virtual machine",
  "displayname": "displayname (string) - user generated name. The name of the virtual machine is returned if no displayname exists.",
  "displayvm": "displayvm (boolean) - an optional field whether to the display the vm to the end user or not.",
  "domain": "domain (string) - the name of the domain in which the virtual machine exists",
  "domainid": "domainid (string) - the ID of the domain in which the virtual machine exists",
  "forvirtualnetwork": "forvirtualnetwork (boolean) - the virtual network for the service offering",
  "group": "group (string) - the group name of the virtual machine",
  "groupid": "groupid (string) - the group ID of the virtual machine",
  "haenable": "haenable (boolean) - true if high-availability is enabled, false otherwise",
  "hostid": "hostid (string) - the name of the host for the virtual machine",
  "hypervisor": "hypervisor (string) - the hypervisor on which the template runs",
  "id": "id (string) - the ID of the virtual machine",
  "instancename": "instancename (string) - instance name of the user vm; this parameter is returned to the ROOT admin only",
  "isdynamicallyscalable": "isdynamicallyscalable (boolean) - true if vm contains XS/VMWare tools inorder to support dynamic scaling of VM cpu/memory.",
  "isodisplaytext": "isodisplaytext (string) - an alternate display text of the ISO attached to the virtual machine",
  "isoid": "isoid (string) - the ID of the ISO attached to the virtual machine",
  "isoname": "isoname (string) - the name of the ISO attached to the virtual machine",
  "keypair": "keypair (string) - ssh key-pair",
  "memory": "memory (integer) - the memory allocated for the virtual machine",
  "name": "name (string) - the name of the virtual machine",
  "networkkbsread": "networkkbsread (long) - the incoming network traffic on the vm",
  "networkkbswrite": "networkkbswrite (long) - the outgoing network traffic on the host",
  "nic": [
    {
      "broadcasturi": "broadcasturi (string) - the broadcast uri of the nic",
      "deviceid": "deviceid (string) - device id for the network when plugged into the virtual machine",
      "gateway": "gateway (string) - the gateway of the nic",
      "id": "id (string) - the ID of the nic",
      "ip6address": "ip6address (string) - the IPv6 address of network",
      "ip6cidr": "ip6cidr (string) - the cidr of IPv6 network",
      "ip6gateway": "ip6gateway (string) - the gateway of IPv6 network",
      "ipaddress": "ipaddress (string) - the ip address of the nic",
      "isdefault": "isdefault (boolean) - true if nic is default, false otherwise",
      "isolationuri": "isolationuri (string) - the isolation uri of the nic",
      "macaddress": "macaddress (string) - true if nic is default, false otherwise",
      "netmask": "netmask (string) - the netmask of the nic",
      "networkid": "networkid (string) - the ID of the corresponding network",
      "networkname": "networkname (string) - the name of the corresponding network",
      "reversedns": [
        {
          "domainname": "domainname (string) - the domain name of the PTR record",
          "ip6address": "ip6address (string) - the IPv6 address linked with the PTR record (mutually exclusive with ipaddress)",
          "ipaddress": "ipaddress (string) - the IPv4 address linked with the PTR record (mutually exclusive with ip6address)",
          "nicid": "nicid (string) - the virtual machine default NIC ID",
          "publicipid": "publicipid (string) - the public IP address ID",
          "virtualmachineid": "virtualmachineid (string) - the virtual machine ID"
        }
      ],
      "secondaryip": [
        {
          "id": "id (uuid) - the ID of the secondary private IP addr",
          "ipaddress": "ipaddress (string) - Secondary IP address",
          "networkid": "networkid (uuid) - the ID of the network",
          "nicid": "nicid (uuid) - the ID of the nic",
          "virtualmachineid": "virtualmachineid (uuid) - the ID of the vm"
        }
      ],
      "traffictype": "traffictype (string) - the traffic type of the nic",
      "type": "type (string) - the type of the nic",
      "virtualmachineid": "virtualmachineid (string) - Id of the vm to which the nic belongs"
    }
  ],
  "oscategoryid": "oscategoryid (string) - Os category ID of the virtual machine",
  "oscategoryname": "oscategoryname (string) - Os category name of the virtual machine",
  "ostypeid": "ostypeid (long) - OS type id of the vm",
  "password": "password (string) - the password (if exists) of the virtual machine",
  "passwordenabled": "passwordenabled (boolean) - true if the password rest feature is enabled, false otherwise",
  "pcidevices": [
    {
      "deviceid": "deviceid (uuid) - Device model ID of pci card",
      "maxcapacity": "maxcapacity (int) - Maximum vgpu can be created with this vgpu type on the given pci group",
      "pcidevicename": "pcidevicename (string) - Device model name of pci card",
      "pcivendorid": "pcivendorid (uuid) - Device vendor ID of pci card",
      "pcivendorname": "pcivendorname (string) - Device vendor name of pci card",
      "remainingcapticy": "remainingcapticy (int) - Remaining capacity in terms of no. of more VMs that can be deployped with this vGPU type"
    }
  ],
  "podid": "podid (string) - the ID of the vm's pod",
  "podname": "podname (string) - the name of the vm's pod",
  "project": "project (string) - the project name of the vm",
  "projectid": "projectid (string) - the project id of the vm",
  "publicip": "publicip (string) - public IP address id associated with vm via Static nat rule",
  "publicipid": "publicipid (string) - public IP address id associated with vm via Static nat rule",
  "rootdeviceid": "rootdeviceid (long) - device ID of the root volume",
  "rootdevicetype": "rootdevicetype (string) - device type of the root volume",
  "securitygroup": [
    {
      "account": "account (string) - the account owning the security group",
      "description": "description (string) - the description of the security group",
      "domain": "domain (string) - the domain name of the security group",
      "domainid": "domainid (string) - the domain ID of the security group",
      "egressrule": [
        {
          "account": "account (string) - account owning the security group rule",
          "cidr": "cidr (string) - the CIDR notation for the base IP address of the security group rule",
          "description": "description (string) - description of the security group rule",
          "endport": "endport (integer) - the ending IP of the security group rule ",
          "icmpcode": "icmpcode (integer) - the code for the ICMP message response",
          "icmptype": "icmptype (integer) - the type of the ICMP message response",
          "protocol": "protocol (string) - the protocol of the security group rule",
          "ruleid": "ruleid (string) - the id of the security group rule",
          "securitygroupname": "securitygroupname (string) - security group name",
          "startport": "startport (integer) - the starting IP of the security group rule",
          "tags": [
            {
              "account": "account (string) - the account associated with the tag",
              "customer": "customer (string) - customer associated with the tag",
              "domain": "domain (string) - the domain associated with the tag",
              "domainid": "domainid (string) - the ID of the domain associated with the tag",
              "key": "key (string) - tag key name",
              "project": "project (string) - the project name where tag belongs to",
              "projectid": "projectid (string) - the project id the tag belongs to",
              "resourceid": "resourceid (string) - id of the resource",
              "resourcetype": "resourcetype (string) - resource type",
              "value": "value (string) - tag value"
            }
          ]
        }
      ],
      "id": "id (string) - the ID of the security group",
      "ingressrule": [
        {
          "account": "account (string) - account owning the security group rule",
          "cidr": "cidr (string) - the CIDR notation for the base IP address of the security group rule",
          "description": "description (string) - description of the security group rule",
          "endport": "endport (integer) - the ending IP of the security group rule ",
          "icmpcode": "icmpcode (integer) - the code for the ICMP message response",
          "icmptype": "icmptype (integer) - the type of the ICMP message response",
          "protocol": "protocol (string) - the protocol of the security group rule",
          "ruleid": "ruleid (string) - the id of the security group rule",
          "securitygroupname": "securitygroupname (string) - security group name",
          "startport": "startport (integer) - the starting IP of the security group rule",
          "tags": [
            {
              "account": "account (string) - the account associated with the tag",
              "customer": "customer (string) - customer associated with the tag",
              "domain": "domain (string) - the domain associated with the tag",
              "domainid": "domainid (string) - the ID of the domain associated with the tag",
              "key": "key (string) - tag key name",
              "project": "project (string) - the project name where tag belongs to",
              "projectid": "projectid (string) - the project id the tag belongs to",
              "resourceid": "resourceid (string) - id of the resource",
              "resourcetype": "resourcetype (string) - resource type",
              "value": "value (string) - tag value"
            }
          ]
        }
      ],
      "name": "name (string) - the name of the security group",
      "project": "project (string) - the project name of the group",
      "projectid": "projectid (string) - the project id of the group",
      "tags": [
        {
          "account": "account (string) - the account associated with the tag",
          "customer": "customer (string) - customer associated with the tag",
          "domain": "domain (string) - the domain associated with the tag",
          "domainid": "domainid (string) - the ID of the domain associated with the tag",
          "key": "key (string) - tag key name",
          "project": "project (string) - the project name where tag belongs to",
          "projectid": "projectid (string) - the project id the tag belongs to",
          "resourceid": "resourceid (string) - id of the resource",
          "resourcetype": "resourcetype (string) - resource type",
          "value": "value (string) - tag value"
        }
      ]
    }
  ],
  "serviceofferingid": "serviceofferingid (string) - the ID of the service offering of the virtual machine",
  "serviceofferingname": "serviceofferingname (string) - the name of the service offering of the virtual machine",
  "servicestate": "servicestate (string) - State of the Service from LB rule",
  "state": "state (string) - the state of the virtual machine",
  "tags": [
    {
      "account": "account (string) - the account associated with the tag",
      "customer": "customer (string) - customer associated with the tag",
      "domain": "domain (string) - the domain associated with the tag",
      "domainid": "domainid (string) - the ID of the domain associated with the tag",
      "key": "key (string) - tag key name",
      "project": "project (string) - the project name where tag belongs to",
      "projectid": "projectid (string) - the project id the tag belongs to",
      "resourceid": "resourceid (string) - id of the resource",
      "resourcetype": "resourcetype (string) - resource type",
      "value": "value (string) - tag value"
    }
  ],
  "templatedisplaytext": "templatedisplaytext (string) - an alternate display text of the template for the virtual machine",
  "templateid": "templateid (string) - the ID of the template for the virtual machine. A -1 is returned if the virtual machine was created from an ISO file.",
  "templatename": "templatename (string) - the name of the template for the virtual machine",
  "zoneid": "zoneid (string) - the ID of the availablility zone for the virtual machine",
  "zonename": "zonename (string) - the name of the availability zone for the virtual machine"
}
```