### PR TITLE
global: export BooleanResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.13.4 (unreleased)
+------
+
+- change: export `BooleanResponse`
+
 0.13.3
 ------
 

--- a/addresses.go
+++ b/addresses.go
@@ -106,7 +106,7 @@ func (DisassociateIPAddress) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (DisassociateIPAddress) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // UpdateIPAddress (Async) represents the IP modification

--- a/addresses_test.go
+++ b/addresses_test.go
@@ -20,7 +20,7 @@ func TestAssociateIPAddress(t *testing.T) {
 func TestDisassociateIPAddress(t *testing.T) {
 	req := &DisassociateIPAddress{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestListPublicIPAddresses(t *testing.T) {

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -107,7 +107,7 @@ func (DeleteAffinityGroup) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (DeleteAffinityGroup) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListAffinityGroups

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -14,7 +14,7 @@ func TestCreateAffinityGroup(t *testing.T) {
 func TestDeleteAffinityGroup(t *testing.T) {
 	req := &DeleteAffinityGroup{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestListAffinityGroups(t *testing.T) {

--- a/instance_groups.go
+++ b/instance_groups.go
@@ -49,7 +49,7 @@ type DeleteInstanceGroup struct {
 
 // Response returns the struct to unmarshal
 func (DeleteInstanceGroup) Response() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListInstanceGroups

--- a/instance_groups_test.go
+++ b/instance_groups_test.go
@@ -21,5 +21,5 @@ func TestUpdateInstanceGroup(t *testing.T) {
 
 func TestDeleteInstanceGroup(t *testing.T) {
 	req := &DeleteInstanceGroup{}
-	_ = req.Response().(*booleanResponse)
+	_ = req.Response().(*BooleanResponse)
 }

--- a/networks.go
+++ b/networks.go
@@ -198,7 +198,7 @@ func (DeleteNetwork) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (DeleteNetwork) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListNetworks

--- a/networks_test.go
+++ b/networks_test.go
@@ -37,7 +37,7 @@ func TestUpdateNetwork(t *testing.T) {
 func TestDeleteNetwork(t *testing.T) {
 	req := &DeleteNetwork{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestCreateNetworkOnBeforeSend(t *testing.T) {

--- a/nics.go
+++ b/nics.go
@@ -98,7 +98,7 @@ func (RemoveIPFromNic) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (RemoveIPFromNic) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // ActivateIP6 (Async) activates the IP6 on the given NIC

--- a/nics_test.go
+++ b/nics_test.go
@@ -13,7 +13,7 @@ func TestAddIPToNic(t *testing.T) {
 func TestRemoveIPFromNic(t *testing.T) {
 	req := &RemoveIPFromNic{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestListNicsAPIName(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -24,7 +24,7 @@ func (e ErrorResponse) Error() string {
 }
 
 // Error formats a CloudStack job response into a standard error
-func (e booleanResponse) Error() error {
+func (e BooleanResponse) Error() error {
 	if !e.Success {
 		return fmt.Errorf("API error: %s", e.DisplayText)
 	}
@@ -143,7 +143,7 @@ func (client *Client) SyncRequestWithContext(ctx context.Context, command Comman
 	}
 
 	response := command.Response()
-	b, ok := response.(*booleanResponse)
+	b, ok := response.(*BooleanResponse)
 	if ok {
 		m := make(map[string]interface{})
 		if errUnmarshal := json.Unmarshal(body, &m); errUnmarshal != nil {
@@ -181,7 +181,7 @@ func (client *Client) BooleanRequest(command Command) error {
 		return err
 	}
 
-	if b, ok := resp.(*booleanResponse); ok {
+	if b, ok := resp.(*BooleanResponse); ok {
 		return b.Error()
 	}
 
@@ -195,7 +195,7 @@ func (client *Client) BooleanRequestWithContext(ctx context.Context, command Com
 		return err
 	}
 
-	if b, ok := resp.(*booleanResponse); ok {
+	if b, ok := resp.(*BooleanResponse); ok {
 		return b.Error()
 	}
 

--- a/request_type.go
+++ b/request_type.go
@@ -177,8 +177,8 @@ type UUIDItem struct {
 	UUID             string `json:"uuid"`
 }
 
-// booleanResponse represents a boolean response (usually after a deletion)
-type booleanResponse struct {
+// BooleanResponse represents a boolean response (usually after a deletion)
+type BooleanResponse struct {
 	DisplayText string `json:"displaytext,omitempty"`
 	Success     bool   `json:"success"`
 }

--- a/reversedns.go
+++ b/reversedns.go
@@ -22,7 +22,7 @@ type DeleteReverseDNSFromPublicIPAddress struct {
 
 // Response returns the struct to unmarshal
 func (*DeleteReverseDNSFromPublicIPAddress) Response() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // DeleteReverseDNSFromVirtualMachine is a command to create/delete the PTR record(s) of a virtual machine
@@ -33,7 +33,7 @@ type DeleteReverseDNSFromVirtualMachine struct {
 
 // Response returns the struct to unmarshal
 func (*DeleteReverseDNSFromVirtualMachine) Response() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // QueryReverseDNSForPublicIPAddress is a command to create/query the PTR record of a public IP address

--- a/reversedns_test.go
+++ b/reversedns_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestDeleteReverseDNSFromVirtualMachine(t *testing.T) {
 	req := &DeleteReverseDNSFromVirtualMachine{}
-	_ = req.Response().(*booleanResponse)
+	_ = req.Response().(*BooleanResponse)
 }
 
 func TestDeleteReverseDNSFromPublicIPAddress(t *testing.T) {
 	req := &DeleteReverseDNSFromPublicIPAddress{}
-	_ = req.Response().(*booleanResponse)
+	_ = req.Response().(*BooleanResponse)
 }
 
 func TestQueryReverseDNSForVirtualMachine(t *testing.T) {

--- a/security_groups.go
+++ b/security_groups.go
@@ -116,7 +116,7 @@ type DeleteSecurityGroup struct {
 
 // Response returns the struct to unmarshal
 func (DeleteSecurityGroup) Response() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // AuthorizeSecurityGroupIngress (Async) represents the ingress rule creation
@@ -187,7 +187,7 @@ func (RevokeSecurityGroupIngress) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (RevokeSecurityGroupIngress) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // RevokeSecurityGroupEgress (Async) represents the ingress/egress rule deletion
@@ -203,7 +203,7 @@ func (RevokeSecurityGroupEgress) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (RevokeSecurityGroupEgress) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListSecurityGroups

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -35,7 +35,7 @@ func TestCreateSecurityGroup(t *testing.T) {
 
 func TestDeleteSecurityGroup(t *testing.T) {
 	req := &DeleteSecurityGroup{}
-	_ = req.Response().(*booleanResponse)
+	_ = req.Response().(*BooleanResponse)
 }
 
 func TestListSecurityGroupsApiName(t *testing.T) {
@@ -46,13 +46,13 @@ func TestListSecurityGroupsApiName(t *testing.T) {
 func TestRevokeSecurityGroupEgress(t *testing.T) {
 	req := &RevokeSecurityGroupEgress{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestRevokeSecurityGroupIngress(t *testing.T) {
 	req := &RevokeSecurityGroupIngress{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestAuthorizeSecurityGroupEgressOnBeforeSendICMP(t *testing.T) {

--- a/snapshots.go
+++ b/snapshots.go
@@ -119,7 +119,7 @@ func (DeleteSnapshot) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (DeleteSnapshot) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // RevertSnapshot (Async) reverts a volume snapshot
@@ -135,5 +135,5 @@ func (RevertSnapshot) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (RevertSnapshot) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }

--- a/snapshots_test.go
+++ b/snapshots_test.go
@@ -25,11 +25,11 @@ func TestListSnapshots(t *testing.T) {
 func TestDeleteSnapshot(t *testing.T) {
 	req := &DeleteSnapshot{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestRevertSnapshot(t *testing.T) {
 	req := &RevertSnapshot{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }

--- a/ssh_keypairs.go
+++ b/ssh_keypairs.go
@@ -54,7 +54,7 @@ type DeleteSSHKeyPair struct {
 
 // Response returns the struct to unmarshal
 func (DeleteSSHKeyPair) Response() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // RegisterSSHKeyPair represents a new registration of a public key in a keypair

--- a/ssh_keypairs_test.go
+++ b/ssh_keypairs_test.go
@@ -22,7 +22,7 @@ func TestCreateSSHKeyPair(t *testing.T) {
 
 func TestDeleteSSHKeyPair(t *testing.T) {
 	req := &DeleteSSHKeyPair{}
-	_ = req.Response().(*booleanResponse)
+	_ = req.Response().(*BooleanResponse)
 }
 
 func TestListSSHKeyPairsResponse(t *testing.T) {

--- a/tags.go
+++ b/tags.go
@@ -41,7 +41,7 @@ func (CreateTags) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (CreateTags) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // DeleteTags (Async) deletes the resource tag(s)
@@ -59,7 +59,7 @@ func (DeleteTags) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (DeleteTags) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListTags

--- a/tags_test.go
+++ b/tags_test.go
@@ -7,13 +7,13 @@ import (
 func TestCreateTags(t *testing.T) {
 	req := &CreateTags{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestDeleteTags(t *testing.T) {
 	req := &DeleteTags{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestListTags(t *testing.T) {

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -436,7 +436,7 @@ func (ExpungeVirtualMachine) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (ExpungeVirtualMachine) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // ScaleVirtualMachine (Async) scales the virtual machine to a new service offering.
@@ -457,7 +457,7 @@ func (ScaleVirtualMachine) Response() interface{} {
 
 // AsyncResponse returns the struct to unmarshal the async job
 func (ScaleVirtualMachine) AsyncResponse() interface{} {
-	return new(booleanResponse)
+	return new(BooleanResponse)
 }
 
 // ChangeServiceForVirtualMachine changes the service offering for a virtual machine. The virtual machine must be in a "Stopped" state for this command to take effect.

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -78,7 +78,7 @@ func TestChangeServiceForVirtualMachine(t *testing.T) {
 func TestScaleVirtualMachine(t *testing.T) {
 	req := &ScaleVirtualMachine{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestRecoverVirtualMachine(t *testing.T) {
@@ -89,7 +89,7 @@ func TestRecoverVirtualMachine(t *testing.T) {
 func TestExpungeVirtualMachine(t *testing.T) {
 	req := &ExpungeVirtualMachine{}
 	_ = req.Response().(*AsyncJobResult)
-	_ = req.AsyncResponse().(*booleanResponse)
+	_ = req.AsyncResponse().(*BooleanResponse)
 }
 
 func TestGetVirtualMachineUserData(t *testing.T) {


### PR DESCRIPTION
```console
% sed -i "s/booleanResponse/BooleanResponse/g" *.go
```

cf. https://github.com/exoscale/cli/issues/88