### PR TITLE
Fix ListVolumes call to allow search by ID

### DIFF
--- a/volumes.go
+++ b/volumes.go
@@ -62,6 +62,7 @@ func (Volume) ResourceType() string {
 // ListRequest builds the ListVolumes request
 func (vol Volume) ListRequest() (ListCommand, error) {
 	req := &ListVolumes{
+		ID:               vol.ID,
 		Name:             vol.Name,
 		Type:             vol.Type,
 		VirtualMachineID: vol.VirtualMachineID,


### PR DESCRIPTION
This change fixes the `ListVolumes` to allow volumes search by ID.