### PR TITLE
Fix handling of brackets '[]'

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,12 +117,13 @@ func (client *Client) GetWithContext(ctx context.Context, g Gettable) error {
 		if err != nil {
 			return err
 		}
-		payload, err := client.Payload(req)
+		params, err := client.Payload(req)
 		if err != nil {
 			return err
 		}
 
 		// formatting the query string nicely
+		payload := params.Encode()
 		payload = strings.Replace(payload, "&", ", ", -1)
 
 		if count == 0 {

--- a/serialization.go
+++ b/serialization.go
@@ -13,8 +13,6 @@ import (
 
 func csQuotePlus(s string) string {
 	s = strings.Replace(s, "+", "%20", -1)
-	s = strings.Replace(s, "%5B", "[", -1)
-	s = strings.Replace(s, "%5D", "]", -1)
 	return s
 }
 


### PR DESCRIPTION
Fix handling of brackets '[]' in parameter values (e.g.in a description field) and 
when a parameter name contains
'[]' and a POST is used (e.g. during a DeployVirtualMachine).

CloudStack only uses a specialized encoding for the signature
calculation. It only query encodes the values of the query arguments
and always use '%20' for whitespaces (no '+'). But for the GET url
and for the POST body, we always have to use the normal
query escaping as standardized.

Signed-off-by: stffabi <stffabi@pm.me>