### PR TITLE
Improve the requests User-Agent HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+- change: make the "User-Agent" HTTP request header more informative and exposed
+
 0.18.0
 ------
 

--- a/client.go
+++ b/client.go
@@ -9,9 +9,17 @@ import (
 	"net/http/httputil"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"time"
 )
+
+// UserAgent is the "User-Agent" HTTP request header added to outgoing HTTP requests.
+var UserAgent = fmt.Sprintf("egoscale/%s (%s; %s/%s)",
+	Version,
+	runtime.Version(),
+	runtime.GOOS,
+	runtime.GOARCH)
 
 // Taggable represents a resource to which tags can be attached
 //

--- a/dns.go
+++ b/dns.go
@@ -329,7 +329,7 @@ func (client *Client) dnsRequest(ctx context.Context, uri string, urlValues url.
 
 	var hdr = make(http.Header)
 	hdr.Add("X-DNS-TOKEN", client.APIKey+":"+client.apiSecret)
-	hdr.Add("User-Agent", fmt.Sprintf("exoscale/egoscale (%v)", Version))
+	hdr.Add("User-Agent", UserAgent)
 	hdr.Add("Accept", "application/json")
 	if params != "" {
 		hdr.Add("Content-Type", "application/json")

--- a/request.go
+++ b/request.go
@@ -345,7 +345,7 @@ func (client *Client) request(ctx context.Context, command Command) (json.RawMes
 		return nil, err
 	}
 	request = request.WithContext(ctx)
-	request.Header.Add("User-Agent", fmt.Sprintf("exoscale/egoscale (%v)", Version))
+	request.Header.Add("User-Agent", UserAgent)
 
 	if method == "POST" {
 		request.Header.Add("Content-Type", "application/x-www-form-urlencoded")

--- a/runstatus.go
+++ b/runstatus.go
@@ -82,7 +82,7 @@ func (client *Client) runstatusRequest(ctx context.Context, uri string, structPa
 
 	hdr.Add("Authorization", fmt.Sprintf("Exoscale-HMAC-SHA256 %s:%s", client.APIKey, signature))
 	hdr.Add("Exoscale-Date", time)
-	hdr.Add("User-Agent", fmt.Sprintf("exoscale/egoscale (%v)", Version))
+	hdr.Add("User-Agent", UserAgent)
 	hdr.Add("Accept", "application/json")
 	if params != "" {
 		hdr.Add("Content-Type", "application/json")


### PR DESCRIPTION
This change makes the "User-Agent" HTTP request header more informative,
and exposes it outside of the package if a caller wants to prefix it
with is own UA segment:

```go
import "github.com/exoscale/egoscale"

...

egoscale.UserAgent = fmt.Sprintf("Exoscale-CLI/%s %s", version, egoscale.UserAgent)

```