### PR TITLE
affinity group: empty name should be accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.13.4 (unreleased)
+-------------------
+
+- fix: `CreateAffinityGroup` allows empty `name`
+
 0.13.3
 ------
 

--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -52,9 +52,17 @@ type AffinityGroupType struct {
 // CreateAffinityGroup (Async) represents a new (anti-)affinity group
 type CreateAffinityGroup struct {
 	Description string `json:"description,omitempty" doc:"Optional description of the affinity group"`
-	Name        string `json:"name" doc:"Name of the affinity group"`
+	Name        string `json:"name,omitempty" doc:"Name of the affinity group"`
 	Type        string `json:"type" doc:"Type of the affinity group from the available affinity/anti-affinity group types"`
 	_           bool   `name:"createAffinityGroup" description:"Creates an affinity/anti-affinity group"`
+}
+
+func (req CreateAffinityGroup) onBeforeSend(params url.Values) error {
+	// Name must be set, but can be empty
+	if req.Name == "" {
+		params.Set("name", "")
+	}
+	return nil
 }
 
 // Response returns the struct to unmarshal

--- a/affinity_groups_test.go
+++ b/affinity_groups_test.go
@@ -33,6 +33,19 @@ func TestUpdateVMAffinityGroup(t *testing.T) {
 	_ = req.AsyncResponse().(*VirtualMachine)
 }
 
+func TestCreateAffinityGroupOnBeforeSend(t *testing.T) {
+	req := &CreateAffinityGroup{}
+	params := url.Values{}
+
+	if err := req.onBeforeSend(params); err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := params["name"]; !ok {
+		t.Errorf("name should have been set")
+	}
+}
+
 func TestUpdateVMOnBeforeSend(t *testing.T) {
 	req := &UpdateVMAffinityGroup{}
 	params := url.Values{}


### PR DESCRIPTION
```console
% cs createAffinityGroup name="" type="host anti-affinity"
{
  "affinitygroup": {
    "id": "6d06b1e8-f899-4fa9-97ba-1ff202ecc2a4",
    "name": "",
    "type": "host anti-affinity"
  }
}
```