### PR TITLE
exo: config to also pick legacy computeEndpoint

### DIFF
--- a/cmd/exo/cmd/config.go
+++ b/cmd/exo/cmd/config.go
@@ -218,7 +218,7 @@ func addAccount(filePath string, newAccounts *config) error {
 		accounts[i] = map[string]string{}
 
 		accounts[i]["name"] = acc.Name
-		accounts[i]["computeEndpoint"] = acc.Endpoint
+		accounts[i]["endpoint"] = acc.Endpoint
 		accounts[i]["key"] = acc.Key
 		accounts[i]["secret"] = acc.Secret
 		accounts[i]["defaultZone"] = acc.DefaultZone
@@ -235,7 +235,7 @@ func addAccount(filePath string, newAccounts *config) error {
 			accounts[accountsSize+i] = map[string]string{}
 
 			accounts[accountsSize+i]["name"] = acc.Name
-			accounts[accountsSize+i]["computeEndpoint"] = acc.Endpoint
+			accounts[accountsSize+i]["endpoint"] = acc.Endpoint
 			accounts[accountsSize+i]["key"] = acc.Key
 			accounts[accountsSize+i]["secret"] = acc.Secret
 			accounts[accountsSize+i]["defaultZone"] = acc.DefaultZone

--- a/cmd/exo/cmd/root.go
+++ b/cmd/exo/cmd/root.go
@@ -44,6 +44,7 @@ type account struct {
 	Name            string
 	Account         string
 	Endpoint        string
+	ComputeEndpoint string // legacy config.
 	DNSEndpoint     string
 	SosEndpoint     string
 	Key             string
@@ -223,7 +224,11 @@ func initConfig() {
 	}
 
 	if gCurrentAccount.Endpoint == "" {
-		gCurrentAccount.Endpoint = defaultEndpoint
+		if gCurrentAccount.ComputeEndpoint != "" {
+			gCurrentAccount.Endpoint = gCurrentAccount.ComputeEndpoint
+		} else {
+			gCurrentAccount.Endpoint = defaultEndpoint
+		}
 	}
 
 	if gCurrentAccount.DNSEndpoint == "" {


### PR DESCRIPTION
the config file should use `endpoint` and not `computeEndpoint`, although we forgot to remove some of them. This should fix new config as well as support old ones.

```console
% more ~/.exoscale/exoscale.toml | grep -i endpoint
  computeEndpoint = "https://ppapi.exoscale.ch/compute/"
  sosEndpoint = "https://ppsos-{zone}.exo.io"

% ./exo api zone ls --keyword de                   
{
  "count": 1,
  "zone": [
    {
      "allocationstate": "Enabled",
      "dhcpprovider": "VirtualRouter",
      "id": "de88c980-78f6-467c-a431-71bcc88e437f",
      "localstorageenabled": true,
      "name": "de-fra-1",
      "networktype": "Basic",
      "securitygroupsenabled": true,
      "zonetoken": "c4bdb9f2-c28d-36a3-bbc5-f91fc69527e6"
    }
  ]
}
```