### PR TITLE
Annotate API doc regarding use of tags

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -169,7 +169,7 @@ type ListPublicIPAddresses struct {
 	Page                int           `json:"page,omitempty"`
 	PageSize            int           `json:"pagesize,omitempty"`
 	PhysicalNetworkID   *UUID         `json:"physicalnetworkid,omitempty" doc:"lists all public IP addresses by physical network id"`
-	Tags                []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags                []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	VlanID              *UUID         `json:"vlanid,omitempty" doc:"lists all public IP addresses by VLAN ID"`
 	ZoneID              *UUID         `json:"zoneid,omitempty" doc:"lists all public IP addresses by Zone ID"`
 	_                   bool          `name:"listPublicIpAddresses" description:"Lists all public ip addresses"`

--- a/isos.go
+++ b/isos.go
@@ -50,7 +50,7 @@ type ListISOs struct {
 	Page        int           `json:"page,omitempty"`
 	PageSize    int           `json:"pagesize,omitempty"`
 	ShowRemoved *bool         `json:"showremoved,omitempty" doc:"Show removed ISOs as well"`
-	Tags        []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags        []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	ZoneID      *UUID         `json:"zoneid,omitempty" doc:"The ID of the zone"`
 }
 

--- a/networks.go
+++ b/networks.go
@@ -208,7 +208,7 @@ type ListNetworks struct {
 	RestartRequired   *bool         `json:"restartrequired,omitempty" doc:"List networks by restartRequired"`
 	SpecifyIPRanges   *bool         `json:"specifyipranges,omitempty" doc:"True if need to list only networks which support specifying ip ranges"`
 	SupportedServices []Service     `json:"supportedservices,omitempty" doc:"List networks supporting certain services"`
-	Tags              []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags              []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	TrafficType       string        `json:"traffictype,omitempty" doc:"Type of the traffic"`
 	Type              string        `json:"type,omitempty" doc:"The type of the network. Supported values are: Isolated and Shared"`
 	ZoneID            *UUID         `json:"zoneid,omitempty" doc:"The Zone ID of the network"`

--- a/snapshots.go
+++ b/snapshots.go
@@ -94,7 +94,7 @@ type ListSnapshots struct {
 	Page         int           `json:"page,omitempty"`
 	PageSize     int           `json:"pagesize,omitempty"`
 	SnapshotType string        `json:"snapshottype,omitempty" doc:"valid values are MANUAL or RECURRING."`
-	Tags         []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags         []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	VolumeID     *UUID         `json:"volumeid,omitempty" doc:"the ID of the disk volume"`
 	ZoneID       *UUID         `json:"zoneid,omitempty" doc:"list snapshots by zone id"`
 	_            bool          `name:"listSnapshots" description:"Lists all available snapshots for the account."`

--- a/templates.go
+++ b/templates.go
@@ -77,7 +77,7 @@ type ListTemplates struct {
 	Page           int           `json:"page,omitempty"`
 	PageSize       int           `json:"pagesize,omitempty"`
 	ShowRemoved    *bool         `json:"showremoved,omitempty" doc:"Show removed templates as well"`
-	Tags           []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags           []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	ZoneID         *UUID         `json:"zoneid,omitempty" doc:"list templates by zoneid"`
 	_              bool          `name:"listTemplates" description:"List all public, private, and privileged templates."`
 }

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -520,7 +520,7 @@ type ListVirtualMachines struct {
 	PageSize          int           `json:"pagesize,omitempty"`
 	ServiceOfferindID *UUID         `json:"serviceofferingid,omitempty" doc:"list by the service offering"`
 	State             string        `json:"state,omitempty" doc:"state of the virtual machine"`
-	Tags              []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags              []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	TemplateID        *UUID         `json:"templateid,omitempty" doc:"list vms by template"`
 	ZoneID            *UUID         `json:"zoneid,omitempty" doc:"the availability zone ID"`
 	_                 bool          `name:"listVirtualMachines" description:"List the virtual machines owned by the account."`

--- a/volumes.go
+++ b/volumes.go
@@ -99,7 +99,7 @@ type ListVolumes struct {
 	Name             string        `json:"name,omitempty" doc:"The name of the disk volume"`
 	Page             int           `json:"page,omitempty"`
 	PageSize         int           `json:"pagesize,omitempty"`
-	Tags             []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs)"`
+	Tags             []ResourceTag `json:"tags,omitempty" doc:"List resources by tags (key/value pairs). Note: multiple tags are OR'ed, not AND'ed."`
 	Type             string        `json:"type,omitempty" doc:"The type of disk volume"`
 	VirtualMachineID *UUID         `json:"virtualmachineid,omitempty" doc:"The ID of the virtual machine"`
 	ZoneID           *UUID         `json:"zoneid,omitempty" doc:"The ID of the availability zone"`


### PR DESCRIPTION
This change annotates the API documentation regarding the use of tags parameter, so that users know that multiple tags are OR'ed and not AND'ed.

Story: [Allow listing VM with a AND for tags](https://app.clubhouse.io/exoscale/story/8665/allow-listing-vm-with-a-and-for-tags)