### PR TITLE
request: update vm affinity group response

### DIFF
--- a/request.go
+++ b/request.go
@@ -37,6 +37,7 @@ var responseKeys = map[string]string{
 	"addiptonicresponse":            "addiptovmnicresponse",
 	"activateip6response":           "activateip6nicresponse",
 	"restorevirtualmachineresponse": "restorevmresponse",
+	"updatevmaffinitygroupresponse": "updatevirtualmachineresponse",
 }
 
 func (client *Client) parseResponse(resp *http.Response, apiName string) (json.RawMessage, error) {


### PR DESCRIPTION
**then**
```console
% cs -r testing updateVMAffinityGroup --id 1252eddd-9cbf-4f9e-847c-be25de210ccb --affinitygroupnames yoan 
malformed JSON response, "updatevmaffinitygroupresponse" was expected, got "updatevirtualmachineresponse"
```

**now**
```console
% cs -r testing updateVMAffinityGroup --id 1252eddd-9cbf-4f9e-847c-be25de210ccb --affinitygroupnames yoan   
{
  "account": "cloudstack-testing",
  "affinitygroup": [
    {
      "account": "cloudstack-testing",
      "id": "9f0b3f8b-b331-479a-81d8-6c9c94c2a699",
      "name": "yoan"
    }
  ],
  "created": "2018-07-11T08:54:56+0200",
  "displayname": "obwald-testing-do-not-delete",
  "domain": "cloudstack-testing",
  "domainid": "2083e04d-500f-48ef-8e3d-bae6805417cd",
  "hypervisor": "KVM",
  "id": "1252eddd-9cbf-4f9e-847c-be25de210ccb",
  "keypair": "jenkins",
  "name": "VM-1252eddd-9cbf-4f9e-847c-be25de210ccb",
  "nic": [
    {
      "broadcasturi": "vlan://untagged",
      "gateway": "185.150.8.1",
      "id": "94b796df-e165-4a0d-acb6-425120ede3aa",
      "ip6address": "2a04:c45:c00:68f:4d2:bcff:fe00:62",
      "ip6cidr": "2a04:c45:c00:68f::/64",
      "ipaddress": "185.150.8.31",
      "isdefault": true,
      "macaddress": "06:d2:bc:00:00:62",
      "netmask": "255.255.252.0",
      "networkid": "2fbc4161-da5a-4be3-b5d8-ed34270cb827",
      "networkname": "defaultGuestNetwork",
      "secondaryip": [
        {
          "id": "bd717e8e-3096-4cd5-ad51-c8a2ef38d50a",
          "ipaddress": "185.150.8.6"
        }
      ],
      "traffictype": "Guest",
      "type": "Shared"
    }
  ],
  "oscategoryid": "ca158095-a6d2-4b0c-95e3-9a2e5123cbfc",
  "oscategoryname": "Other",
  "securitygroup": [
    {
      "account": "cloudstack-testing",
      "description": "Default Security Group",
      "id": "2b2d923a-01fc-4c2f-b98d-401f4c8630fc",
      "name": "default"
    }
  ],
  "state": "Stopped",
  "zoneid": "b0fcd72f-47ad-4779-a64f-fe4de007ec72",
  "zonename": "at-vie-1"
}
```