### PR TITLE
admin: listVMs for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ------
 
 - feat: initial Runstatus API support
+- feat: `admin` namespace containing `ListVirtualMachines` for admin usage
 
 0.13.1
 ------

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,5 @@
+# Admin
+
+Specific structures for admin users.
+
+- `ListVirtualMachines` with the `ListAll` argument.

--- a/admin/doc.go
+++ b/admin/doc.go
@@ -1,0 +1,6 @@
+/*
+
+Some aspects of the Exoscale API are restricted to admin privileges, meaning not all field would be useful for everyone if we allowed them to coexist with the base structs. E.g. an admin can list all resources belonging to anyone using the listall=true parameter.
+
+*/
+package admin

--- a/admin/doc.go
+++ b/admin/doc.go
@@ -1,5 +1,7 @@
 /*
 
+Package admin contains the privileged API calls.
+
 Some aspects of the Exoscale API are restricted to admin privileges, meaning not all field would be useful for everyone if we allowed them to coexist with the base structs. E.g. an admin can list all resources belonging to anyone using the listall=true parameter.
 
 */

--- a/admin/virtual_machines.go
+++ b/admin/virtual_machines.go
@@ -20,7 +20,7 @@ type ListVirtualMachines struct {
 }
 
 // ListVirtualMachinesResponse represents the list of VirtualMachine in the admin world
-type LisVirtualMachinesResponse struct {
+type ListVirtualMachinesResponse struct {
 	Count          int              `json:"count"`
 	VirtualMachine []VirtualMachine `json:"virtualmachine"`
 }

--- a/admin/virtual_machines.go
+++ b/admin/virtual_machines.go
@@ -2,19 +2,30 @@ package admin
 
 import "github.com/exoscale/egoscale"
 
+// VirtualMachine represents the enriched VirtualMachine in the admin world
 type VirtualMachine struct {
 	egoscale.VirtualMachine
-	Account   string         `json:"account,omitempty"`
+	Account   string         `json:"account,omitempty" doc:"list resources by account"`
 	AccountID *egoscale.UUID `json:"accountid,omitempty"`
+	HostID    *egoscale.UUID `json:"hostid,omitempty" doc:"the host ID"`
+	PodID     *egoscale.UUID `json:"podid,omitempty" doc:"the pod ID"`
+	StorageID *egoscale.UUID `json:"storageid,omitempty" doc:"the storage ID where vm's volumes belong to"`
 	HostName  string         `json:"string,omitempty"`
 }
 
+// ListVirtualMachines represents the enriched ListVirtualMachines command
 type ListVirtualMachines struct {
 	egoscale.ListVirtualMachines
 	ListAll *bool `json:"listall,omitempty"`
 }
 
+// ListVirtualMachinesResponse represents the list of VirtualMachine in the admin world
 type LisVirtualMachinesResponse struct {
 	Count          int              `json:"count"`
 	VirtualMachine []VirtualMachine `json:"virtualmachine"`
+}
+
+// Response returns the struct to unmarshal
+func (ListVirtualMachines) Response() interface{} {
+	return new(ListVirtualMachinesResponse)
 }

--- a/admin/virtual_machines.go
+++ b/admin/virtual_machines.go
@@ -1,0 +1,20 @@
+package admin
+
+import "github.com/exoscale/egoscale"
+
+type VirtualMachine struct {
+	egoscale.VirtualMachine
+	Account   string         `json:"account,omitempty"`
+	AccountID *egoscale.UUID `json:"accountid,omitempty"`
+	HostName  string         `json:"string,omitempty"`
+}
+
+type ListVirtualMachines struct {
+	egoscale.ListVirtualMachines
+	ListAll *bool `json:"listall,omitempty"`
+}
+
+type LisVirtualMachinesResponse struct {
+	Count          int              `json:"count"`
+	VirtualMachine []VirtualMachine `json:"virtualmachine"`
+}


### PR DESCRIPTION
A minimal usage of this first extended API call. cc @falzm 

```go
package main

import (
	"fmt"

	"github.com/exoscale/egoscale"
	"github.com/exoscale/egoscale/admin"
)

func main() {
	cs := egoscale.NewClient("<URL>", "<KEY>", "<SECRET>")
	b := true
	request := &admin.ListVirtualMachines{
		ListVirtualMachines: egoscale.ListVirtualMachines{
			ZoneID: egoscale.MustParseUUID("de88c980-78f6-467c-a431-71bcc88e437f"),
		},
		ListAll: &b,
	}
	query, _ := cs.Payload(request)
	fmt.Println(query.Encode())
}
```

output:

> apikey=%3CKEY%3E&command=listVirtualMachines&expires=2018-11-23T10%3A33%3A43%2B0100&listall=true&response=json&signatureversion=3&zoneid=de88c980-78f6-467c-a431-71bcc88e437f