### PR TITLE
Improve GetWithContext() error messages.

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,8 +150,11 @@ func (client *Client) GetWithContext(ctx context.Context, ls Listable) (interfac
 		return nil, err
 	}
 
-	count := len(gs)
-	if count != 1 {
+	switch len(gs) {
+	case 0:
+		return nil, ErrNotFound
+
+	case 1:
 		req, err := ls.ListRequest()
 		if err != nil {
 			return nil, err
@@ -171,17 +174,11 @@ func (client *Client) GetWithContext(ctx context.Context, ls Listable) (interfac
 		payload := params.Encode()
 		payload = strings.Replace(payload, "&", ", ", -1)
 
-		if count == 0 {
-			return nil, &ErrorResponse{
-				CSErrorCode: ServerAPIException,
-				ErrorCode:   ParamError,
-				ErrorText:   fmt.Sprintf("not found, query: %s", payload),
-			}
-		}
-		return nil, fmt.Errorf("more than one element found: %s", payload)
-	}
+		return gs[0], nil
 
-	return gs[0], nil
+	default:
+		return nil, fmt.Errorf("multiple resources found")
+	}
 }
 
 // Delete removes the given resource of fails

--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (client *Client) GetWithContext(ctx context.Context, ls Listable) (interfac
 		return gs[0], nil
 
 	default:
-		return nil, fmt.Errorf("multiple resources found")
+		return nil, ErrTooManyFound
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -155,25 +154,6 @@ func (client *Client) GetWithContext(ctx context.Context, ls Listable) (interfac
 		return nil, ErrNotFound
 
 	case 1:
-		req, err := ls.ListRequest()
-		if err != nil {
-			return nil, err
-		}
-		params, err := client.Payload(req)
-		if err != nil {
-			return nil, err
-		}
-
-		// removing sensitive/useless informations
-		params.Del("expires")
-		params.Del("response")
-		params.Del("signature")
-		params.Del("signatureversion")
-
-		// formatting the query string nicely
-		payload := params.Encode()
-		payload = strings.Replace(payload, "&", ", ", -1)
-
 		return gs[0], nil
 
 	default:

--- a/client_test.go
+++ b/client_test.go
@@ -256,21 +256,14 @@ func TestClientGetNone(t *testing.T) {
 
 		cs := NewClient(ts.URL, "KEY", "SECRET")
 
-		errText := "not found"
 		_, err := cs.Get(thing.listable)
 		if err == nil {
 			t.Error("an error was expected")
 			continue
 		}
 
-		e, ok := err.(*ErrorResponse)
-		if !ok {
-			t.Errorf("an ErrorResponse was expected, got %T", err)
-			continue
-		}
-
-		if !strings.Contains(e.ErrorText, errText) {
-			t.Errorf("bad error test, got %q", e.ErrorText)
+		if err != ErrNotFound {
+			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 
 		ts.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -319,8 +319,8 @@ func TestClientGetZero(t *testing.T) {
 			t.Errorf("an error was expected")
 		}
 
-		if !strings.HasPrefix(err.Error(), "API error ParamError 431") {
-			t.Errorf("bad error %q", err)
+		if err != ErrNotFound {
+			t.Fatalf("expected ErrNotFound, got %v", err)
 		}
 
 		ts.Close()
@@ -383,8 +383,8 @@ func TestClientGetTooMany(t *testing.T) {
 			t.Errorf("an error was expected")
 		}
 
-		if !strings.HasPrefix(err.Error(), "more than one") {
-			t.Errorf("bad error %s", err)
+		if err != ErrTooManyFound {
+			t.Fatalf("expected ErrTooManyFound, got %v", err)
 		}
 
 		ts.Close()

--- a/error.go
+++ b/error.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNotFound represents an error indicating a non-existent resource.
 var ErrNotFound = errors.New("resource not found")
+
+// ErrTooManyFound represents an error indicating multiple results found for a single resource.
+var ErrTooManyFound = errors.New("multiple resources found")


### PR DESCRIPTION
This change improves the error messages returned by the `GetWithContext`
method in case no resource or multiple resources are found, as it was
previously returned an error suggesting an API-side issue.