### PR TITLE
Runstatus maintenance list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.14.1 (unreleased)
+-------------------
+
+- fix: `GetRunstatusPage` to always contain the subresources
+
 0.14.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 -------------------
 
 - fix: `GetRunstatusPage` to always contain the subresources
+- fix: `ListRunstatus*` to fetch all the subresources
+- feature: `PaginateRunstatus*` used by list
 
 0.14.0
 ------

--- a/runstatus.go
+++ b/runstatus.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -25,138 +24,6 @@ type RunstatusErrorResponse struct {
 
 // runstatusPagesURL is the only URL that cannot be guessed
 const runstatusPagesURL = "/pages"
-
-// RunstatusPage runstatus page
-type RunstatusPage struct {
-	Created          *time.Time             `json:"created,omitempty"`
-	DarkTheme        bool                   `json:"dark_theme,omitempty"`
-	Domain           string                 `json:"domain,omitempty"`
-	GradientEnd      string                 `json:"gradient_end,omitempty"`
-	GradientStart    string                 `json:"gradient_start,omitempty"`
-	HeaderBackground string                 `json:"header_background,omitempty"`
-	ID               int                    `json:"id,omitempty"`
-	Incidents        []RunstatusIncident    `json:"incidents,omitempty"`
-	IncidentsURL     string                 `json:"incidents_url,omitempty"`
-	Logo             string                 `json:"logo,omitempty"`
-	Maintenances     []RunstatusMaintenance `json:"maintenances,omitempty"`
-	MaintenancesURL  string                 `json:"maintenances_url,omitempty"`
-	Name             string                 `json:"name"` //fake field (used to post a new runstatus page)
-	OkText           string                 `json:"ok_text,omitempty"`
-	Plan             string                 `json:"plan,omitempty"`
-	PublicURL        string                 `json:"public_url,omitempty"`
-	Services         []RunstatusService     `json:"services,omitempty"`
-	ServicesURL      string                 `json:"services_url,omitempty"`
-	State            string                 `json:"state,omitempty"`
-	Subdomain        string                 `json:"subdomain"`
-	SupportEmail     string                 `json:"support_email,omitempty"`
-	TimeZone         string                 `json:"time_zone,omitempty"`
-	Title            string                 `json:"title,omitempty"`
-	TitleColor       string                 `json:"title_color,omitempty"`
-	TwitterUsername  string                 `json:"twitter_username,omitempty"`
-	URL              string                 `json:"url,omitempty"`
-}
-
-// Match returns true if the other page has got similarities with itself
-func (page RunstatusPage) Match(other RunstatusPage) bool {
-	if other.Subdomain != "" && page.Subdomain == other.Subdomain {
-		return true
-	}
-
-	if other.ID > 0 && page.ID == other.ID {
-		return true
-	}
-
-	return false
-}
-
-//RunstatusPageList runstatus page list
-type RunstatusPageList struct {
-	Count    int             `json:"count"`
-	Next     string          `json:"next"`
-	Previous string          `json:"previous"`
-	Results  []RunstatusPage `json:"results"`
-}
-
-// CreateRunstatusPage create runstatus page
-func (client *Client) CreateRunstatusPage(ctx context.Context, page RunstatusPage) (*RunstatusPage, error) {
-	resp, err := client.runstatusRequest(ctx, client.Endpoint+runstatusPagesURL, page, "POST")
-	if err != nil {
-		return nil, err
-	}
-
-	var p *RunstatusPage
-	if err := json.Unmarshal(resp, &p); err != nil {
-		return nil, err
-	}
-
-	return p, nil
-}
-
-// DeleteRunstatusPage delete runstatus page
-func (client *Client) DeleteRunstatusPage(ctx context.Context, page RunstatusPage) error {
-	if page.URL == "" {
-		return fmt.Errorf("empty URL for %#v", page)
-	}
-	_, err := client.runstatusRequest(ctx, page.URL, nil, "DELETE")
-	return err
-}
-
-// GetRunstatusPage fetches the runstatus page
-func (client *Client) GetRunstatusPage(ctx context.Context, page RunstatusPage) (*RunstatusPage, error) {
-	if page.URL != "" {
-		return client.getRunstatusPage(ctx, page.URL)
-	}
-
-	ps, err := client.ListRunstatusPages(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range ps {
-		if ps[i].Match(page) {
-			return &ps[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf("%#v not found", page)
-}
-
-func (client *Client) getRunstatusPage(ctx context.Context, pageURL string) (*RunstatusPage, error) {
-	resp, err := client.runstatusRequest(ctx, pageURL, nil, "GET")
-	if err != nil {
-		return nil, err
-	}
-
-	p := new(RunstatusPage)
-	if err := json.Unmarshal(resp, p); err != nil {
-		return nil, err
-	}
-
-	// NOTE: fix the missing IDs
-	for i := range p.Maintenances {
-		if err := p.Maintenances[i].FakeID(); err != nil {
-			log.Printf("bad fake ID for %#v, %s", p.Maintenances[i], err)
-		}
-	}
-
-	return p, nil
-}
-
-// ListRunstatusPages list all the runstatus pages
-func (client *Client) ListRunstatusPages(ctx context.Context) ([]RunstatusPage, error) {
-	resp, err := client.runstatusRequest(ctx, client.Endpoint+runstatusPagesURL, nil, "GET")
-	if err != nil {
-		return nil, err
-	}
-
-	var p *RunstatusPageList
-	if err := json.Unmarshal(resp, &p); err != nil {
-		return nil, err
-	}
-
-	// XXX: handle pagination
-	return p.Results, nil
-}
 
 // Error formats the DNSerror into a string
 func (req RunstatusErrorResponse) Error() string {
@@ -239,7 +106,7 @@ func (client *Client) runstatusRequest(ctx context.Context, uri string, structPa
 
 	contentType := resp.Header.Get("content-type")
 	if !strings.Contains(contentType, "application/json") {
-		return nil, fmt.Errorf(`response content-type expected to be "application/json", got %q`, contentType)
+		return nil, fmt.Errorf(`response %d content-type expected to be "application/json", got %q`, resp.StatusCode, contentType)
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)

--- a/runstatus_incident.go
+++ b/runstatus_incident.go
@@ -127,7 +127,7 @@ func (client *Client) PaginateRunstatusIncidents(ctx context.Context, page Runst
 		}
 
 		for i := range is.Incidents {
-			if ok := callback(&is.Incidents[i], nil); ok {
+			if cont := callback(&is.Incidents[i], nil); !cont {
 				return
 			}
 		}

--- a/runstatus_incident.go
+++ b/runstatus_incident.go
@@ -89,17 +89,20 @@ func (client *Client) ListRunstatusIncidents(ctx context.Context, page Runstatus
 		return nil, fmt.Errorf("empty Incidents URL for %#v", page)
 	}
 
-	resp, err := client.runstatusRequest(ctx, page.IncidentsURL, nil, "GET")
-	if err != nil {
-		return nil, err
-	}
+	results := make([]RunstatusIncident, 0)
 
-	var p *RunstatusIncidentList
-	if err := json.Unmarshal(resp, &p); err != nil {
-		return nil, err
-	}
+	var err error
+	client.PaginateRunstatusIncidents(ctx, page, func(incident *RunstatusIncident, e error) bool {
+		if e != nil {
+			err = e
+			return false
+		}
 
-	return p.Incidents, nil
+		results = append(results, *incident)
+		return true
+	})
+
+	return results, err
 }
 
 // PaginateRunstatusIncidents paginate Incidents

--- a/runstatus_incident.go
+++ b/runstatus_incident.go
@@ -112,9 +112,9 @@ func (client *Client) PaginateRunstatusIncidents(ctx context.Context, page Runst
 		return
 	}
 
-	IncidentsURL := page.IncidentsURL
-	for IncidentsURL != "" {
-		resp, err := client.runstatusRequest(ctx, IncidentsURL, nil, "GET")
+	incidentsURL := page.IncidentsURL
+	for incidentsURL != "" {
+		resp, err := client.runstatusRequest(ctx, incidentsURL, nil, "GET")
 		if err != nil {
 			callback(nil, err)
 			return
@@ -132,7 +132,7 @@ func (client *Client) PaginateRunstatusIncidents(ctx context.Context, page Runst
 			}
 		}
 
-		IncidentsURL = is.Next
+		incidentsURL = is.Next
 	}
 }
 

--- a/runstatus_incident_test.go
+++ b/runstatus_incident_test.go
@@ -60,10 +60,17 @@ func TestRunstatusIncidentGenericError(t *testing.T) { // nolint: dupl
 	}
 }
 
-func TestRunstatusListIncident(t *testing.T) {
+func TestRunstatusListIncidents(t *testing.T) {
+	ts := newServer()
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
 	is := response{200, jsonContentType, `
 {
-  "incidents": [
+  "next": null,
+  "previous": null,
+  "results": [
     {
       "id": 90,
       "url": "https://example.org/pages/testpage/incidents/90",
@@ -103,11 +110,57 @@ func TestRunstatusListIncident(t *testing.T) {
   ]
 }`}
 
-	ts := newServer(is)
-	defer ts.Close()
+	i := response{200, jsonContentType, `{
+  "id": 90,
+  "status": "degraded_performance"
+}`}
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	p := response{200, jsonContentType, fmt.Sprintf(`
+{
+  "url": "https://api.runstatus.com/pages/testpage",
+  "incidents_url": %q,
+  "incidents": [
+    {
+      "id": 90,
+      "url": "https://example.org/pages/testpage/incidents/90",
+      "services": [
+        "API"
+      ],
+      "start_date": "2018-11-14T15:37:29Z",
+      "end_date": "2018-11-14T15:38:19Z",
+      "status": "resolved",
+      "events": [
+        {
+          "created": "2018-11-14T15:38:19Z",
+          "text": "fini",
+          "status": "resolved",
+          "state": "operational"
+        },
+        {
+          "created": "2018-11-14T15:38:09Z",
+          "text": "c'est la vie!",
+          "status": "identified",
+          "state": "degraded_performance"
+        },
+        {
+          "created": "2018-11-14T15:37:29Z",
+          "text": "Foo bar",
+          "status": "monitoring",
+          "state": "operational"
+        }
+      ],
+      "status_text": "fini",
+      "state": "degraded_performance",
+      "title": "AAAH",
+      "events_url": "https://example.org/pages/testpage/incidents/90/events",
+      "post_mortem": "# foo bar\n\nc'est la life",
+      "real_time": true
+    }
+  ],
+  "subdomain": "testpage"
+}`, ts.URL)}
 
+	ts.addResponse(is)
 	incidents, err := cs.ListRunstatusIncidents(context.TODO(), RunstatusPage{IncidentsURL: ts.URL})
 	if err != nil {
 		t.Fatal(err)
@@ -121,16 +174,6 @@ func TestRunstatusListIncident(t *testing.T) {
 		t.Errorf("id 90 expected: got %d", incidents[0].ID)
 	}
 
-	i := response{200, jsonContentType, `{
-  "id": 90,
-  "status": "degraded_performance"
-}`}
-	p := response{200, jsonContentType, fmt.Sprintf(`{
-  "url": "https://api.runstatus.com/pages/testpage",
-  "incidents_url": %q,
-  "subdomain": "testpage"
-}`, ts.URL)}
-
 	ts.addResponse(i)
 	incident, err := cs.GetRunstatusIncident(context.TODO(), RunstatusIncident{URL: ts.URL})
 	if err != nil {
@@ -141,7 +184,7 @@ func TestRunstatusListIncident(t *testing.T) {
 		t.Errorf("bad incident, %#v", incident)
 	}
 
-	ts.addResponse(p, is)
+	ts.addResponse(p)
 	incident, err = cs.GetRunstatusIncident(context.TODO(), RunstatusIncident{PageURL: ts.URL, Title: "AAAH"})
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +194,7 @@ func TestRunstatusListIncident(t *testing.T) {
 		t.Errorf("bad incident, %#v", incident)
 	}
 
-	ts.addResponse(p, is)
+	ts.addResponse(p)
 	incident, err = cs.GetRunstatusIncident(context.TODO(), RunstatusIncident{PageURL: ts.URL, ID: 90})
 	if err != nil {
 		t.Fatal(err)
@@ -160,6 +203,118 @@ func TestRunstatusListIncident(t *testing.T) {
 	if incident.Title != "AAAH" {
 		t.Errorf("bad incident, %#v", incident)
 	}
+}
+
+func TestRunstatusPaginateIncidents(t *testing.T) {
+	ts := newServer()
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	is := response{200, jsonContentType, fmt.Sprintf(`
+	{
+		"count":64,
+		"next": %q,
+		"previous":null,
+		"results": [
+			{
+				"id": 90,
+				"url": "https://example.org/pages/testpage/incidents/90",
+				"services": [
+					"API"
+				],
+				"start_date": "2018-11-14T15:37:29Z",
+				"end_date": "2018-11-14T15:38:19Z",
+				"status": "resolved",
+				"events": [
+					{
+						"created": "2018-11-14T15:38:19Z",
+						"text": "fini",
+						"status": "resolved",
+						"state": "operational"
+					},
+					{
+						"created": "2018-11-14T15:38:09Z",
+						"text": "c'est la vie!",
+						"status": "identified",
+						"state": "degraded_performance"
+					},
+					{
+						"created": "2018-11-14T15:37:29Z",
+						"text": "Foo bar",
+						"status": "monitoring",
+						"state": "operational"
+					}
+				],
+				"status_text": "fini",
+				"state": "degraded_performance",
+				"title": "AAAH",
+				"events_url": "https://example.org/pages/testpage/incidents/90/events",
+				"post_mortem": "# foo bar\n\nc'est la life",
+				"real_time": true
+			}
+		]
+	}`, ts.URL)}
+
+	p := response{200, jsonContentType, `
+	{
+		"count":64,
+		"next": null,
+		"previous":null,
+		"incidents": [
+			{
+				"id": 90,
+				"url": "https://example.org/pages/testpage/incidents/90",
+				"services": [
+					"API"
+				],
+				"start_date": "2018-11-14T15:37:29Z",
+				"end_date": "2018-11-14T15:38:19Z",
+				"status": "resolved",
+				"events": [
+					{
+						"created": "2018-11-14T15:38:19Z",
+						"text": "fini",
+						"status": "resolved",
+						"state": "operational"
+					},
+					{
+						"created": "2018-11-14T15:38:09Z",
+						"text": "c'est la vie!",
+						"status": "identified",
+						"state": "degraded_performance"
+					},
+					{
+						"created": "2018-11-14T15:37:29Z",
+						"text": "Foo bar",
+						"status": "monitoring",
+						"state": "operational"
+					}
+				],
+				"status_text": "fini",
+				"state": "degraded_performance",
+				"title": "AAAH",
+				"events_url": "https://example.org/pages/testpage/incidents/90/events",
+				"post_mortem": "# foo bar\n\nc'est la life",
+				"real_time": true
+			}
+		]
+	}`}
+
+	ts.addResponse(is, p)
+	cs.PaginateRunstatusIncidents(context.TODO(), RunstatusPage{IncidentsURL: ts.URL}, func(incident *RunstatusIncident, e error) bool {
+
+		if e != nil {
+			t.Errorf(`reply error not expected: %v`, e)
+		}
+
+		if incident.Title != "AAAH" {
+			t.Errorf(`AAAH was expected but got %q`, incident.Title)
+		}
+
+		return false
+	})
+
 }
 
 func TestRunstatusIncidentDelete(t *testing.T) {

--- a/runstatus_maintenance.go
+++ b/runstatus_maintenance.go
@@ -142,9 +142,9 @@ func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page Ru
 		return
 	}
 
-	MaintenancesURL := page.MaintenancesURL
-	for MaintenancesURL != "" {
-		resp, err := client.runstatusRequest(ctx, MaintenancesURL, nil, "GET")
+	maintenancesURL := page.MaintenancesURL
+	for maintenancesURL != "" {
+		resp, err := client.runstatusRequest(ctx, maintenancesURL, nil, "GET")
 		if err != nil {
 			callback(nil, err)
 			return
@@ -165,7 +165,7 @@ func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page Ru
 			}
 		}
 
-		MaintenancesURL = ms.Next
+		maintenancesURL = ms.Next
 	}
 }
 

--- a/runstatus_maintenance.go
+++ b/runstatus_maintenance.go
@@ -160,7 +160,7 @@ func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page Ru
 			if err := ms.Maintenances[i].FakeID(); err != nil {
 				log.Printf("bad fake ID for %#v, %s", ms.Maintenances[i], err)
 			}
-			if ok := callback(&ms.Maintenances[i], nil); !ok {
+			if cont := callback(&ms.Maintenances[i], nil); !cont {
 				return
 			}
 		}

--- a/runstatus_maintenance.go
+++ b/runstatus_maintenance.go
@@ -128,7 +128,6 @@ func (client *Client) ListRunstatusMaintenances(ctx context.Context, page Runsta
 			return false
 		}
 
-		log.Printf("maintenance.... %#v", maintenance)
 		results = append(results, *maintenance)
 		return true
 	})
@@ -159,13 +158,10 @@ func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page Ru
 
 		for i := range ms.Maintenances {
 			if err := ms.Maintenances[i].FakeID(); err != nil {
-				if ok := callback(nil, err); !ok {
-					return
-				}
-			} else {
-				if ok := callback(&ms.Maintenances[i], nil); !ok {
-					return
-				}
+				log.Printf("bad fake ID for %#v, %s", ms.Maintenances[i], err)
+			}
+			if ok := callback(&ms.Maintenances[i], nil); !ok {
+				return
 			}
 		}
 

--- a/runstatus_maintenance.go
+++ b/runstatus_maintenance.go
@@ -136,7 +136,7 @@ func (client *Client) ListRunstatusMaintenances(ctx context.Context, page Runsta
 }
 
 // PaginateRunstatusMaintenances paginate Maintenances
-func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page RunstatusPage, callback func(*RunstatusMaintenance, error) bool) {
+func (client *Client) PaginateRunstatusMaintenances(ctx context.Context, page RunstatusPage, callback func(*RunstatusMaintenance, error) bool) { // nolint: dupl
 	if page.MaintenancesURL == "" {
 		callback(nil, fmt.Errorf("empty Maintenances URL for %#v", page))
 		return

--- a/runstatus_page.go
+++ b/runstatus_page.go
@@ -1,0 +1,168 @@
+package egoscale
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+)
+
+// RunstatusPage runstatus page
+type RunstatusPage struct {
+	Created          *time.Time             `json:"created,omitempty"`
+	DarkTheme        bool                   `json:"dark_theme,omitempty"`
+	Domain           string                 `json:"domain,omitempty"`
+	GradientEnd      string                 `json:"gradient_end,omitempty"`
+	GradientStart    string                 `json:"gradient_start,omitempty"`
+	HeaderBackground string                 `json:"header_background,omitempty"`
+	ID               int                    `json:"id,omitempty"`
+	Incidents        []RunstatusIncident    `json:"incidents,omitempty"`
+	IncidentsURL     string                 `json:"incidents_url,omitempty"`
+	Logo             string                 `json:"logo,omitempty"`
+	Maintenances     []RunstatusMaintenance `json:"maintenances,omitempty"`
+	MaintenancesURL  string                 `json:"maintenances_url,omitempty"`
+	Name             string                 `json:"name"` //fake field (used to post a new runstatus page)
+	OkText           string                 `json:"ok_text,omitempty"`
+	Plan             string                 `json:"plan,omitempty"`
+	PublicURL        string                 `json:"public_url,omitempty"`
+	Services         []RunstatusService     `json:"services,omitempty"`
+	ServicesURL      string                 `json:"services_url,omitempty"`
+	State            string                 `json:"state,omitempty"`
+	Subdomain        string                 `json:"subdomain"`
+	SupportEmail     string                 `json:"support_email,omitempty"`
+	TimeZone         string                 `json:"time_zone,omitempty"`
+	Title            string                 `json:"title,omitempty"`
+	TitleColor       string                 `json:"title_color,omitempty"`
+	TwitterUsername  string                 `json:"twitter_username,omitempty"`
+	URL              string                 `json:"url,omitempty"`
+}
+
+// Match returns true if the other page has got similarities with itself
+func (page RunstatusPage) Match(other RunstatusPage) bool {
+	if other.Subdomain != "" && page.Subdomain == other.Subdomain {
+		return true
+	}
+
+	if other.ID > 0 && page.ID == other.ID {
+		return true
+	}
+
+	return false
+}
+
+// RunstatusPageList runstatus page list
+type RunstatusPageList struct {
+	Next     string          `json:"next"`
+	Previous string          `json:"previous"`
+	Pages    []RunstatusPage `json:"results"`
+}
+
+// CreateRunstatusPage create runstatus page
+func (client *Client) CreateRunstatusPage(ctx context.Context, page RunstatusPage) (*RunstatusPage, error) {
+	resp, err := client.runstatusRequest(ctx, client.Endpoint+runstatusPagesURL, page, "POST")
+	if err != nil {
+		return nil, err
+	}
+
+	var p *RunstatusPage
+	if err := json.Unmarshal(resp, &p); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// DeleteRunstatusPage delete runstatus page
+func (client *Client) DeleteRunstatusPage(ctx context.Context, page RunstatusPage) error {
+	if page.URL == "" {
+		return fmt.Errorf("empty URL for %#v", page)
+	}
+	_, err := client.runstatusRequest(ctx, page.URL, nil, "DELETE")
+	return err
+}
+
+// GetRunstatusPage fetches the runstatus page
+func (client *Client) GetRunstatusPage(ctx context.Context, page RunstatusPage) (*RunstatusPage, error) {
+	if page.URL != "" {
+		return client.getRunstatusPage(ctx, page.URL)
+	}
+
+	ps, err := client.ListRunstatusPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range ps {
+		if ps[i].Match(page) {
+			return client.getRunstatusPage(ctx, ps[i].URL)
+		}
+	}
+
+	return nil, fmt.Errorf("%#v not found", page)
+}
+
+func (client *Client) getRunstatusPage(ctx context.Context, pageURL string) (*RunstatusPage, error) {
+	resp, err := client.runstatusRequest(ctx, pageURL, nil, "GET")
+	if err != nil {
+		return nil, err
+	}
+
+	p := new(RunstatusPage)
+	if err := json.Unmarshal(resp, p); err != nil {
+		return nil, err
+	}
+
+	// NOTE: fix the missing IDs
+	for i := range p.Maintenances {
+		if err := p.Maintenances[i].FakeID(); err != nil {
+			log.Printf("bad fake ID for %#v, %s", p.Maintenances[i], err)
+		}
+	}
+	for i := range p.Services {
+		if err := p.Services[i].FakeID(); err != nil {
+			log.Printf("bad fake ID for %#v, %s", p.Services[i], err)
+		}
+	}
+
+	return p, nil
+}
+
+// ListRunstatusPages list all the runstatus pages
+func (client *Client) ListRunstatusPages(ctx context.Context) ([]RunstatusPage, error) {
+	resp, err := client.runstatusRequest(ctx, client.Endpoint+runstatusPagesURL, nil, "GET")
+	if err != nil {
+		return nil, err
+	}
+
+	var p *RunstatusPageList
+	if err := json.Unmarshal(resp, &p); err != nil {
+		return nil, err
+	}
+
+	return p.Pages, nil
+}
+
+//PaginateRunstatusPages paginate on runstatus pages
+func (client *Client) PaginateRunstatusPages(ctx context.Context, callback func(pages []RunstatusPage, e error) bool) {
+	pageURL := client.Endpoint + runstatusPagesURL
+	for pageURL != "" {
+		resp, err := client.runstatusRequest(ctx, pageURL, nil, "GET")
+		if err != nil {
+			callback(nil, err)
+			return
+		}
+
+		var p *RunstatusPageList
+		if err := json.Unmarshal(resp, &p); err != nil {
+			callback(nil, err)
+			return
+		}
+
+		if ok := callback(p.Pages, nil); ok {
+			return
+		}
+
+		pageURL = p.Next
+	}
+}

--- a/runstatus_page_test.go
+++ b/runstatus_page_test.go
@@ -2,6 +2,7 @@ package egoscale
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -212,7 +213,18 @@ func TestCreateRunstatusPage(t *testing.T) {
 }
 
 func TestListRunstatusPage(t *testing.T) {
-	ps := response{200, jsonContentType, `
+	ts := newServer()
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	p := response{200, jsonContentType, `
+{
+  "id": 102,
+  "url": "https://example.org/pages/testpage",
+  "subdomain": "testpage"
+}`}
+	ps := response{200, jsonContentType, fmt.Sprintf(`
 {
   "count":9,
   "next":null,
@@ -220,81 +232,14 @@ func TestListRunstatusPage(t *testing.T) {
   "results":[
     {
       "id": 102,
-      "url": "https://example.org/pages/testpage",
-      "created": "2018-11-14T15:21:10Z",
-      "plan": "free",
+      "url": %q,
       "subdomain": "testpage",
-      "domain": null,
-      "ok_text": "All systems operational",
-      "state": "operational",
-      "time_zone": "UTC",
-      "title": "",
-      "support_email": "",
-      "services_url": "https://example.org/pages/testpage/services",
-      "incidents_url": "https://example.org/pages/testpage/incidents",
-      "maintenances_url": "https://example.org/pages/testpage/maintenances",
-      "logo": null,
-      "twitter_username": "",
-      "public_url": "https://testpage.runstat.us",
-      "dark_theme": false,
-      "gradient_start": "224,224,224,0.9",
-      "gradient_end": "255,255,255,0.9",
-      "title_color": "204,204,204,1",
-      "header_background": null,
-      "services": [
-        {
-          "url": "https://example.org/pages/testpage/services/28",
-          "name": "API",
-          "state": "operational"
-        }
-      ],
+      "services": [],
       "maintenances": [],
-      "incidents": [
-        {
-          "id": 90,
-          "url": "https://example.org/pages/testpage/incidents/90",
-          "services": [
-            "API"
-          ],
-          "start_date": "2018-11-14T15:37:29Z",
-          "end_date": "2018-11-14T15:38:19Z",
-          "status": "resolved",
-          "events": [
-            {
-              "created": "2018-11-14T15:38:19Z",
-              "text": "fini",
-              "status": "resolved",
-              "state": "operational"
-            },
-            {
-              "created": "2018-11-14T15:38:09Z",
-              "text": "c'est la vie!",
-              "status": "identified",
-              "state": "degraded_performance"
-            },
-            {
-              "created": "2018-11-14T15:37:29Z",
-              "text": "Foo bar",
-              "status": "monitoring",
-              "state": "operational"
-            }
-          ],
-          "status_text": "fini",
-          "state": "degraded_performance",
-          "title": "AAAH",
-          "events_url": "https://example.org/pages/testpage/incidents/90/events",
-          "post_mortem": "# foo bar\n\nc'est la life",
-          "real_time": true
-        }
-      ]
+      "incidents": []
     }
   ]
-}`}
-
-	ts := newServer()
-	defer ts.Close()
-
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+}`, ts.URL)}
 
 	ts.addResponse(ps)
 	pages, err := cs.ListRunstatusPages(context.TODO())
@@ -310,7 +255,7 @@ func TestListRunstatusPage(t *testing.T) {
 		t.Errorf("subpage should be %q, got %q", "testpage", pages[0].Subdomain)
 	}
 
-	ts.addResponse(ps)
+	ts.addResponse(ps, p)
 	page, err := cs.GetRunstatusPage(context.TODO(), RunstatusPage{Subdomain: "testpage"})
 	if err != nil {
 		t.Fatal(err)
@@ -319,7 +264,7 @@ func TestListRunstatusPage(t *testing.T) {
 		t.Errorf("bad page ID, got %d, wanted 102", page.ID)
 	}
 
-	ts.addResponse(ps)
+	ts.addResponse(ps, p)
 	page, err = cs.GetRunstatusPage(context.TODO(), RunstatusPage{ID: 102})
 	if err != nil {
 		t.Fatal(err)
@@ -327,4 +272,59 @@ func TestListRunstatusPage(t *testing.T) {
 	if page.Subdomain != "testpage" {
 		t.Errorf(`bad page ID, got %q, wanted "testpage"`, page.Subdomain)
 	}
+}
+
+func TestPaginateRunstatusPage(t *testing.T) {
+	ts := newServer()
+	defer ts.Close()
+
+	cs := NewClient(ts.URL, "KEY", "SECRET")
+
+	p := response{200, jsonContentType, fmt.Sprintf(`
+  {
+    "count":9,
+    "next": %q,
+    "previous":null,
+    "results":[
+      {
+        "id": 102,
+        "url": "",
+        "subdomain": "testpage",
+        "services": [],
+        "maintenances": [],
+        "incidents": []
+      }
+    ]
+  }`, ts.URL)}
+
+	ps := response{200, jsonContentType, `
+  {
+    "count":64,
+    "next":null,
+    "previous":null,
+    "results":[
+      {
+        "id": 102,
+        "url": "",
+        "subdomain": "testpage",
+        "services": [],
+        "maintenances": [],
+        "incidents": []
+      }
+    ]
+  }`}
+
+	ts.addResponse(p, ps)
+	cs.PaginateRunstatusPages(context.TODO(), func(pages []RunstatusPage, e error) bool {
+
+		if e != nil {
+			t.Errorf(`reply error not expected: %v`, e)
+		}
+
+		if pages[0].Subdomain != "testpage" {
+			t.Errorf(`testpage2 was expected but got %q`, pages[0].Subdomain)
+		}
+
+		return false
+	})
 }

--- a/runstatus_service.go
+++ b/runstatus_service.go
@@ -166,7 +166,7 @@ func (client *Client) ListRunstatusServices(ctx context.Context, page RunstatusP
 }
 
 // PaginateRunstatusServices paginates Services
-func (client *Client) PaginateRunstatusServices(ctx context.Context, page RunstatusPage, callback func(*RunstatusService, error) bool) {
+func (client *Client) PaginateRunstatusServices(ctx context.Context, page RunstatusPage, callback func(*RunstatusService, error) bool) { // nolint: dupl
 	if page.ServicesURL == "" {
 		callback(nil, fmt.Errorf("empty Services URL for %#v", page))
 		return


### PR DESCRIPTION
cf https://github.com/exoscale/cli/pull/84

- `/pages` has an empty maintenances bag, while `/pages/<page>` fills it
- known bug. `/pages/<page>/maintenances` fetches the 50 oldest maintenances
- ditto for incidents and services.