### PR TITLE
exo: failed async job should fail

### DIFF
--- a/cmd/exo/cmd/request.go
+++ b/cmd/exo/cmd/request.go
@@ -156,17 +156,17 @@ func asyncRequest(cmd egoscale.AsyncCommand, msg string) (interface{}, error) {
 			return false
 		}
 
-		if jobResult.JobStatus == egoscale.Success {
-			if errR := jobResult.Result(response); errR != nil {
-				errorReq = errR
-				return false
-			}
+		if jobResult.JobStatus == egoscale.Pending {
+			return true
+		}
 
-			fmt.Println(" success.")
+		if errR := jobResult.Result(response); errR != nil {
+			errorReq = errR
 			return false
 		}
 
-		return true
+		fmt.Println(" success.")
+		return false
 	})
 
 	if errorReq != nil {


### PR DESCRIPTION
closes #322.

```console
% EXOSCALE_TRACE= ./exo privnet update --id 5ee3d97f-3187-4451-8e02-464da7e5c50c --startip=10.0.0.0 --endip=10.0.0.100

2018/09/18 10:40:00 HTTP/2.0 200 OK
Content-Type: application/json; charset=utf-8
Date: Tue, 18 Sep 2018 08:39:38 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Request-Id: 96c33c94-12e5-491b-b431-3cfcb9a94266

{"updatenetworkresponse":{"jobid":"6125f290-bb1e-11e8-9282-e76b23d3ba0e"}}

{"queryasyncjobresultresponse":{"jobprocstatus":0,"userid":"64024bfa-6de0-40a1-a655-10d16be74d7f","created":"2018-09-18T10:39:38+0200","jobid":"6125f290-bb1e-11e8-9282-e76b23d3ba0e","jobresult":{"errorcode":530,"errortext":"You should provide all of these fields:  start-ip, end-ip, n
etmask."},"jobresultcode":0,"jobstatus":2,"cmd":"org.apache.cloudstack.api.command.user.network.UpdateNetworkCmd","accountid":"74c1d64f-50b5-4cfa-b461-955b02a8ec99"}}
. failure!

API error InternalError 530 (CSErrorCode(0) 0): You should provide all of these fields:  start-ip, end-ip, netmask.
```