### PR TITLE
cli: updateVmNicIp call is async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+master
+------
+
+- fix: `updateVmNicIp`: the call is async
+
 0.12.0
 ------
 

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -637,5 +637,9 @@ type UpdateVMNicIP struct {
 }
 
 func (UpdateVMNicIP) response() interface{} {
+	return new(AsyncJobResult)
+}
+
+func (UpdateVMNicIP) asyncResponse() interface{} {
 	return new(VirtualMachine)
 }

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -123,7 +123,8 @@ func TestUpdateDefaultNicForVirtualMachine(t *testing.T) {
 
 func TestUpdateVMNicIP(t *testing.T) {
 	req := &UpdateVMNicIP{}
-	_ = req.response().(*VirtualMachine)
+	_ = req.response().(*AsyncJobResult)
+	_ = req.asyncResponse().(*VirtualMachine)
 }
 
 func TestDeployOnBeforeSend(t *testing.T) {


### PR DESCRIPTION
This call can be used to associate an ip to an existing private
network interface.

The current implementation shows some informations about the updated VM and then the private network interfaces.

```
exo vm updatenicip f8464441-0d1e-4c2b-b203-bbe5d1ab55ea 11.0.0.100
Updating the nic "f8464441-0d1e-4c2b-b203-bbe5d1ab55ea" . success.
Instance ID:           3c2b2ec6-c7c4-41da-a02f-736a67a93dbd
Isntance Hostname:     VM-3c2b2ec6-c7c4-41da-a02f-736a67a93dbd
Instance Display name: test
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│                NIC ID                │              NETWORK ID              │ IP ADDRESS │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│ f8464441-0d1e-4c2b-b203-bbe5d1ab55ea │ da9b7b1b-8906-4e0d-9f42-09a985044f02 │ 11.0.0.100 │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼

```