### PR TITLE
request: show the source message on parsing error.

### DIFF
--- a/request.go
+++ b/request.go
@@ -68,9 +68,7 @@ func (client *Client) parseResponse(resp *http.Response, apiName string) (json.R
 			response, ok = m[key]
 
 			if !ok {
-				for k := range m {
-					return nil, fmt.Errorf("malformed JSON response, %q was expected, got %q", key, k)
-				}
+				return nil, fmt.Errorf("malformed JSON response %d, %q was expected.\n%s", resp.StatusCode, key, b)
 			}
 		}
 	}


### PR DESCRIPTION
Then

```console
% exo api api list
malformed JSON response, "listapisresponse" was expected, got "message"
```

Now

```console
% exo api api list
malformed JSON response 500, "listapisresponse" was expected.
{"message":null}
```

(feel free to ignore the -0.2% code coverage change)