### PR TITLE
managed private networks: update the create and list commands

### DIFF
--- a/cmd/exo/cmd/privnet.go
+++ b/cmd/exo/cmd/privnet.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"net"
+
 	"github.com/exoscale/egoscale"
 	"github.com/spf13/cobra"
 )
@@ -33,4 +36,14 @@ func getNetworkByName(name string) (*egoscale.Network, error) {
 
 func init() {
 	RootCmd.AddCommand(privnetCmd)
+}
+
+// dhcpRange returns the string representation for a DHCP
+func dhcpRange(startIP, endIP, netmask net.IP) string {
+	if startIP != nil && endIP != nil && netmask != nil {
+		mask := net.IPMask(netmask.To4())
+		prefixSize, _ := mask.Size()
+		return fmt.Sprintf("%s-%s /%d", startIP.String(), endIP.String(), prefixSize)
+	}
+	return "n/a"
 }

--- a/cmd/exo/cmd/privnet_create.go
+++ b/cmd/exo/cmd/privnet_create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"net"
 	"os"
 
 	"github.com/exoscale/egoscale"
@@ -16,11 +17,23 @@ var privnetCreateCmd = &cobra.Command{
 	Short:   "Create private network",
 	Aliases: gCreateAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, err := cmd.Flags().GetString("name")
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+		name := args[0]
+		desc, err := cmd.Flags().GetString("description")
 		if err != nil {
 			return err
 		}
-		desc, err := cmd.Flags().GetString("description")
+		startip, err := cmd.Flags().GetString("startip")
+		if err != nil {
+			return err
+		}
+		endip, err := cmd.Flags().GetString("endip")
+		if err != nil {
+			return err
+		}
+		netmask, err := cmd.Flags().GetString("netmask")
 		if err != nil {
 			return err
 		}
@@ -29,18 +42,12 @@ var privnetCreateCmd = &cobra.Command{
 			return err
 		}
 
-		if name != "" && zone == "" {
+		if zone == "" {
 			zone = gCurrentAccount.DefaultZone
 		}
 
 		if name == "" && zone == "" {
 			reader := bufio.NewReader(os.Stdin)
-			if name == "" {
-				name, err = readInput(reader, "Name", "")
-				if err != nil {
-					return err
-				}
-			}
 			if desc == "" {
 				desc, err = readInput(reader, "Description", "")
 				if err != nil {
@@ -59,7 +66,7 @@ var privnetCreateCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 
-		return privnetCreate(name, desc, zone)
+		return privnetCreate(name, desc, zone, startip, endip, netmask)
 	},
 }
 
@@ -72,7 +79,7 @@ func isEmptyArgs(args ...string) bool {
 	return false
 }
 
-func privnetCreate(name, desc, zoneName string) error {
+func privnetCreate(name, desc, zoneName, startIPAddr, endIPAddr, netmask string) error {
 	zone, err := getZoneIDByName(zoneName)
 	if err != nil {
 		return err
@@ -83,12 +90,19 @@ func privnetCreate(name, desc, zoneName string) error {
 		return err
 	}
 
+	startIP := net.ParseIP(startIPAddr)
+	endIP := net.ParseIP(endIPAddr)
+	netmaskIP := net.ParseIP(netmask)
+
 	s := resp.(*egoscale.ListNetworkOfferingsResponse)
 
 	req := &egoscale.CreateNetwork{
 		DisplayText: desc,
 		Name:        name,
 		ZoneID:      zone,
+		StartIP:     startIP,
+		EndIP:       endIP,
+		Netmask:     netmaskIP,
 	}
 	if len(s.NetworkOffering) > 0 {
 		req.NetworkOfferingID = s.NetworkOffering[0].ID
@@ -102,15 +116,23 @@ func privnetCreate(name, desc, zoneName string) error {
 	newNet := resp.(*egoscale.Network)
 
 	table := table.NewTable(os.Stdout)
-	table.SetHeader([]string{"Name", "Description", "ID"})
-	table.Append([]string{newNet.Name, newNet.DisplayText, newNet.ID.String()})
+	table.SetHeader([]string{"Name", "Description", "ID", "DHCP"})
+
+	table.Append([]string{
+		newNet.Name,
+		newNet.DisplayText,
+		newNet.ID.String(),
+		dhcpRange(startIP, endIP, netmaskIP),
+	})
 	table.Render()
 	return nil
 }
 
 func init() {
-	privnetCreateCmd.Flags().StringP("name", "n", "", "Private network name")
 	privnetCreateCmd.Flags().StringP("description", "d", "", "Private network description")
+	privnetCreateCmd.Flags().StringP("startip", "s", "", "the beginning IP address in the network IP range. Required for managed networks.")
+	privnetCreateCmd.Flags().StringP("endip", "e", "", "the ending IP address in the network IP range. Required for managed networks.")
+	privnetCreateCmd.Flags().StringP("netmask", "n", "", "the netmask of the network. Required for managed networks.")
 	privnetCreateCmd.Flags().StringP("zone", "z", "", "Assign private network to a zone")
 	privnetCmd.AddCommand(privnetCreateCmd)
 }

--- a/cmd/exo/cmd/privnet_list.go
+++ b/cmd/exo/cmd/privnet_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/exoscale/egoscale"
 	"github.com/exoscale/egoscale/cmd/exo/table"
+
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ var privnetListCmd = &cobra.Command{
 			return err
 		}
 		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"zone", "Name", "ID", "Associated Virtual machine"})
+		table.SetHeader([]string{"zone", "Name", "ID", "Associated Virtual machine", "DHCP"})
 		if err := listPrivnets(zone, table); err != nil {
 			return err
 		}
@@ -59,7 +60,13 @@ func listPrivnets(zone string, table *table.Table) error {
 
 			vmNum := fmt.Sprintf("%d", len(vms))
 
-			table.Append([]string{zone, pn.Name, pn.ID.String(), vmNum})
+			table.Append([]string{
+				zone,
+				pn.Name,
+				pn.ID.String(),
+				vmNum,
+				dhcpRange(pn.StartIP, pn.EndIP, pn.Netmask),
+			})
 
 			zone = ""
 		}

--- a/cmd/exo/cmd/privnet_test.go
+++ b/cmd/exo/cmd/privnet_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"net"
+	"testing"
+)
+
+type dhcp struct {
+	startIP net.IP
+	endIP   net.IP
+	netmask net.IP
+}
+
+func TestDhcpRange(t *testing.T) {
+	cases := []struct {
+		in   dhcp
+		want string
+	}{
+		{
+			in: dhcp{
+				startIP: net.ParseIP("10.0.0.2"),
+				endIP:   net.ParseIP("10.0.0.100"),
+				netmask: net.ParseIP("255.255.255.0"),
+			},
+			want: "10.0.0.2-10.0.0.100 /24",
+		},
+		{
+			in: dhcp{
+				startIP: net.ParseIP("10.0.0.1"),
+				endIP:   net.ParseIP("10.0.0.200"),
+				netmask: net.ParseIP("255.255.0.0"),
+			},
+			want: "10.0.0.1-10.0.0.200 /16",
+		},
+		{
+			in: dhcp{
+				startIP: net.ParseIP("10.0.0.1"),
+				endIP:   net.ParseIP("foo"),
+				netmask: net.ParseIP("255.255.0.0"),
+			},
+			want: "n/a",
+		},
+	}
+	for _, c := range cases {
+		result := dhcpRange(c.in.startIP, c.in.endIP, c.in.netmask)
+		if result != c.want {
+			t.Errorf("got %s, want %s", result, c.want)
+		}
+	}
+}

--- a/networks.go
+++ b/networks.go
@@ -22,6 +22,7 @@ type Network struct {
 	DNS2                        net.IP        `json:"dns2,omitempty" doc:"the second DNS for the network"`
 	Domain                      string        `json:"domain,omitempty" doc:"the domain name of the network owner"`
 	DomainID                    *UUID         `json:"domainid,omitempty" doc:"the domain id of the network owner"`
+	EndIP                       net.IP        `json:"endip,omitempty" doc:"the ending IP address in the network IP range. Required for managed networks."`
 	Gateway                     net.IP        `json:"gateway,omitempty" doc:"the network's gateway"`
 	ID                          *UUID         `json:"id,omitempty" doc:"the id of the network"`
 	IP6CIDR                     *CIDR         `json:"ip6cidr,omitempty" doc:"the cidr of IPv6 network"`
@@ -44,6 +45,7 @@ type Network struct {
 	RestartRequired             bool          `json:"restartrequired,omitempty" doc:"true network requires restart"`
 	Service                     []Service     `json:"service,omitempty" doc:"the list of services"`
 	SpecifyIPRanges             bool          `json:"specifyipranges,omitempty" doc:"true if network supports specifying ip ranges, false otherwise"`
+	StartIP                     net.IP        `json:"startip,omitempty" doc:"the beginning IP address in the network IP range. Required for managed networks."`
 	State                       string        `json:"state,omitempty" doc:"state of the network"`
 	StrechedL2Subnet            bool          `json:"strechedl2subnet,omitempty" doc:"true if network can span multiple zones"`
 	SubdomainAccess             bool          `json:"subdomainaccess,omitempty" doc:"true if users from subdomains can access the domain level network"`
@@ -114,18 +116,18 @@ type CreateNetwork struct {
 	DisplayNetwork    *bool  `json:"displaynetwork,omitempty" doc:"an optional field, whether to the display the network to the end user or not."`
 	DisplayText       string `json:"displaytext,omitempty" doc:"the display text of the network"` // This field is required but might be empty
 	DomainID          *UUID  `json:"domainid,omitempty" doc:"domain ID of the account owning a network"`
-	EndIP             net.IP `json:"endip,omitempty" doc:"the ending IP address in the network IP range. If not specified, will be defaulted to startIP"`
+	EndIP             net.IP `json:"endip,omitempty" doc:"the ending IP address in the network IP range. Required for managed networks."`
 	EndIpv6           net.IP `json:"endipv6,omitempty" doc:"the ending IPv6 address in the IPv6 network range"`
 	Gateway           net.IP `json:"gateway,omitempty" doc:"the gateway of the network. Required for Shared networks and Isolated networks when it belongs to VPC"`
 	IP6CIDR           *CIDR  `json:"ip6cidr,omitempty" doc:"the CIDR of IPv6 network, must be at least /64"`
 	IP6Gateway        net.IP `json:"ip6gateway,omitempty" doc:"the gateway of the IPv6 network. Required for Shared networks and Isolated networks when it belongs to VPC"`
 	IsolatedPVlan     string `json:"isolatedpvlan,omitempty" doc:"the isolated private vlan for this network"`
 	Name              string `json:"name,omitempty" doc:"the name of the network"` // This field is required but might be empty
-	Netmask           net.IP `json:"netmask,omitempty" doc:"the netmask of the network. Required for Shared networks and Isolated networks when it belongs to VPC"`
+	Netmask           net.IP `json:"netmask,omitempty" doc:"the netmask of the network. Required for managed networks."`
 	NetworkDomain     string `json:"networkdomain,omitempty" doc:"network domain"`
 	NetworkOfferingID *UUID  `json:"networkofferingid" doc:"the network offering id"`
 	PhysicalNetworkID *UUID  `json:"physicalnetworkid,omitempty" doc:"the Physical Network ID the network belongs to"`
-	StartIP           net.IP `json:"startip,omitempty" doc:"the beginning IP address in the network IP range"`
+	StartIP           net.IP `json:"startip,omitempty" doc:"the beginning IP address in the network IP range. Required for managed networks."`
 	StartIpv6         net.IP `json:"startipv6,omitempty" doc:"the beginning IPv6 address in the IPv6 network range"`
 	SubdomainAccess   *bool  `json:"subdomainaccess,omitempty" doc:"Defines whether to allow subdomains to use networks dedicated to their parent domain(s). Should be used with aclType=Domain, defaulted to allow.subdomain.network.access global config if not specified"`
 	Vlan              string `json:"vlan,omitempty" doc:"the ID or VID of the network"`


### PR DESCRIPTION
#319 

- Add the `startip`, `endip`, `netmask` parameters to the create
  network command
- Show the `startip`, `endip`, `netmask` fields in the list networks command