### PR TITLE
network: listNetworks by name (hack)

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -63,6 +63,7 @@ func (network Network) ListRequest() (ListCommand, error) {
 		Account:           network.Account,
 		DomainID:          network.DomainID,
 		ID:                network.ID,
+		Keyword:           network.Name, // this is a hack as listNetworks doesn't support to search by name.
 		PhysicalNetworkID: network.PhysicalNetworkID,
 		TrafficType:       network.TrafficType,
 		Type:              network.Type,


### PR DESCRIPTION
The `listNetworks` command doesn't offer any _name_ parameter but we can work around it using the _keyword_ one.

**then**

```console
% exo privnet show my-privnet
more than one element found: apikey=EXOc94bc655ff901b7218a5c3cd, canusefordeploy=true, command=listNetworks, response=json, type=Isolated
```

**now**

```console
% exo privnet show my-privnet
┼──────────┼────────────┼─────────────────┼────────────────────┼
│   ZONE   │    NAME    │ VIRTUAL MACHINE │ VIRTUAL MACHINE ID │
┼──────────┼────────────┼─────────────────┼────────────────────┼
│ ch-gva-2 │ my-privnet │                 │                    │
┼──────────┼────────────┼─────────────────┼────────────────────┼
```