### PR TITLE
exo: fix affinity delete

### DIFF
--- a/cmd/exo/cmd/affinitygroup.go
+++ b/cmd/exo/cmd/affinitygroup.go
@@ -17,7 +17,7 @@ func getAffinityGroupByName(name string) (*egoscale.AffinityGroup, error) {
 	aff := &egoscale.AffinityGroup{}
 
 	id, err := egoscale.ParseUUID(name)
-	if err != nil {
+	if err == nil {
 		aff.ID = id
 	} else {
 		aff.Name = name


### PR DESCRIPTION
the affinity group name wasn't properly set... hence it was failing when one had more than one anti-affinity group (crickey).

**then**

```console
% exo affinitygroup delete my-anti-aff                                                                                      
[+] sure you want to delete "my-anti-aff" affinity group [yN]: y                                                                             
more than one element found: apikey=EXOc94bc655ff901b7218a5c3cd, command=listAffinityGroups, response=json
```

**now**

```console
% exo affinitygroup delete my-anti-aff                                                                                      
[+] sure you want to delete "my-anti-aff" affinity group [yN]: y
7bb25bc3-7901-495e-a5a8-13b578551fb7
```