### PR TITLE
request: Better error messages in parseResponse

### DIFF
--- a/request.go
+++ b/request.go
@@ -67,8 +67,13 @@ func (client *Client) parseResponse(resp *http.Response, apiName string) (json.R
 			response, ok = m[key]
 
 			if !ok {
-				for k := range m {
-					return nil, fmt.Errorf("malformed JSON response, %q was expected, got %q", key, k)
+				// try again with the message key
+				key = "message"
+				response, ok = m[key]
+				if !ok {
+					for k := range m {
+						return nil, fmt.Errorf("malformed JSON response, %q was expected, got %q : %q", key, k, b)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The Exoscale API can return error messages in the `message` key. Also,
i added the raw message in the error message generated if the response
body is invalid (it will be easier for the users to fire out what
happened exactly).