### PR TITLE
generate: re-enable check of the return type

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -87,7 +87,7 @@ type ListAccounts struct {
 	DomainID          *UUID       `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID                *UUID       `json:"id,omitempty" doc:"list account by account ID"`
 	IsCleanUpRequired *bool       `json:"iscleanuprequired,omitempty" doc:"list accounts by cleanuprequired attribute (values are true or false)"`
-	IsRecursive       *bool       `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive       *bool       `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword           string      `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll           *bool       `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name              string      `json:"name,omitempty" doc:"list account by account name"`

--- a/addresses.go
+++ b/addresses.go
@@ -136,7 +136,7 @@ func (UpdateIPAddress) asyncResponse() interface{} {
 
 // ListPublicIPAddresses represents a search for public IP addresses
 type ListPublicIPAddresses struct {
-	Account             string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account             string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	AllocatedOnly       *bool         `json:"allocatedonly,omitempty" doc:"limits search results to allocated public IP addresses"`
 	AssociatedNetworkID *UUID         `json:"associatednetworkid,omitempty" doc:"lists all public IP addresses associated to the network specified"`
 	DomainID            *UUID         `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
@@ -146,7 +146,7 @@ type ListPublicIPAddresses struct {
 	ID                  *UUID         `json:"id,omitempty" doc:"lists ip address by id"`
 	IPAddress           net.IP        `json:"ipaddress,omitempty" doc:"lists the specified IP address"`
 	IsElastic           *bool         `json:"iselastic,omitempty" doc:"list only elastic ip addresses"`
-	IsRecursive         *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive         *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	IsSourceNat         *bool         `json:"issourcenat,omitempty" doc:"list only source nat ip addresses"`
 	IsStaticNat         *bool         `json:"isstaticnat,omitempty" doc:"list only static nat ip addresses"`
 	Keyword             string        `json:"keyword,omitempty" doc:"List by keyword"`

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -56,9 +56,9 @@ type AffinityGroupType struct {
 
 // CreateAffinityGroup (Async) represents a new (anti-)affinity group
 type CreateAffinityGroup struct {
-	Account     string `json:"account,omitempty" doc:"an account for the affinity group. Must be used with domainId."`
+	Account     string `json:"account,omitempty" doc:"an account for the affinity group. Must be used with domainid."`
 	Description string `json:"description,omitempty" doc:"optional description of the affinity group"`
-	DomainID    *UUID  `json:"domainid,omitempty" doc:"domainId of the account owning the affinity group"`
+	DomainID    *UUID  `json:"domainid,omitempty" doc:"domainid of the account owning the affinity group"`
 	Name        string `json:"name" doc:"name of the affinity group"`
 	Type        string `json:"type" doc:"Type of the affinity group from the available affinity/anti-affinity group types"`
 	_           bool   `name:"createAffinityGroup" description:"Creates an affinity/anti-affinity group"`
@@ -115,10 +115,10 @@ func (DeleteAffinityGroup) asyncResponse() interface{} {
 
 // ListAffinityGroups represents an (anti-)affinity groups search
 type ListAffinityGroups struct {
-	Account          string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account          string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID         *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID               *UUID  `json:"id,omitempty" doc:"list the affinity group by the ID provided"`
-	IsRecursive      *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive      *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword          string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll          *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name             string `json:"name,omitempty" doc:"lists affinity groups by name"`

--- a/async_jobs.go
+++ b/async_jobs.go
@@ -41,9 +41,9 @@ func (QueryAsyncJobResult) response() interface{} {
 
 // ListAsyncJobs list the asynchronous jobs
 type ListAsyncJobs struct {
-	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID    *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
-	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword     string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll     *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Page        int    `json:"page,omitempty"`

--- a/events.go
+++ b/events.go
@@ -22,13 +22,13 @@ type EventType struct {
 
 // ListEvents list the events
 type ListEvents struct {
-	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID    *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	Duration    int    `json:"duration,omitempty" doc:"the duration of the event"`
 	EndDate     string `json:"enddate,omitempty" doc:"the end date range of the list you want to retrieve (use format \"yyyy-MM-dd\" or the new format \"yyyy-MM-dd HH:mm:ss\")"`
 	EntryTime   int    `json:"entrytime,omitempty" doc:"the time the event was entered"`
 	ID          *UUID  `json:"id,omitempty" doc:"the ID of the event"`
-	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves." doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves." doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword     string `json:"keyword,omitempty" doc:"List by keyword"`
 	Level       string `json:"level,omitempty" doc:"the event level (INFO, WARN, ERROR)"`
 	ListAll     *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`

--- a/generate/main.go
+++ b/generate/main.go
@@ -175,7 +175,7 @@ func (c *command) CheckResponse(response []egoscale.APIField) {
 
 		if field.Doc != description {
 			if field.Doc == "" {
-				errs[n] = append(errs[n], fmt.Errorf("missing doc:\n\t\t`doc:%q`"))
+				errs[n] = append(errs[n], fmt.Errorf("missing doc:\n\t\t`doc:%q`", description))
 			} else {
 				errs[n] = append(errs[n], fmt.Errorf("wrong doc want %q got %q", description, field.Doc))
 			}

--- a/generate/main.go
+++ b/generate/main.go
@@ -61,13 +61,11 @@ type fieldInfo struct {
 
 // response represents a response struc for a command
 type response struct {
-	name        string
-	description string
-	s           *types.Struct
-	position    token.Pos
-	fields      map[string]fieldInfo
-	errors      map[string][]error
-	response    *response
+	name     string
+	s        *types.Struct
+	position token.Pos
+	fields   map[string]fieldInfo
+	errors   map[string][]error
 }
 
 // command represents a struct within the source code
@@ -264,7 +262,7 @@ func (c *command) CheckFields(api egoscale.API) {
 		}
 
 		name := ""
-		omitempty := false
+		var omitempty bool
 		tag := (reflect.StructTag)(c.s.Tag(i))
 		if match, ok := tag.Lookup("json"); !ok {
 			n := f.Name()

--- a/limits.go
+++ b/limits.go
@@ -66,7 +66,7 @@ const (
 type ResourceLimit struct {
 	Account          string       `json:"account,omitempty" doc:"the account of the resource limit"`
 	Domain           string       `json:"domain,omitempty" doc:"the domain name of the resource limit"`
-	DomainID         string       `json:"domainid,omitempty" doc:"the domain ID of the resource limit"`
+	DomainID         *UUID        `json:"domainid,omitempty" doc:"the domain ID of the resource limit"`
 	Max              int64        `json:"max,omitempty" doc:"the maximum number of the resource. A -1 means the resource currently has no limit."`
 	ResourceType     ResourceType `json:"resourcetype,omitempty" doc:"resource type. Values include 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11. See the resourceType parameter for more information on these values."`
 	ResourceTypeName string       `json:"resourcetypename,omitempty" doc:"resource type name. Values include user_vm, public_ip, volume, snapshot, template, project, network, vpc, cpu, memory, primary_storage, secondary_storage."`
@@ -83,10 +83,10 @@ type APILimit struct {
 
 // ListResourceLimits lists the resource limits
 type ListResourceLimits struct {
-	Account          string       `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account          string       `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID         string       `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID               int64        `json:"id,omitempty" doc:"Lists resource limits by ID."`
-	IsRecursive      *bool        `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive      *bool        `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword          string       `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll          *bool        `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Page             int          `json:"page,omitempty"`
@@ -108,7 +108,7 @@ func (ListResourceLimits) response() interface{} {
 
 // UpdateResourceLimit updates the resource limit
 type UpdateResourceLimit struct {
-	Account      string       `json:"account,omitempty" doc:"Update resource for a specified account. Must be used with the domainId parameter."`
+	Account      string       `json:"account,omitempty" doc:"Update resource for a specified account. Must be used with the domainid parameter."`
 	DomainID     string       `json:"domainid,omitempty" doc:"Update resource limits for all accounts in specified domain. If used with the account parameter, updates resource limits for a specified account in specified domain."`
 	Max          int64        `json:"max,omitempty" doc:"Maximum resource limit."`
 	ResourceType ResourceType `json:"resourcetype" doc:"Type of resource to update. Values are 0, 1, 2, 3, 4, 6, 7, 8, 9, 10 and 11. 0 - Instance. Number of instances a user can create. 1 - IP. Number of public IP addresses a user can own. 2 - Volume. Number of disk volumes a user can create. 3 - Snapshot. Number of snapshots a user can create. 4 - Template. Number of templates that a user can register/create. 6 - Network. Number of guest network a user can create. 7 - VPC. Number of VPC a user can create. 8 - CPU. Total number of CPU cores a user can use. 9 - Memory. Total Memory (in MB) a user can use. 10 - PrimaryStorage. Total primary storage space (in GiB) a user can use. 11 - SecondaryStorage. Total secondary storage space (in GiB) a user can use."`

--- a/networks.go
+++ b/networks.go
@@ -208,12 +208,12 @@ func (DeleteNetwork) asyncResponse() interface{} {
 
 // ListNetworks represents a query to a network
 type ListNetworks struct {
-	Account           string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account           string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	CanUseForDeploy   *bool         `json:"canusefordeploy,omitempty" doc:"list networks available for vm deployment"`
 	DisplayNetwork    *bool         `json:"displaynetwork,omitempty" doc:"list resources by display flag; only ROOT admin is eligible to pass this parameter"`
 	DomainID          *UUID         `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID                *UUID         `json:"id,omitempty" doc:"list networks by id"`
-	IsRecursive       *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive       *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	IsSystem          *bool         `json:"issystem,omitempty" doc:"true if network is system, false otherwise"`
 	Keyword           string        `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll           *bool         `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`

--- a/nics.go
+++ b/nics.go
@@ -62,7 +62,7 @@ type ListNics struct {
 	NicID            *UUID  `json:"nicid,omitempty" doc:"the ID of the nic to to list IPs"`
 	Page             int    `json:"page,omitempty"`
 	PageSize         int    `json:"pagesize,omitempty"`
-	VirtualMachineID *UUID  `json:"virtualmachineid" doc:"the ID of the vm"`
+	VirtualMachineID *UUID  `json:"virtualmachineid,omitempty" doc:"the ID of the vm"`
 	_                bool   `name:"listNics" description:"list the vm nics  IP to NIC"`
 }
 

--- a/resource_metadata.go
+++ b/resource_metadata.go
@@ -3,7 +3,7 @@ package egoscale
 // ListResourceDetails lists the resource tag(s) (but different from listTags...)
 type ListResourceDetails struct {
 	ResourceType string `json:"resourcetype" doc:"list by resource type"`
-	Account      string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account      string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID     *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ForDisplay   bool   `json:"fordisplay,omitempty" doc:"if set to true, only details marked with display=true, are returned. False by default"`
 	Key          string `json:"key,omitempty" doc:"list by key"`
@@ -13,7 +13,7 @@ type ListResourceDetails struct {
 	PageSize     int    `json:"pagesize,omitempty"`
 	ResourceID   *UUID  `json:"resourceid,omitempty" doc:"list by resource id"`
 	Value        string `json:"value,omitempty" doc:"list by key, value. Needs to be passed only along with key"`
-	IsRecursive  bool   `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive  bool   `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	_            bool   `name:"listResourceDetails" description:"List resource detail(s)"`
 }
 

--- a/security_groups.go
+++ b/security_groups.go
@@ -110,9 +110,9 @@ func (usg UserSecurityGroup) String() string {
 // CreateSecurityGroup represents a security group creation
 type CreateSecurityGroup struct {
 	Name        string `json:"name" doc:"name of the security group"`
-	Account     string `json:"account,omitempty" doc:"an optional account for the security group. Must be used with domainId."`
+	Account     string `json:"account,omitempty" doc:"an optional account for the security group. Must be used with domainid."`
 	Description string `json:"description,omitempty" doc:"the description of the security group"`
-	DomainID    *UUID  `json:"domainid,omitempty" doc:"an optional domainId for the security group. If the account parameter is used, domainId must also be used."`
+	DomainID    *UUID  `json:"domainid,omitempty" doc:"an optional domainid for the security group. If the account parameter is used, domainid must also be used."`
 	_           bool   `name:"createSecurityGroup" description:"Creates a security group"`
 }
 
@@ -135,7 +135,7 @@ func (DeleteSecurityGroup) response() interface{} {
 
 // AuthorizeSecurityGroupIngress (Async) represents the ingress rule creation
 type AuthorizeSecurityGroupIngress struct {
-	Account               string              `json:"account,omitempty" doc:"an optional account for the security group. Must be used with domainId."`
+	Account               string              `json:"account,omitempty" doc:"an optional account for the security group. Must be used with domainid."`
 	CIDRList              []CIDR              `json:"cidrlist,omitempty" doc:"the cidr list associated"`
 	Description           string              `json:"description,omitempty" doc:"the description of the ingress/egress rule"`
 	DomainID              *UUID               `json:"domainid,omitempty" doc:"an optional domainid for the security group. If the account parameter is used, domainid must also be used."`
@@ -215,10 +215,10 @@ func (RevokeSecurityGroupEgress) asyncResponse() interface{} {
 
 // ListSecurityGroups represents a search for security groups
 type ListSecurityGroups struct {
-	Account           string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account           string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID          *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID                *UUID  `json:"id,omitempty" doc:"list the security group by the id provided"`
-	IsRecursive       *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive       *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword           string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll           *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Page              int    `json:"page,omitempty"`

--- a/snapshots.go
+++ b/snapshots.go
@@ -57,7 +57,7 @@ func (Snapshot) ResourceType() string {
 // CreateSnapshot (Async) creates an instant snapshot of a volume
 type CreateSnapshot struct {
 	VolumeID  *UUID  `json:"volumeid" doc:"The ID of the disk volume"`
-	Account   string `json:"account,omitempty" doc:"The account of the snapshot. The account parameter must be used with the domainId parameter."`
+	Account   string `json:"account,omitempty" doc:"The account of the snapshot. The account parameter must be used with the domainid parameter."`
 	DomainID  *UUID  `json:"domainid,omitempty" doc:"The domain ID of the snapshot. If used with the account parameter, specifies a domain for the account associated with the disk volume."`
 	QuiesceVM *bool  `json:"quiescevm,omitempty" doc:"quiesce vm if true"`
 	_         bool   `name:"createSnapshot" description:"Creates an instant snapshot of a volume."`
@@ -73,11 +73,11 @@ func (CreateSnapshot) asyncResponse() interface{} {
 
 // ListSnapshots lists the volume snapshots
 type ListSnapshots struct {
-	Account      string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account      string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID     *UUID         `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID           *UUID         `json:"id,omitempty" doc:"lists snapshot by snapshot ID"`
 	IntervalType string        `json:"intervaltype,omitempty" doc:"valid values are HOURLY, DAILY, WEEKLY, and MONTHLY."`
-	IsRecursive  *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive  *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword      string        `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll      *bool         `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name         string        `json:"name,omitempty" doc:"lists snapshot by snapshot name"`

--- a/ssh_keypairs.go
+++ b/ssh_keypairs.go
@@ -38,8 +38,8 @@ func (ssh SSHKeyPair) ListRequest() (ListCommand, error) {
 // CreateSSHKeyPair represents a new keypair to be created
 type CreateSSHKeyPair struct {
 	Name     string `json:"name" doc:"Name of the keypair"`
-	Account  string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainId."`
-	DomainID *UUID  `json:"domainid,omitempty" doc:"an optional domainId for the ssh key. If the account parameter is used, domainId must also be used."`
+	Account  string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainid."`
+	DomainID *UUID  `json:"domainid,omitempty" doc:"an optional domainid for the ssh key. If the account parameter is used, domainid must also be used."`
 	_        bool   `name:"createSSHKeyPair" description:"Create a new keypair and returns the private key"`
 }
 
@@ -50,7 +50,7 @@ func (CreateSSHKeyPair) response() interface{} {
 // DeleteSSHKeyPair represents a new keypair to be created
 type DeleteSSHKeyPair struct {
 	Name     string `json:"name" doc:"Name of the keypair"`
-	Account  string `json:"account,omitempty" doc:"the account associated with the keypair. Must be used with the domainId parameter."`
+	Account  string `json:"account,omitempty" doc:"the account associated with the keypair. Must be used with the domainid parameter."`
 	DomainID *UUID  `json:"domainid,omitempty" doc:"the domain ID associated with the keypair"`
 	_        bool   `name:"deleteSSHKeyPair" description:"Deletes a keypair by name"`
 }
@@ -63,8 +63,8 @@ func (DeleteSSHKeyPair) response() interface{} {
 type RegisterSSHKeyPair struct {
 	Name      string `json:"name" doc:"Name of the keypair"`
 	PublicKey string `json:"publickey" doc:"Public key material of the keypair"`
-	Account   string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainId."`
-	DomainID  *UUID  `json:"domainid,omitempty" doc:"an optional domainId for the ssh key. If the account parameter is used, domainId must also be used."`
+	Account   string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainid."`
+	DomainID  *UUID  `json:"domainid,omitempty" doc:"an optional domainid for the ssh key. If the account parameter is used, domainid must also be used."`
 	_         bool   `name:"registerSSHKeyPair" description:"Register a public key in a keypair under a certain name"`
 }
 
@@ -74,10 +74,10 @@ func (RegisterSSHKeyPair) response() interface{} {
 
 // ListSSHKeyPairs represents a query for a list of SSH KeyPairs
 type ListSSHKeyPairs struct {
-	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID    *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	Fingerprint string `json:"fingerprint,omitempty" doc:"A public key fingerprint to look for"`
-	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword     string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll     *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name        string `json:"name,omitempty" doc:"A key pair name to look for"`
@@ -124,8 +124,8 @@ func (ListSSHKeyPairs) each(resp interface{}, callback IterateItemFunc) {
 type ResetSSHKeyForVirtualMachine struct {
 	ID       *UUID  `json:"id" doc:"The ID of the virtual machine"`
 	KeyPair  string `json:"keypair" doc:"name of the ssh key pair used to login to the virtual machine"`
-	Account  string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainId."`
-	DomainID *UUID  `json:"domainid,omitempty" doc:"an optional domainId for the virtual machine. If the account parameter is used, domainId must also be used."`
+	Account  string `json:"account,omitempty" doc:"an optional account for the ssh key. Must be used with domainid."`
+	DomainID *UUID  `json:"domainid,omitempty" doc:"an optional domainid for the virtual machine. If the account parameter is used, domainid must also be used."`
 	_        bool   `name:"resetSSHKeyForVirtualMachine" description:"Resets the SSH Key for virtual machine. The virtual machine must be in a \"Stopped\" state."`
 }
 

--- a/tags.go
+++ b/tags.go
@@ -49,10 +49,10 @@ func (DeleteTags) asyncResponse() interface{} {
 
 // ListTags list resource tag(s)
 type ListTags struct {
-	Account      string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account      string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	Customer     string `json:"customer,omitempty" doc:"list by customer name"`
 	DomainID     *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
-	IsRecursive  *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive  *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Key          string `json:"key,omitempty" doc:"list by key"`
 	Keyword      string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll      *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`

--- a/templates.go
+++ b/templates.go
@@ -75,11 +75,11 @@ func (temp Template) ListRequest() (ListCommand, error) {
 // ListTemplates represents a template query filter
 type ListTemplates struct {
 	TemplateFilter string        `json:"templatefilter" doc:"possible values are \"featured\", \"self\", \"selfexecutable\",\"sharedexecutable\",\"executable\", and \"community\". * featured : templates that have been marked as featured and public. * self : templates that have been registered or created by the calling user. * selfexecutable : same as self, but only returns templates that can be used to deploy a new VM. * sharedexecutable : templates ready to be deployed that have been granted to the calling user by another user. * executable : templates that are owned by the calling user, or public templates, that can be used to deploy a VM. * community : templates that have been marked as public but not featured. * all : all templates (only usable by admins)."`
-	Account        string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account        string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID       *UUID         `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	Hypervisor     string        `json:"hypervisor,omitempty" doc:"the hypervisor for which to restrict the search"`
 	ID             *UUID         `json:"id,omitempty" doc:"the template ID"`
-	IsRecursive    *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive    *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword        string        `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll        *bool         `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name           string        `json:"name,omitempty" doc:"the template name"`
@@ -87,7 +87,7 @@ type ListTemplates struct {
 	PageSize       int           `json:"pagesize,omitempty"`
 	ShowRemoved    *bool         `json:"showremoved,omitempty" doc:"show removed templates as well"`
 	Tags           []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
-	ZoneID         *UUID         `json:"zoneid,omitempty" doc:"list templates by zoneId"`
+	ZoneID         *UUID         `json:"zoneid,omitempty" doc:"list templates by zoneid"`
 	_              bool          `name:"listTemplates" description:"List all public, private, and privileged templates."`
 }
 
@@ -225,12 +225,12 @@ func (PrepareTemplate) asyncResponse() interface{} {
 
 // RegisterTemplate represents a template registration
 type RegisterTemplate struct {
-	Account               string            `json:"account,omitempty" doc:"an optional accountName. Must be used with domainId."`
+	Account               string            `json:"account,omitempty" doc:"an optional accountName. Must be used with domainid."`
 	Bits                  int               `json:"bits,omitempty" doc:"32 or 64 bits support. 64 by default"`
 	Checksum              string            `json:"checksum,omitempty" doc:"the MD5 checksum value of this template"`
 	Details               map[string]string `json:"details,omitempty" doc:"Template details in key/value pairs."`
 	DisplayText           string            `json:"displaytext" doc:"the display text of the template. This is usually used for display purposes."`
-	DomainID              *UUID             `json:"domainid,omitempty" doc:"an optional domainId. If the account parameter is used, domainId must also be used."`
+	DomainID              *UUID             `json:"domainid,omitempty" doc:"an optional domainid. If the account parameter is used, domainid must also be used."`
 	Format                string            `json:"format" doc:"the format for the template. Possible values include QCOW2, RAW, and VHD."`
 	Hypervisor            string            `json:"hypervisor" doc:"the target hypervisor for the template"`
 	IsDynamicallyScalable *bool             `json:"isdynamicallyscalable,omitempty" doc:"true if template contains XS/VMWare tools inorder to support dynamic scaling of VM cpu/memory"`
@@ -262,7 +262,7 @@ type OSCategory struct {
 
 // ListOSCategories lists the OS categories
 type ListOSCategories struct {
-	ID       string `json:"id,omitempty" doc:"list Os category by id"`
+	ID       *UUID  `json:"id,omitempty" doc:"list Os category by id"`
 	Keyword  string `json:"keyword,omitempty" doc:"List by keyword"`
 	Name     string `json:"name,omitempty" doc:"list os category by name"`
 	Page     int    `json:"page,omitempty"`

--- a/users.go
+++ b/users.go
@@ -74,11 +74,11 @@ func (UpdateUser) response() interface{} {
 
 // ListUsers represents the search for Users
 type ListUsers struct {
-	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	AccountType int64  `json:"accounttype,omitempty" doc:"List users by account type. Valid types include admin, domain-admin, read-only-admin, or user."`
 	DomainID    *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID          *UUID  `json:"id,omitempty" doc:"List user by ID."`
-	IsRecursive bool   `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive bool   `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword     string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll     bool   `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Page        int    `json:"page,omitempty"`

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -262,16 +262,16 @@ func (userdata VirtualMachineUserData) Decode() (string, error) {
 //
 // Regarding the UserData field, the client is responsible to base64 (and probably gzip) it. Doing it within this library would make the integration with other tools, e.g. Terraform harder.
 type DeployVirtualMachine struct {
-	Account            string            `json:"account,omitempty" doc:"an optional account for the virtual machine. Must be used with domainId."`
+	Account            string            `json:"account,omitempty" doc:"an optional account for the virtual machine. Must be used with domainid."`
 	AffinityGroupIDs   []UUID            `json:"affinitygroupids,omitempty" doc:"comma separated list of affinity groups id that are going to be applied to the virtual machine. Mutually exclusive with affinitygroupnames parameter"`
 	AffinityGroupNames []string          `json:"affinitygroupnames,omitempty" doc:"comma separated list of affinity groups names that are going to be applied to the virtual machine.Mutually exclusive with affinitygroupids parameter"`
 	CustomID           *UUID             `json:"customid,omitempty" doc:"an optional field, in case you want to set a custom id to the resource. Allowed to Root Admins only"`
 	DeploymentPlanner  string            `json:"deploymentplanner,omitempty" doc:"Deployment planner to use for vm allocation. Available to ROOT admin only"`
 	Details            map[string]string `json:"details,omitempty" doc:"used to specify the custom parameters."`
-	DiskOfferingID     *UUID             `json:"diskofferingid,omitempty" doc:"the ID of the disk offering for the virtual machine. If the template is of ISO format, the diskOfferingId is for the root disk volume. Otherwise this parameter is used to indicate the offering for the data disk volume. If the templateId parameter passed is from a Template object, the diskOfferingId refers to a DATA Disk Volume created. If the templateId parameter passed is from an ISO object, the diskOfferingId refers to a ROOT Disk Volume created."`
+	DiskOfferingID     *UUID             `json:"diskofferingid,omitempty" doc:"the ID of the disk offering for the virtual machine. If the template is of ISO format, the diskofferingid is for the root disk volume. Otherwise this parameter is used to indicate the offering for the data disk volume. If the templateid parameter passed is from a Template object, the diskofferingid refers to a DATA Disk Volume created. If the templateid parameter passed is from an ISO object, the diskofferingid refers to a ROOT Disk Volume created."`
 	DisplayName        string            `json:"displayname,omitempty" doc:"an optional user generated name for the virtual machine"`
 	DisplayVM          *bool             `json:"displayvm,omitempty" doc:"an optional field, whether to the display the vm to the end user or not."`
-	DomainID           *UUID             `json:"domainid,omitempty" doc:"an optional domainId for the virtual machine. If the account parameter is used, domainId must also be used."`
+	DomainID           *UUID             `json:"domainid,omitempty" doc:"an optional domainid for the virtual machine. If the account parameter is used, domainid must also be used."`
 	Group              string            `json:"group,omitempty" doc:"an optional group for the virtual machine"`
 	HostID             *UUID             `json:"hostid,omitempty" doc:"destination Host ID to deploy the VM to - parameter available for root admin only"`
 	Hypervisor         string            `json:"hypervisor,omitempty" doc:"the hypervisor on which to deploy the virtual machine"`
@@ -279,7 +279,7 @@ type DeployVirtualMachine struct {
 	IP6                *bool             `json:"ip6,omitempty" doc:"True to set an IPv6 to the default interface"`
 	IP6Address         net.IP            `json:"ip6address,omitempty" doc:"the ipv6 address for default vm's network"`
 	IPAddress          net.IP            `json:"ipaddress,omitempty" doc:"the ip address for default vm's network"`
-	IPToNetworkList    []IPToNetwork     `json:"iptonetworklist,omitempty" doc:"ip to network mapping. Can't be specified with networkIds parameter. Example: iptonetworklist[0].ip=10.10.10.11&iptonetworklist[0].ipv6=fc00:1234:5678::abcd&iptonetworklist[0].networkid=uuid - requests to use ip 10.10.10.11 in network id=uuid"`
+	IPToNetworkList    []IPToNetwork     `json:"iptonetworklist,omitempty" doc:"ip to network mapping. Can't be specified with networkids parameter. Example: iptonetworklist[0].ip=10.10.10.11&iptonetworklist[0].ipv6=fc00:1234:5678::abcd&iptonetworklist[0].networkid=uuid - requests to use ip 10.10.10.11 in network id=uuid"`
 	Keyboard           string            `json:"keyboard,omitempty" doc:"an optional keyboard device type for the virtual machine. valid value can be one of de,de-ch,es,fi,fr,fr-be,fr-ch,is,it,jp,nl-be,no,pt,uk,us"`
 	KeyPair            string            `json:"keypair,omitempty" doc:"name of the ssh key pair used to login to the virtual machine"`
 	Name               string            `json:"name,omitempty" doc:"host name for the virtual machine"`
@@ -288,7 +288,7 @@ type DeployVirtualMachine struct {
 	SecurityGroupIDs   []UUID            `json:"securitygroupids,omitempty" doc:"comma separated list of security groups id that going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupnames parameter"`
 	SecurityGroupNames []string          `json:"securitygroupnames,omitempty" doc:"comma separated list of security groups names that going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupids parameter"`
 	ServiceOfferingID  *UUID             `json:"serviceofferingid" doc:"the ID of the service offering for the virtual machine"`
-	Size               int64             `json:"size,omitempty" doc:"the arbitrary size for the DATADISK volume. Mutually exclusive with diskOfferingId"`
+	Size               int64             `json:"size,omitempty" doc:"the arbitrary size for the DATADISK volume. Mutually exclusive with diskofferingid"`
 	StartVM            *bool             `json:"startvm,omitempty" doc:"true if start vm after creating. Default value is true"`
 	TemplateID         *UUID             `json:"templateid" doc:"the ID of the template for the virtual machine"`
 	UserData           string            `json:"userdata,omitempty" doc:"an optional binary data that can be sent to the virtual machine upon a successful deployment. This binary data must be base64 encoded before adding it to the request. Using HTTP GET (via querystring), you can send up to 2KB of data after base64 encoding. Using HTTP POST(via POST body), you can send up to 32K of data after base64 encoding."`
@@ -494,7 +494,7 @@ func (GetVMPassword) response() interface{} {
 
 // ListVirtualMachines represents a search for a VM
 type ListVirtualMachines struct {
-	Account           string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account           string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	AffinityGroupID   *UUID         `json:"affinitygroupid,omitempty" doc:"list vms by affinity group"`
 	Details           []string      `json:"details,omitempty" doc:"comma separated list of host details requested, value can be a list of [all, group, nics, stats, secgrp, tmpl, servoff, diskoff, iso, volume, min, affgrp]. If no parameter is passed in, the details will be defaulted to all"`
 	DisplayVM         *bool         `json:"displayvm,omitempty" doc:"list resources by display flag; only ROOT admin is eligible to pass this parameter"`
@@ -507,7 +507,7 @@ type ListVirtualMachines struct {
 	IDs               []string      `json:"ids,omitempty" doc:"the IDs of the virtual machines, mutually exclusive with id"`
 	IPAddress         net.IP        `json:"ipaddress,omitempty" doc:"an IP address to filter the result"`
 	IsoID             *UUID         `json:"isoid,omitempty" doc:"list vms by iso"`
-	IsRecursive       *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive       *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword           string        `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll           *bool         `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name              string        `json:"name,omitempty" doc:"name of the virtual machine"`

--- a/vm_groups.go
+++ b/vm_groups.go
@@ -13,7 +13,7 @@ type InstanceGroup struct {
 // CreateInstanceGroup creates a VM group
 type CreateInstanceGroup struct {
 	Name     string `json:"name" doc:"the name of the instance group"`
-	Account  string `json:"account,omitempty" doc:"the account of the instance group. The account parameter must be used with the domainId parameter."`
+	Account  string `json:"account,omitempty" doc:"the account of the instance group. The account parameter must be used with the domainid parameter."`
 	DomainID *UUID  `json:"domainid,omitempty" doc:"the domain ID of account owning the instance group"`
 	_        bool   `name:"createInstanceGroup" description:"Creates a vm group"`
 }
@@ -45,10 +45,10 @@ func (DeleteInstanceGroup) response() interface{} {
 
 // ListInstanceGroups lists VM groups
 type ListInstanceGroups struct {
-	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account     string `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DomainID    *UUID  `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	ID          *UUID  `json:"id,omitempty" doc:"list instance groups by ID"`
-	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive *bool  `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword     string `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll     *bool  `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name        string `json:"name,omitempty" doc:"list instance groups by name"`

--- a/volumes.go
+++ b/volumes.go
@@ -98,13 +98,13 @@ func (ResizeVolume) asyncResponse() interface{} {
 
 // ListVolumes represents a query listing volumes
 type ListVolumes struct {
-	Account          string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainId parameter."`
+	Account          string        `json:"account,omitempty" doc:"list resources by account. Must be used with the domainid parameter."`
 	DiskOfferingID   *UUID         `json:"diskofferingid,omitempty" doc:"list volumes by disk offering"`
 	DisplayVolume    *bool         `json:"displayvolume,omitempty" doc:"list resources by display flag; only ROOT admin is eligible to pass this parameter"`
 	DomainID         *UUID         `json:"domainid,omitempty" doc:"list only resources belonging to the domain specified"`
 	HostID           *UUID         `json:"hostid,omitempty" doc:"list volumes on specified host"`
 	ID               *UUID         `json:"id,omitempty" doc:"the ID of the disk volume"`
-	IsRecursive      *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainId till leaves."`
+	IsRecursive      *bool         `json:"isrecursive,omitempty" doc:"defaults to false, but if true, lists all resources from the parent specified by the domainid till leaves."`
 	Keyword          string        `json:"keyword,omitempty" doc:"List by keyword"`
 	ListAll          *bool         `json:"listall,omitempty" doc:"If set to false, list only resources belonging to the command's caller; if set to true - list resources that the caller is authorized to see. Default value is false"`
 	Name             string        `json:"name,omitempty" doc:"the name of the disk volume"`


### PR DESCRIPTION
the checking for the return type was disabled when the listApis format changed. This fixes it. Although is doesn't check recursively for sub-struct.

**before**

```console
% go run generate/main.go -apis listApis.json
    2 ssh_keypairs.go:76:6: ListSSHKeyPairs
    5 virtual_machines.go:264:6: DeployVirtualMachine (A)
    2 addresses.go:138:6: ListPublicIPAddresses
    2 volumes.go:100:6: ListVolumes
    2 networks.go:210:6: ListNetworks
    3 accounts.go:85:6: ListAccounts
    4 templates.go:76:6: ListTemplates
    2 virtual_machines.go:496:6: ListVirtualMachines
    4 events.go:24:6: ListEvents
    1 service_offerings.go:65:6: ListServiceOfferings
    2 resource_metadata.go:4:6: ListResourceDetails
    1 ssh_keypairs.go:51:6: DeleteSSHKeyPair
    2 ssh_keypairs.go:124:6: ResetSSHKeyForVirtualMachine (A)
    1 snapshots.go:58:6: CreateSnapshot (A)
    3 security_groups.go:137:6: AuthorizeSecurityGroupIngress (A)
    2 snapshots.go:75:6: ListSnapshots
    1 virtual_machines.go:393:6: DestroyVirtualMachine (A)
    2 async_jobs.go:43:6: ListAsyncJobs
    2 vm_groups.go:47:6: ListInstanceGroups
    1 vm_groups.go:14:6: CreateInstanceGroup
    2 affinity_groups.go:58:6: CreateAffinityGroup (A)
    1 nics.go:58:6: ListNics
    2 ssh_keypairs.go:63:6: RegisterSSHKeyPair
    2 security_groups.go:111:6: CreateSecurityGroup
    1 virtual_machines.go:560:6: AddNicToVirtualMachine (A)
    1 templates.go:264:6: ListOSCategories
    5 security_groups.go:175:6: AuthorizeSecurityGroupEgress (A)
    2 ssh_keypairs.go:39:6: CreateSSHKeyPair
    2 networks.go:115:6: CreateNetwork
    2 tags.go:51:6: ListTags
    2 affinity_groups.go:117:6: ListAffinityGroups
    4 limits.go:85:6: ListResourceLimits
    3 security_groups.go:217:6: ListSecurityGroups
    1 apis.go:34:6: ListAPIs

% go run generate/main.go -apis listApis.json -cmd listNics -type nic
panic: checking return type is temporary disabled
```

**after**

```console
%  go run generate/main.go -apis listApis.json                        
    2 security_groups.go:137:6: AuthorizeSecurityGroupIngress (A)
    2 accounts.go:85:6: ListAccounts
    2 limits.go:85:6: ListResourceLimits
    2 networks.go:115:6: CreateNetwork
    1 security_groups.go:217:6: ListSecurityGroups
    1 apis.go:34:6: ListAPIs
    4 security_groups.go:175:6: AuthorizeSecurityGroupEgress (A)
    1 virtual_machines.go:393:6: DestroyVirtualMachine (A)
    1 virtual_machines.go:560:6: AddNicToVirtualMachine (A)

% go run generate/main.go -apis listApis.json -cmd listNics -type nic

nics.go:58:6: ListNics has 0 error(s)

nics.go:11:6: Nic has 0 error(s)
```