### PR TITLE
Add anti-affinity create group call

### DIFF
--- a/affinity_groups.go
+++ b/affinity_groups.go
@@ -6,20 +6,20 @@ import (
 	"net/url"
 )
 
-// AffinityGroup represents an (anti-)affinity group
+// AffinityGroup represents an Affinity Group.
 //
-// Affinity and Anti-Affinity groups provide a way to influence where VMs should run.
+// Affinity and Anti-Affinity Groups provide a way to influence where VMs should run.
 // See: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/stable/virtual_machines.html#affinity-groups
 type AffinityGroup struct {
-	Account           string `json:"account,omitempty" doc:"the account owning the affinity group"`
-	Description       string `json:"description,omitempty" doc:"the description of the affinity group"`
-	ID                *UUID  `json:"id,omitempty" doc:"the ID of the affinity group"`
-	Name              string `json:"name,omitempty" doc:"the name of the affinity group"`
-	Type              string `json:"type,omitempty" doc:"the type of the affinity group"`
-	VirtualMachineIDs []UUID `json:"virtualmachineIds,omitempty" doc:"virtual machine Ids associated with this affinity group"`
+	Account           string `json:"account,omitempty" doc:"the account owning the Affinity Group"`
+	Description       string `json:"description,omitempty" doc:"the description of the Affinity Group"`
+	ID                *UUID  `json:"id,omitempty" doc:"the ID of the Affinity Group"`
+	Name              string `json:"name,omitempty" doc:"the name of the Affinity Group"`
+	Type              string `json:"type,omitempty" doc:"the type of the Affinity Group"`
+	VirtualMachineIDs []UUID `json:"virtualmachineIds,omitempty" doc:"virtual machine IDs associated with this Affinity Group"`
 }
 
