### PR TITLE
travis: tests were failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,27 +31,26 @@ install: |
   sudo dpkg -i nfpm_amd64.deb
   npm i codeclimate-test-reporter
 
-script: |
-  dep check
-  dep ensure -v -vendor-only
-  go test -race -coverprofile=coverage.out -covermode=atomic .
-  npx codeclimate-test-reporter < coverage.out
+script:
+  - dep check
+  - dep ensure -v -vendor-only
+  - go test -race -coverprofile=coverage.out -covermode=atomic .
+  - npx codeclimate-test-reporter < coverage.out
 
 jobs:
   include:
   - stage: golangci-lint
     go: 1.10.x
     if: type = pull_request
-    script: |
-      dep ensure -v -vendor-only
-      golangci-lint run .
+    script:
+      - dep ensure -v -vendor-only
+      - golangci-lint run .
   - stage: goreleaser
     go: 1.10.x
     if: type = push
-    script: |
-      dep check
-      dep ensure -v -vendor-only
-      cd cmd/cs
-      dep check
-      dep ensure -v -vendor-only
-      goreleaser --snapshot --skip-sign
+    script:
+      - dep check
+      - dep ensure -v -vendor-only
+      - cd cmd/cs; dep check
+      - cd cmd/cs; dep ensure -v -vendor-only
+      - goreleaser --snapshot --skip-sign

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install: |
   npm i codeclimate-test-reporter
 
 script:
-  - dep check
   - dep ensure -v -vendor-only
+  - dep check
   - go test -race -coverprofile=coverage.out -covermode=atomic .
   - npx codeclimate-test-reporter < coverage.out
 
@@ -49,8 +49,6 @@ jobs:
     go: 1.10.x
     if: type = push
     script:
-      - dep check
       - dep ensure -v -vendor-only
-      - cd cmd/cs; dep check
       - cd cmd/cs; dep ensure -v -vendor-only
       - goreleaser --snapshot --skip-sign

--- a/cidr_test.go
+++ b/cidr_test.go
@@ -8,9 +8,9 @@ import (
 func TestCIDRMustParse(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
-			err, ok := r.(error)
-			if ok {
-				t.Error(err)
+			_, ok := r.(error)
+			if !ok {
+				t.Error(r)
 			}
 		}
 	}()

--- a/client.go
+++ b/client.go
@@ -164,16 +164,24 @@ func (client *Client) List(g Listable) ([]interface{}, error) {
 }
 
 // ListWithContext lists the given resources (and paginate till the end)
-func (client *Client) ListWithContext(ctx context.Context, g Listable) ([]interface{}, error) {
-	s := make([]interface{}, 0)
+func (client *Client) ListWithContext(ctx context.Context, g Listable) (s []interface{}, err error) {
+	s = make([]interface{}, 0)
 
-	if g == nil || reflect.ValueOf(g).IsNil() {
-		return s, fmt.Errorf("g Listable shouldn't be nil, got %#v", g)
-	}
+	defer func() {
+		if e := recover(); e != nil {
+			if g == nil || reflect.ValueOf(g).IsNil() {
+				err = fmt.Errorf("g Listable shouldn't be nil, got %#v", g)
+				return
+			}
 
-	req, err := g.ListRequest()
-	if err != nil {
-		return s, err
+			panic(e)
+		}
+	}()
+
+	req, e := g.ListRequest()
+	if e != nil {
+		err = e
+		return
 	}
 
 	client.PaginateWithContext(ctx, req, func(item interface{}, e error) bool {
@@ -185,7 +193,7 @@ func (client *Client) ListWithContext(ctx context.Context, g Listable) ([]interf
 		return false
 	})
 
-	return s, err
+	return
 }
 
 // AsyncListWithContext lists the given resources (and paginate till the end)

--- a/client_test.go
+++ b/client_test.go
@@ -371,7 +371,7 @@ func TestClientGetTooMany(t *testing.T) {
 }
 
 func TestClientTrace(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `{"listzones":{ "count": 0, "zone": []}}`})
+	ts := newServer(response{200, jsonContentType, `{"listzonesresponse":{ "count": 0, "zone": []}}`})
 	defer ts.Close()
 
 	cs := NewClient(ts.URL, "KEY", "SECRET")

--- a/macaddress_test.go
+++ b/macaddress_test.go
@@ -8,9 +8,9 @@ import (
 func TestMACAddressMustParse(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
-			err, ok := r.(error)
-			if ok {
-				t.Error(err)
+			_, ok := r.(error)
+			if !ok {
+				t.Error(r)
 			}
 		}
 	}()

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -8,9 +8,9 @@ import (
 func TestUUIDMustParse(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
-			err, ok := r.(error)
-			if ok {
-				t.Error(err)
+			_, ok := r.(error)
+			if !ok {
+				t.Error(r)
 			}
 		}
 	}()


### PR DESCRIPTION
`script: |` vs `script: []` semantics...

it's green but it fails, https://travis-ci.org/exoscale/egoscale/jobs/443563483