### PR TITLE
privnet associate: add an optional ip parameter

### DIFF
--- a/cmd/exo/cmd/privnet_associate.go
+++ b/cmd/exo/cmd/privnet_associate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"text/tabwriter"
 
 	"github.com/exoscale/egoscale"
 	"github.com/exoscale/egoscale/cmd/exo/table"
@@ -24,58 +25,65 @@ var privnetAssociateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
+		dhcp := dhcpRange(network.StartIP, network.EndIP, network.Netmask)
+
+		fmt.Fprintf(w, "Network:\t%s\n", network.Name)            // nolint: errcheck
+		fmt.Fprintf(w, "Description:\t%s\n", network.DisplayText) // nolint: errcheck
+		fmt.Fprintf(w, "Zone:\t%s\n", network.ZoneName)           // nolint: errcheck
+		fmt.Fprintf(w, "IP Range:\t%s\n", dhcp)                   // nolint: errcheck
+
 		table := table.NewTable(os.Stdout)
-		table.SetHeader([]string{"Nic ID", "Virtual Machine ID", "IP Address"})
+		table.SetHeader([]string{"Virtual Machine", "IP Address"})
 		for i := 1; i < len(args); i++ {
 			name := args[i]
 			if i != len(args)-1 {
 				ip := net.ParseIP(args[i+1])
 				if ip != nil {
 					// the next param is an ip
-					nic, err := associatePrivNet(network, name, ip)
+					nic, vm, err := associatePrivNet(network, name, ip)
 					if err != nil {
 						return err
 					}
 					table.Append([]string{
-						nic.ID.String(),
-						nic.VirtualMachineID.String(),
+						vm.DisplayName,
 						nicIP(nic)})
 					i = i + 1
 					continue
 				}
 			}
-			nic, err := associatePrivNet(network, name, nil)
+			nic, vm, err := associatePrivNet(network, name, nil)
 			if err != nil {
 				return err
 			}
 			table.Append([]string{
-				nic.ID.String(),
-				nic.VirtualMachineID.String(),
+				vm.DisplayName,
 				nicIP(nic)})
 		}
+		w.Flush() // nolint: errcheck
 		table.Render()
 		return nil
 	},
 }
 
-func associatePrivNet(privnet *egoscale.Network, vmName string, ip net.IP) (*egoscale.Nic, error) {
+func associatePrivNet(privnet *egoscale.Network, vmName string, ip net.IP) (*egoscale.Nic, *egoscale.VirtualMachine, error) {
 	vm, err := getVMWithNameOrID(vmName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	req := &egoscale.AddNicToVirtualMachine{NetworkID: privnet.ID, VirtualMachineID: vm.ID, IPAddress: ip}
 	resp, err := cs.RequestWithContext(gContext, req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	nic := resp.(*egoscale.VirtualMachine).NicByNetworkID(*privnet.ID)
 	if nic == nil {
-		return nil, fmt.Errorf("no nics found for network %q", privnet.ID)
+		return nil, nil, fmt.Errorf("no nics found for network %q", privnet.ID)
 	}
 
-	return nic, nil
+	return nic, vm, nil
 
 }
 

--- a/cmd/exo/cmd/privnet_associate.go
+++ b/cmd/exo/cmd/privnet_associate.go
@@ -2,14 +2,17 @@ package cmd
 
 import (
 	"fmt"
+	"net"
+	"os"
 
 	"github.com/exoscale/egoscale"
+	"github.com/exoscale/egoscale/cmd/exo/table"
 	"github.com/spf13/cobra"
 )
 
 // privnetAssociateCmd represents the associate command
 var privnetAssociateCmd = &cobra.Command{
-	Use:     "associate <privnet name | id> <vm name | vm id> [vm name | vm id] [...]",
+	Use:     "associate <privnet name | id> <vm name | vm id> [<ip>] [<vm name | vm id> [<ip>] [...]",
 	Short:   "Associate a private network to instance(s)",
 	Aliases: gAssociateAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -21,26 +24,47 @@ var privnetAssociateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		for _, vm := range args[1:] {
-			resp, err := associatePrivNet(network, vm)
+		table := table.NewTable(os.Stdout)
+		table.SetHeader([]string{"Nic ID", "Virtual Machine ID", "IP Address"})
+		for i := 1; i < len(args); i++ {
+			name := args[i]
+			if i != len(args)-1 {
+				ip := net.ParseIP(args[i+1])
+				if ip != nil {
+					// the next param is an ip
+					nic, err := associatePrivNet(network, name, ip)
+					if err != nil {
+						return err
+					}
+					table.Append([]string{
+						nic.ID.String(),
+						nic.VirtualMachineID.String(),
+						nicIP(nic)})
+					i = i + 1
+					continue
+				}
+			}
+			nic, err := associatePrivNet(network, name, nil)
 			if err != nil {
 				return err
 			}
-			fmt.Println(resp)
+			table.Append([]string{
+				nic.ID.String(),
+				nic.VirtualMachineID.String(),
+				nicIP(nic)})
 		}
-
+		table.Render()
 		return nil
 	},
 }
 
-func associatePrivNet(privnet *egoscale.Network, vmName string) (*egoscale.UUID, error) {
+func associatePrivNet(privnet *egoscale.Network, vmName string, ip net.IP) (*egoscale.Nic, error) {
 	vm, err := getVMWithNameOrID(vmName)
 	if err != nil {
 		return nil, err
 	}
 
-	req := &egoscale.AddNicToVirtualMachine{NetworkID: privnet.ID, VirtualMachineID: vm.ID}
+	req := &egoscale.AddNicToVirtualMachine{NetworkID: privnet.ID, VirtualMachineID: vm.ID, IPAddress: ip}
 	resp, err := cs.RequestWithContext(gContext, req)
 	if err != nil {
 		return nil, err
@@ -51,7 +75,7 @@ func associatePrivNet(privnet *egoscale.Network, vmName string) (*egoscale.UUID,
 		return nil, fmt.Errorf("no nics found for network %q", privnet.ID)
 	}
 
-	return nic.ID, nil
+	return nic, nil
 
 }
 

--- a/cmd/exo/cmd/privnet_associate.go
+++ b/cmd/exo/cmd/privnet_associate.go
@@ -12,7 +12,7 @@ import (
 
 // privnetAssociateCmd represents the associate command
 var privnetAssociateCmd = &cobra.Command{
-	Use:     "associate <privnet name | id> <vm name | vm id> [<ip>] [<vm name | vm id> [<ip>] [...]",
+	Use:     "associate <privnet name | id> <vm name | vm id> [<ip>] [<vm name | vm id> [<ip>]] [...]",
 	Short:   "Associate a private network to instance(s)",
 	Aliases: gAssociateAlias,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
`exo privnet associate` can be used to associate a static ip to a private interface:

```
exo privnet associate da9b7b1b-8906-4e0d-9f42-09a985044f02 3c2b2ec6-c7c4-41da-a02f-736a67a93dbd 11.0.0.4 45890f39-9d2a-4d8f-ad78-c18cd32934c9
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│                NIC ID                │          VIRTUAL MACHINE ID          │ IP ADDRESS │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼
│ f8464441-0d1e-4c2b-b203-bbe5d1ab55ea │ 3c2b2ec6-c7c4-41da-a02f-736a67a93dbd │ 11.0.0.4   │
│ 2fa5f02a-37b2-439e-b573-987f750452f0 │ 45890f39-9d2a-4d8f-ad78-c18cd32934c9 │ n/a        │
┼──────────────────────────────────────┼──────────────────────────────────────┼────────────┼

```