### PR TITLE
tests: fix request client timeout handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ dist: xenial
 sudo: required
 
 go:
-- "1.7.x"
-- "1.8.x"
-- "1.9.x"
 - "1.10.x"
 - "1.11.x"
 - "1.12.x"
@@ -14,7 +11,7 @@ go:
 - tip
 
 env:
-  - GOLANGCI_LINT_VERSION=1.17.1 GO111MODULES=on
+  - GOLANGCI_LINT_VERSION=1.23.3 GO111MODULES=on
 
 cache: apt
 
@@ -44,7 +41,7 @@ after_script:
 jobs:
   include:
   - stage: golangci-lint
-    go: 1.12.x
+    go: 1.13.x
     if: type = pull_request
     script:
       - go get -u github.com/gofrs/uuid

--- a/networks.go
+++ b/networks.go
@@ -43,7 +43,7 @@ type Network struct {
 	Tags                []ResourceTag `json:"tags,omitempty" doc:"the list of resource tags associated with network"`
 	TrafficType         string        `json:"traffictype,omitempty" doc:"the traffic type of the network"`
 	Type                string        `json:"type,omitempty" doc:"the type of the network"`
-	Vlan                string        `json:"vlan,omitemtpy" doc:"The vlan of the network. This parameter is visible to ROOT admins only"`
+	Vlan                string        `json:"vlan,omitempty" doc:"The vlan of the network. This parameter is visible to ROOT admins only"`
 	ZoneID              *UUID         `json:"zoneid,omitempty" doc:"zone id of the network"`
 	ZoneName            string        `json:"zonename,omitempty" doc:"the name of the zone the network belongs to"`
 	ZonesNetworkSpans   []Zone        `json:"zonesnetworkspans,omitempty" doc:"If a network is enabled for 'streched l2 subnet' then represents zones on which network currently spans"`

--- a/request_test.go
+++ b/request_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -279,8 +280,7 @@ func TestBooleanRequestTimeout(t *testing.T) {
 		}
 
 		// We expect the HTTP Client to timeout
-		msg := err.Error()
-		if !strings.HasPrefix(msg, "Get") {
+		if netErr, ok := err.(net.Error); ok && !netErr.Timeout() {
 			t.Errorf("Unexpected error message: %s", err.Error())
 		}
 
@@ -553,8 +553,7 @@ func TestBooleanRequestWithContext(t *testing.T) {
 		}
 
 		// We expect the context to timeout
-		msg := err.Error()
-		if !strings.HasPrefix(msg, "Get") {
+		if netErr, ok := err.(net.Error); ok && !netErr.Timeout() {
 			t.Errorf("Unexpected error message: %s", err.Error())
 		}
 
@@ -605,8 +604,7 @@ func TestRequestWithContextTimeoutPost(t *testing.T) {
 		}
 
 		// We expect the context to timeout
-		msg := err.Error()
-		if !strings.HasPrefix(msg, "Post") {
+		if netErr, ok := err.(net.Error); ok && !netErr.Timeout() {
 			t.Errorf("Unexpected error message: %s", err.Error())
 		}
 
@@ -649,8 +647,7 @@ func TestBooleanRequestWithContextAndTimeout(t *testing.T) {
 		}
 
 		// We expect the client to timeout
-		msg := err.Error()
-		if !strings.HasPrefix(msg, "Get") || !strings.Contains(msg, "net/http: request canceled") {
+		if netErr, ok := err.(net.Error); ok && !netErr.Timeout() {
 			t.Errorf("Unexpected error message: %s", err.Error())
 		}
 


### PR DESCRIPTION
This change fixes the code testing that a client request times out when
configured with a deadline-type context.

Fixes #421.