### PR TITLE
request: signatureVersion=3

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,6 +52,8 @@ type Client struct {
 	PageSize int
 	// Timeout represents the default timeout for the async requests
 	Timeout time.Duration
+	// Expiration representation how long a signed payload may be used
+	Expiration time.Duration
 	// RetryStrategy represents the waiting strategy for polling the async requests
 	RetryStrategy RetryStrategyFunc
 	// Logger contains any log, plug your own
@@ -72,6 +74,7 @@ type WaitAsyncJobResultFunc func(*AsyncJobResult, error) bool
 // Timeout is set to both the HTTP client and the client itself.
 func NewClient(endpoint, apiKey, apiSecret string) *Client {
 	timeout := 60 * time.Second
+	expiration := 10 * time.Minute
 
 	httpClient := &http.Client{
 		Transport: http.DefaultTransport,
@@ -84,6 +87,7 @@ func NewClient(endpoint, apiKey, apiSecret string) *Client {
 		apiSecret:     apiSecret,
 		PageSize:      50,
 		Timeout:       timeout,
+		Expiration:    expiration,
 		RetryStrategy: MonotonicRetryStrategyFunc(2),
 		Logger:        log.New(ioutil.Discard, "", 0),
 	}

--- a/request.go
+++ b/request.go
@@ -297,7 +297,7 @@ func (client *Client) Payload(command Command) (url.Values, error) {
 	params.Set("command", client.APIName(command))
 	params.Set("response", "json")
 	params.Set("signatureversion", "3")
-	params.Set("expires", time.Now().UTC().Format("2006-01-02T03:04:05-0600"))
+	params.Set("expires", time.Now().Local().Format("2006-01-02T15:04:05-0700"))
 
 	return params, nil
 }

--- a/request.go
+++ b/request.go
@@ -18,6 +18,9 @@ import (
 	"time"
 )
 
+// requestValidity represents when a signed request is meant to expire
+const requestValidity = 10 * time.Second
+
 // Error formats a CloudStack error into a standard error
 func (e ErrorResponse) Error() string {
 	return fmt.Sprintf("API error %s %d (%s %d): %s", e.ErrorCode, e.ErrorCode, e.CSErrorCode, e.CSErrorCode, e.ErrorText)
@@ -296,8 +299,11 @@ func (client *Client) Payload(command Command) (url.Values, error) {
 	params.Set("apikey", client.APIKey)
 	params.Set("command", client.APIName(command))
 	params.Set("response", "json")
-	params.Set("signatureversion", "3")
-	params.Set("expires", time.Now().Local().Format("2006-01-02T15:04:05-0700"))
+
+	if params.Get("expires") == "" {
+		params.Set("signatureversion", "3")
+		params.Set("expires", time.Now().Add(requestValidity).Local().Format("2006-01-02T15:04:05-0700"))
+	}
 
 	return params, nil
 }

--- a/request.go
+++ b/request.go
@@ -18,9 +18,6 @@ import (
 	"time"
 )
 
-// requestValidity represents when a signed request is meant to expire
-const requestValidity = 10 * time.Second
-
 // Error formats a CloudStack error into a standard error
 func (e ErrorResponse) Error() string {
 	return fmt.Sprintf("API error %s %d (%s %d): %s", e.ErrorCode, e.ErrorCode, e.CSErrorCode, e.CSErrorCode, e.ErrorText)
@@ -300,9 +297,9 @@ func (client *Client) Payload(command Command) (url.Values, error) {
 	params.Set("command", client.APIName(command))
 	params.Set("response", "json")
 
-	if params.Get("expires") == "" {
+	if params.Get("expires") == "" && client.Expiration >= 0 {
 		params.Set("signatureversion", "3")
-		params.Set("expires", time.Now().Add(requestValidity).Local().Format("2006-01-02T15:04:05-0700"))
+		params.Set("expires", time.Now().Add(client.Expiration).Local().Format("2006-01-02T15:04:05-0700"))
 	}
 
 	return params, nil

--- a/request.go
+++ b/request.go
@@ -296,6 +296,8 @@ func (client *Client) Payload(command Command) (url.Values, error) {
 	params.Set("apikey", client.APIKey)
 	params.Set("command", client.APIName(command))
 	params.Set("response", "json")
+	params.Set("signatureversion", "3")
+	params.Set("expires", time.Now().UTC().Format("2006-01-02T03:04:05-0600"))
 
 	return params, nil
 }


### PR DESCRIPTION
Enables the API call expiration, 10 minutes by default.

http://docs.cloudstack.apache.org/en/4.11.1.0/developersguide/dev.html?enabling-api-call-expiration