### PR TITLE
Fix empty list result

### DIFF
--- a/request.go
+++ b/request.go
@@ -87,7 +87,8 @@ func (client *Client) parseResponse(resp *http.Response, apiName string) (json.R
 		return nil, err
 	}
 
-	if len(n) > 1 {
+	// list response may contain only one key
+	if len(n) > 1 || strings.HasPrefix(key, "list") {
 		return response, nil
 	}
 


### PR DESCRIPTION
```console
% cs listVirtualMachines
2018/08/29 11:06:29 GET /compute/?apikey=EXOc94bc655ff901b7218a5c3cd&command=listVirtualMachines&response=json&signature=*** HTTP/1.1
Host: ppapi.exoscale.ch
User-Agent: exoscale/egoscale (0.11.1)

2018/08/29 11:06:29 HTTP/2.0 200 OK
Content-Type: application/json; charset=utf-8
Date: Wed, 29 Aug 2018 09:06:21 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Request-Id: f77e40a3-4e41-4976-b515-c9bbaf3a4563

{"listvirtualmachinesresponse":{"virtualmachine":[]}}
```

**before**

```
json: cannot unmarshal array into Go value of type egoscale.ListVirtualMachinesResponse
```

**after**

```json
{
  "count": 0,
  "virtualmachine": []
}
```