### PR TITLE
sg: remove non-existent fields

### DIFF
--- a/security_groups.go
+++ b/security_groups.go
@@ -71,17 +71,15 @@ func (sg SecurityGroup) RuleByID(ruleID UUID) (*IngressRule, *EgressRule) {
 
 // IngressRule represents the ingress rule
 type IngressRule struct {
-	CIDR                  *CIDR               `json:"cidr,omitempty" doc:"the CIDR notation for the base IP address of the security group rule"`
-	Description           string              `json:"description,omitempty" doc:"description of the security group rule"`
-	EndPort               uint16              `json:"endport,omitempty" doc:"the ending port of the security group rule "`
-	IcmpCode              uint8               `json:"icmpcode,omitempty" doc:"the code for the ICMP message response"`
-	IcmpType              uint8               `json:"icmptype,omitempty" doc:"the type of the ICMP message response"`
-	Protocol              string              `json:"protocol,omitempty" doc:"the protocol of the security group rule"`
-	RuleID                *UUID               `json:"ruleid" doc:"the id of the security group rule"`
-	SecurityGroupID       *UUID               `json:"securitygroupid,omitempty"`
-	SecurityGroupName     string              `json:"securitygroupname,omitempty" doc:"security group name"`
-	StartPort             uint16              `json:"startport,omitempty" doc:"the starting port of the security group rule"`
-	UserSecurityGroupList []UserSecurityGroup `json:"usersecuritygrouplist,omitempty"`
+	CIDR              *CIDR  `json:"cidr,omitempty" doc:"the CIDR notation for the base IP address of the security group rule"`
+	Description       string `json:"description,omitempty" doc:"description of the security group rule"`
+	EndPort           uint16 `json:"endport,omitempty" doc:"the ending port of the security group rule "`
+	IcmpCode          uint8  `json:"icmpcode,omitempty" doc:"the code for the ICMP message response"`
+	IcmpType          uint8  `json:"icmptype,omitempty" doc:"the type of the ICMP message response"`
+	Protocol          string `json:"protocol,omitempty" doc:"the protocol of the security group rule"`
+	RuleID            *UUID  `json:"ruleid" doc:"the id of the security group rule"`
+	SecurityGroupName string `json:"securitygroupname,omitempty" doc:"security group name"`
+	StartPort         uint16 `json:"startport,omitempty" doc:"the starting port of the security group rule"`
 }
 
 // EgressRule represents the ingress rule


### PR DESCRIPTION
we may have used `securitygroupid` and `usersecuritygrouplist` here an there, but they don't exist.