### PR TITLE
BucketUsage: change Usage to int64

### DIFF
--- a/sos_buckets_usage.go
+++ b/sos_buckets_usage.go
@@ -5,7 +5,7 @@ type BucketUsage struct {
 	Created string `json:"created"`
 	Name    string `json:"name"`
 	Region  string `json:"region"`
-	Usage   int    `json:"usage"`
+	Usage   int64  `json:"usage"`
 }
 
 // ListBucketsUsage represents a listBucketsUsage API request


### PR DESCRIPTION
This change replaces the type for `BucketUsage.Usage` to `int64`.