-// ListRequest builds the ListAffinityGroups request
+// ListRequest builds the ListAffinityGroups request.
 func (ag AffinityGroup) ListRequest() (ListCommand, error) {
 	return &ListAffinityGroups{
 		ID:   ag.ID,
@@ -27,7 +27,7 @@ func (ag AffinityGroup) ListRequest() (ListCommand, error) {
 	}, nil
 }
 
-// Delete removes the given Affinity Group
+// Delete deletes the given Affinity Group.
 func (ag AffinityGroup) Delete(ctx context.Context, client *Client) error {
 	if ag.ID == nil && ag.Name == "" {
 		return fmt.Errorf("an Affinity Group may only be deleted using ID or Name")
@@ -44,114 +44,114 @@ func (ag AffinityGroup) Delete(ctx context.Context, client *Client) error {
 	return client.BooleanRequestWithContext(ctx, req)
 }
 
-// AffinityGroupType represent an affinity group type
+// AffinityGroupType represent an Affinity Group type.
 type AffinityGroupType struct {
-	Type string `json:"type,omitempty" doc:"the type of the affinity group"`
+	Type string `json:"type,omitempty" doc:"the type of the Affinity Group"`
 }
 
-// CreateAffinityGroup (Async) represents a new (anti-)affinity group
+// CreateAffinityGroup (Async) represents a new Affinity Group.
 type CreateAffinityGroup struct {
-	Description string `json:"description,omitempty" doc:"Optional description of the affinity group"`
-	Name        string `json:"name,omitempty" doc:"Name of the affinity group"`
-	Type        string `json:"type" doc:"Type of the affinity group from the available affinity/anti-affinity group types"`
-	_           bool   `name:"createAffinityGroup" description:"Creates an affinity/anti-affinity group"`
+	Description string `json:"description,omitempty" doc:"Optional description of the Affinity Group"`
+	Name        string `json:"name" doc:"Name of the Affinity Group"`
+	Type        string `json:"type" doc:"Type of the Affinity Group from the available Affinity Group Group types"`
+	_           bool   `name:"createAffinityGroup" description:"Creates an Affinity Group Group"`
 }
 
 func (req CreateAffinityGroup) onBeforeSend(params url.Values) error {
-	// Name must be set, but can be empty
+	// Name must be set, but can be empty.
 	if req.Name == "" {
 		params.Set("name", "")
 	}
 	return nil
 }
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func (CreateAffinityGroup) Response() interface{} {
 	return new(AsyncJobResult)
 }
 
-// AsyncResponse returns the struct to unmarshal the async job
+// AsyncResponse returns the struct to unmarshal the async job.
 func (CreateAffinityGroup) AsyncResponse() interface{} {
 	return new(AffinityGroup)
 }
 
-// UpdateVMAffinityGroup (Async) represents a modification of a (anti-)affinity group
+// UpdateVMAffinityGroup (Async) represents a modification of an Affinity Group.
 type UpdateVMAffinityGroup struct {
 	ID                 *UUID    `json:"id" doc:"The ID of the virtual machine"`
-	AffinityGroupIDs   []UUID   `json:"affinitygroupids,omitempty" doc:"comma separated list of affinity groups id that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupnames parameter"`
-	AffinityGroupNames []string `json:"affinitygroupnames,omitempty" doc:"comma separated list of affinity groups names that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupids parameter"`
-	_                  bool     `name:"updateVMAffinityGroup" description:"Updates the affinity/anti-affinity group associations of a virtual machine. The VM has to be stopped and restarted for the new properties to take effect."`
+	AffinityGroupIDs   []UUID   `json:"affinitygroupids,omitempty" doc:"comma separated list of Affinity Groups id that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupnames parameter"`
+	AffinityGroupNames []string `json:"affinitygroupnames,omitempty" doc:"comma separated list of Affinity Groups names that are going to be applied to the virtual machine. Should be passed only when vm is created from a zone with Basic Network support. Mutually exclusive with securitygroupids parameter"`
+	_                  bool     `name:"updateVMAffinityGroup" description:"Updates the Affinity Group Group associations of a virtual machine. The VM has to be stopped and restarted for the new properties to take effect."`
 }
 
 func (req UpdateVMAffinityGroup) onBeforeSend(params url.Values) error {
-	// Either AffinityGroupIDs or AffinityGroupNames must be set
+	// Either AffinityGroupIDs or AffinityGroupNames must be set.
 	if len(req.AffinityGroupIDs) == 0 && len(req.AffinityGroupNames) == 0 {
 		params.Set("affinitygroupids", "")
 	}
 	return nil
 }
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func (UpdateVMAffinityGroup) Response() interface{} {
 	return new(AsyncJobResult)
 }
 
-// AsyncResponse returns the struct to unmarshal the async job
+// AsyncResponse returns the struct to unmarshal the async job.
 func (UpdateVMAffinityGroup) AsyncResponse() interface{} {
 	return new(VirtualMachine)
 }
 
-// DeleteAffinityGroup (Async) represents an (anti-)affinity group to be deleted
+// DeleteAffinityGroup (Async) represents an Affinity Group to be deleted.
 type DeleteAffinityGroup struct {
-	ID   *UUID  `json:"id,omitempty" doc:"The ID of the affinity group. Mutually exclusive with name parameter"`
-	Name string `json:"name,omitempty" doc:"The name of the affinity group. Mutually exclusive with ID parameter"`
-	_    bool   `name:"deleteAffinityGroup" description:"Deletes affinity group"`
+	ID   *UUID  `json:"id,omitempty" doc:"The ID of the Affinity Group. Mutually exclusive with name parameter"`
+	Name string `json:"name,omitempty" doc:"The name of the Affinity Group. Mutually exclusive with ID parameter"`
+	_    bool   `name:"deleteAffinityGroup" description:"Deletes Affinity Group"`
 }
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func (DeleteAffinityGroup) Response() interface{} {
 	return new(AsyncJobResult)
 }
 
-// AsyncResponse returns the struct to unmarshal the async job
+// AsyncResponse returns the struct to unmarshal the async job.
 func (DeleteAffinityGroup) AsyncResponse() interface{} {
 	return new(BooleanResponse)
 }
 
 //go:generate go run generate/main.go -interface=Listable ListAffinityGroups
 
-// ListAffinityGroups represents an (anti-)affinity groups search
+// ListAffinityGroups represents an Affinity Groups search.
 type ListAffinityGroups struct {
-	ID               *UUID  `json:"id,omitempty" doc:"List the affinity group by the ID provided"`
+	ID               *UUID  `json:"id,omitempty" doc:"List the Affinity Group by the ID provided"`
 	Keyword          string `json:"keyword,omitempty" doc:"List by keyword"`
-	Name             string `json:"name,omitempty" doc:"Lists affinity groups by name"`
+	Name             string `json:"name,omitempty" doc:"Lists Affinity Groups by name"`
 	Page             int    `json:"page,omitempty"`
 	PageSize         int    `json:"pagesize,omitempty"`
-	Type             string `json:"type,omitempty" doc:"Lists affinity groups by type"`
-	VirtualMachineID *UUID  `json:"virtualmachineid,omitempty" doc:"Lists affinity groups by virtual machine ID"`
-	_                bool   `name:"listAffinityGroups" description:"Lists affinity groups"`
+	Type             string `json:"type,omitempty" doc:"Lists Affinity Groups by type"`
+	VirtualMachineID *UUID  `json:"virtualmachineid,omitempty" doc:"Lists Affinity Groups by virtual machine ID"`
+	_                bool   `name:"listAffinityGroups" description:"Lists Affinity Groups"`
 }
 
-// ListAffinityGroupsResponse represents a list of (anti-)affinity groups
+// ListAffinityGroupsResponse represents a list of Affinity Groups.
 type ListAffinityGroupsResponse struct {
 	Count         int             `json:"count"`
 	AffinityGroup []AffinityGroup `json:"affinitygroup"`
 }
 
-// ListAffinityGroupTypes represents an (anti-)affinity groups search
+// ListAffinityGroupTypes represents an Affinity Groups types search.
 type ListAffinityGroupTypes struct {
 	Keyword  string `json:"keyword,omitempty" doc:"List by keyword"`
 	Page     int    `json:"page,omitempty"`
 	PageSize int    `json:"pagesize,omitempty"`
-	_        bool   `name:"listAffinityGroupTypes" description:"Lists affinity group types available"`
+	_        bool   `name:"listAffinityGroupTypes" description:"Lists Affinity Group types available"`
 }
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func (ListAffinityGroupTypes) Response() interface{} {
 	return new(ListAffinityGroupTypesResponse)
 }
 
-// ListAffinityGroupTypesResponse represents a list of (anti-)affinity group types
+// ListAffinityGroupTypesResponse represents a list of Affinity Group types.
 type ListAffinityGroupTypesResponse struct {
 	Count             int                 `json:"count"`
 	AffinityGroupType []AffinityGroupType `json:"affinitygrouptype"`

--- a/affinitygroups_response.go
+++ b/affinitygroups_response.go
@@ -4,12 +4,12 @@ package egoscale
 
 import "fmt"
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func (ListAffinityGroups) Response() interface{} {
 	return new(ListAffinityGroupsResponse)
 }
 
-// ListRequest returns itself
+// ListRequest returns itself.
 func (ls *ListAffinityGroups) ListRequest() (ListCommand, error) {
 	if ls == nil {
 		return nil, fmt.Errorf("%T cannot be nil", ls)
@@ -17,17 +17,17 @@ func (ls *ListAffinityGroups) ListRequest() (ListCommand, error) {
 	return ls, nil
 }
 
-// SetPage sets the current apge
+// SetPage sets the current page.
 func (ls *ListAffinityGroups) SetPage(page int) {
 	ls.Page = page
 }
 
-// SetPageSize sets the page size
+// SetPageSize sets the page size.
 func (ls *ListAffinityGroups) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-// Each triggers the callback for each, valid answer or any non 404 issue
+// Each triggers the callback for each, valid answer or any non 404 issue.
 func (ListAffinityGroups) Each(resp interface{}, callback IterateItemFunc) {
 	items, ok := resp.(*ListAffinityGroupsResponse)
 	if !ok {

--- a/antiaffinity_groups.go
+++ b/antiaffinity_groups.go
@@ -1,0 +1,103 @@
+package egoscale
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// AntiAffinityGroup represents an Anti-Affinity Group.
+type AntiAffinityGroup struct {
+	Account           string `json:"account,omitempty" doc:"the account owning the Anti-Affinity Group"`
+	Description       string `json:"description,omitempty" doc:"the description of the Anti-Affinity Group"`
+	ID                *UUID  `json:"id,omitempty" doc:"the ID of the Anti-Affinity Group"`
+	Name              string `json:"name,omitempty" doc:"the name of the Anti-Affinity Group"`
+	Type              string `json:"type,omitempty" doc:"the type of the Anti-Affinity Group"`
+	VirtualMachineIDs []UUID `json:"virtualmachineIds,omitempty" doc:"virtual machine IDs associated with this Anti-Affinity Group"`
+}
+
+// ListRequest builds the ListAntiAffinityGroups request.
+func (ag AntiAffinityGroup) ListRequest() (ListCommand, error) {
+	return &ListAffinityGroups{
+		ID:   ag.ID,
+		Name: ag.Name,
+	}, nil
+}
+
+// Delete deletes the given Anti-Affinity Group.
+func (ag AntiAffinityGroup) Delete(ctx context.Context, client *Client) error {
+	if ag.ID == nil && ag.Name == "" {
+		return fmt.Errorf("an Anti-Affinity Group may only be deleted using ID or Name")
+	}
+
+	req := &DeleteAffinityGroup{}
+
+	if ag.ID != nil {
+		req.ID = ag.ID
+	} else {
+		req.Name = ag.Name
+	}
+
+	return client.BooleanRequestWithContext(ctx, req)
+}
+
+// CreateAntiAffinityGroup represents an Anti-Affinity Group creation.
+type CreateAntiAffinityGroup struct {
+	Name        string `json:"name" doc:"Name of the Anti-Affinity Group"`
+	Description string `json:"description,omitempty" doc:"Optional description of the Anti-Affinity Group"`
+	_           bool   `name:"createAntiAffinityGroup" description:"Creates an Anti-Affinity Group"`
+}
+
+func (req CreateAntiAffinityGroup) onBeforeSend(params url.Values) error {
+	// Name must be set, but can be empty.
+	if req.Name == "" {
+		params.Set("name", "")
+	}
+	return nil
+}
+
+// Response returns the struct to unmarshal.
+func (CreateAntiAffinityGroup) Response() interface{} {
+	return new(AsyncJobResult)
+}
+
+// AsyncResponse returns the struct to unmarshal the async job.
+func (CreateAntiAffinityGroup) AsyncResponse() interface{} {
+	return new(AffinityGroup)
+}
+
+//go:generate go run generate/main.go -interface=Listable ListAntiAffinityGroups
+
+// ListAntiAffinityGroups represents an Anti-Affinity Groups search.
+type ListAntiAffinityGroups struct {
+	ID               *UUID  `json:"id,omitempty" doc:"List the Anti-Affinity Group by the ID provided"`
+	Keyword          string `json:"keyword,omitempty" doc:"List by keyword"`
+	Name             string `json:"name,omitempty" doc:"Lists Anti-Affinity Groups by name"`
+	Page             int    `json:"page,omitempty"`
+	PageSize         int    `json:"pagesize,omitempty"`
+	VirtualMachineID *UUID  `json:"virtualmachineid,omitempty" doc:"Lists Anti-Affinity Groups by virtual machine ID"`
+	_                bool   `name:"listAntiAffinityGroups" description:"Lists Anti-Affinity Groups"`
+}
+
+// ListAntiAffinityGroupsResponse represents a list of Anti-Affinity Groups.
+type ListAntiAffinityGroupsResponse struct {
+	Count             int             `json:"count"`
+	AntiAffinityGroup []AffinityGroup `json:"antiaffinitygroup"`
+}
+
+// DeleteAntiAffinityGroup (Async) represents an Anti-Affinity Group to be deleted.
+type DeleteAntiAffinityGroup struct {
+	ID   *UUID  `json:"id,omitempty" doc:"The ID of the Anti-Affinity Group. Mutually exclusive with name parameter"`
+	Name string `json:"name,omitempty" doc:"The name of the Anti-Affinity Group. Mutually exclusive with ID parameter"`
+	_    bool   `name:"deleteAntiAffinityGroup" description:"Deletes Anti-Affinity Group"`
+}
+
+// Response returns the struct to unmarshal.
+func (DeleteAntiAffinityGroup) Response() interface{} {
+	return new(AsyncJobResult)
+}
+
+// AsyncResponse returns the struct to unmarshal the async job.
+func (DeleteAntiAffinityGroup) AsyncResponse() interface{} {
+	return new(BooleanResponse)
+}

--- a/antiaffinity_groups_response.go
+++ b/antiaffinity_groups_response.go
@@ -1,0 +1,43 @@
+// code generated; DO NOT EDIT.
+
+package egoscale
+
+import "fmt"
+
+// Response returns the struct to unmarshal.
+func (ListAntiAffinityGroups) Response() interface{} {
+	return new(ListAntiAffinityGroupsResponse)
+}
+
+// ListRequest returns itself.
+func (ls *ListAntiAffinityGroups) ListRequest() (ListCommand, error) {
+	if ls == nil {
+		return nil, fmt.Errorf("%T cannot be nil", ls)
+	}
+	return ls, nil
+}
+
+// SetPage sets the current page.
+func (ls *ListAntiAffinityGroups) SetPage(page int) {
+	ls.Page = page
+}
+
+// SetPageSize sets the page size.
+func (ls *ListAntiAffinityGroups) SetPageSize(pageSize int) {
+	ls.PageSize = pageSize
+}
+
+// Each triggers the callback for each, valid answer or any non 404 issue.
+func (ListAntiAffinityGroups) Each(resp interface{}, callback IterateItemFunc) {
+	items, ok := resp.(*ListAntiAffinityGroupsResponse)
+	if !ok {
+		callback(nil, fmt.Errorf("wrong type, ListAntiAffinityGroupsResponse was expected, got %T", resp))
+		return
+	}
+
+	for i := range items.AntiAffinityGroup {
+		if !callback(&items.AntiAffinityGroup[i], nil) {
+			break
+		}
+	}
+}

--- a/generate/main.go
+++ b/generate/main.go
@@ -596,12 +596,12 @@ package {{.Package}}
 
 import "fmt"
 
-// Response returns the struct to unmarshal
+// Response returns the struct to unmarshal.
 func ({{.Type}}) Response() interface{} {
 	return new({{.Type}}Response)
 }
 
-// ListRequest returns itself
+// ListRequest returns itself.
 func (ls *{{.Type}}) ListRequest() (ListCommand, error) {
 	if ls == nil {
 		return nil, fmt.Errorf("%T cannot be nil", ls)
@@ -609,17 +609,17 @@ func (ls *{{.Type}}) ListRequest() (ListCommand, error) {
 	return ls, nil
 }
 
-// SetPage sets the current apge
+// SetPage sets the current page.
 func (ls *{{.Type}}) SetPage(page int) {
 	ls.Page = page
 }
 
-// SetPageSize sets the page size
+// SetPageSize sets the page size.
 func (ls *{{.Type}}) SetPageSize(pageSize int) {
 	ls.PageSize = pageSize
 }
 
-// Each triggers the callback for each, valid answer or any non 404 issue
+// Each triggers the callback for each, valid answer or any non 404 issue.
 func ({{.Type}}) Each(resp interface{}, callback IterateItemFunc) {
 	items, ok := resp.(*{{.Type}}Response)
 	if !ok {


### PR DESCRIPTION
The Exoscale API now exposes dedicated Anti-Affinity Group calls for managing Anti-Affinity Groups in addition to Affinity Groups: add support for those new calls in egoscale.


Tested on my side