### PR TITLE
serialization: fail on empty IP, not zero.

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -159,7 +159,7 @@ func prepareValues(prefix string, params url.Values, command interface{}) error 
 					switch field.Type {
 					case reflect.TypeOf(net.IPv4zero):
 						ip := (net.IP)(val.Bytes())
-						if ip == nil || ip.Equal(net.IPv4zero) {
+						if ip == nil || ip.Equal(net.IP{}) {
 							if required {
 								return fmt.Errorf("%s.%s (%v) is required, got zero IPv4 address", typeof.Name(), n, val.Kind())
 							}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -262,11 +262,11 @@ func TestPrepareValuesIP(t *testing.T) {
 	}
 }
 
-func TestPrepareValuesIPZero(t *testing.T) {
+func TestPrepareValuesIPNil(t *testing.T) {
 	profile := struct {
 		RequiredField net.IP `json:"requiredfield"`
 	}{
-		RequiredField: net.IPv4zero,
+		RequiredField: net.IP{},
 	}
 
 	params := url.Values{}


### PR DESCRIPTION
`net.IPv4zero` serialize as `0.0.0.0` while `net.IP{}` produces `nil`. Only the later should be avoided.