### PR TITLE
client: fix authorizeSecurityGroupEgress when non-ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.12.5
+------
+
+- fix: `AuthorizeGroupEgress` could return `authorizeGroupIngress` as name
+
 0.12.4
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 0.12.5
 ------
 
-- fix: `AuthorizeGroupEgress` could return `authorizeGroupIngress` as name
+- fix: `AuthorizeSecurityGroupEgress` could return `authorizeSecurityGroupIngress` as name
 
 0.12.4
 ------

--- a/client.go
+++ b/client.go
@@ -305,7 +305,9 @@ func (client *Client) PaginateWithContext(ctx context.Context, req ListCommand, 
 // APIName returns the CloudStack name of the given command
 func (client *Client) APIName(command Command) string {
 	// This is due to a limitation of Go<=1.7
-	if _, ok := command.(*AuthorizeSecurityGroupEgress); ok {
+	_, ok := command.(*AuthorizeSecurityGroupEgress)
+	_, okPtr := command.(AuthorizeSecurityGroupEgress)
+	if ok || okPtr {
 		return "authorizeSecurityGroupEgress"
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,9 @@ func TestClientAPIName(t *testing.T) {
 	if cs.APIName(&AuthorizeSecurityGroupEgress{}) != "authorizeSecurityGroupEgress" {
 		t.Errorf("APIName is wrong, wanted Egress")
 	}
+	if cs.APIName(AuthorizeSecurityGroupEgress{}) != "authorizeSecurityGroupEgress" {
+		t.Errorf("APIName is wrong, wanted Egress")
+	}
 }
 
 func TestClientAPIDescription(t *testing.T) {


### PR DESCRIPTION
this is suboptimal and we should check that all projects are 1.8+ (I'm looking at you docker/machine)