### PR TITLE
Fix CreateInstancePool.AntiAffinityGroupIDs field

### DIFF
--- a/instance_pool.go
+++ b/instance_pool.go
@@ -43,7 +43,7 @@ type CreateInstancePool struct {
 	ServiceOfferingID    *UUID  `json:"serviceofferingid"`
 	TemplateID           *UUID  `json:"templateid"`
 	ZoneID               *UUID  `json:"zoneid"`
-	AntiAffinityGroupIDs []UUID `json:"affinitygroupids"`
+	AntiAffinityGroupIDs []UUID `json:"affinitygroupids,omitempty"`
 	SecurityGroupIDs     []UUID `json:"securitygroupids,omitempty"`
 	NetworkIDs           []UUID `json:"networkids,omitempty"`
 	IPv6                 bool   `json:"ipv6,omitempty"`


### PR DESCRIPTION
This change makes the `CreateInstancePool.AntiAffinityGroupIDs` field
optional.