### PR TITLE
Replace satori/go.uuid by gofrs/uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
 install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v${GOLANGCI_LINT_VERSION}
   - npm i codeclimate-test-reporter
-  - '[ "$(echo "$TRAVIS_GO_VERSION" | perl -pe "s/\\.[x\\d]+$//")" = "1.11" ] && go mod vendor || go get -u github.com/satori/go.uuid'
+  - '[ "$(echo "$TRAVIS_GO_VERSION" | perl -pe "s/\\.[x\\d]+$//")" = "1.11" ] && go mod vendor || go get -u github.com/gofrs/uuid'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -45,5 +45,5 @@ jobs:
     go: 1.10.x
     if: type = pull_request
     script:
-      - go get -u github.com/satori/go.uuid
+      - go get -u github.com/gofrs/uuid
       - golangci-lint run .

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/exoscale/egoscale
 
-require github.com/satori/go.uuid v1.2.0
+require github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
+github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/uuid.go
+++ b/uuid.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 )
 
 // UUID holds a UUID v4
@@ -38,7 +38,7 @@ func (u *UUID) DeepCopyInto(out *UUID) {
 
 // Equal returns true if itself is equal to other.
 func (u UUID) Equal(other UUID) bool {
-	return uuid.Equal(u.UUID, other.UUID)
+	return u == other
 }
 
 // UnmarshalJSON unmarshals the raw JSON into the UUID.


### PR DESCRIPTION
The satori/go.uuid package has critical
bugs (https://github.com/satori/go.uuid/issues/73).

This commit replaces this package by the gofrs/uuid fork.

In that package, The `Equal` function for UUID has been deleted (we
can use `==` directly for comparisons as explained in the `3.0.0`
release note of the package:
https://github.com/gofrs/uuid/releases/tag/v3.0.0).

Related to https://github.com/containous/traefik/pull/4718