### PR TITLE
Add API v2 ListZones() call

### DIFF
--- a/zones.go
+++ b/zones.go
@@ -1,6 +1,7 @@
 package egoscale
 
 import (
+	"context"
 	"net"
 )
 
@@ -59,4 +60,23 @@ type ListZones struct {
 type ListZonesResponse struct {
 	Count int    `json:"count"`
 	Zone  []Zone `json:"zone"`
+}
+
+// ListZones returns the list of Exoscale zones.
+func (c *Client) ListZones(ctx context.Context) ([]string, error) {
+	list := make([]string, 0)
+
+	resp, err := c.v2.ListZonesWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Zones != nil {
+		for i := range *resp.JSON200.Zones {
+			zone := &(*resp.JSON200.Zones)[i]
+			list = append(list, *zone.Name)
+		}
+	}
+
+	return list, nil
 }

--- a/zones_test.go
+++ b/zones_test.go
@@ -2,8 +2,14 @@ package egoscale
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/exoscale/egoscale/internal/v2"
 )
 
 func TestListZonesAPIName(t *testing.T) {
@@ -276,4 +282,48 @@ func TestListZonesTimeout(t *testing.T) {
 	if err == nil {
 		t.Errorf("An error was expected")
 	}
+}
+
+func TestClient_ListZones(t *testing.T) {
+	var (
+		testZones = []string{
+			"at-vie-1",
+			"bg-sof-1",
+			"ch-dk-2",
+			"ch-gva-2",
+			"de-fra-1",
+			"de-muc-1",
+		}
+		err error
+	)
+
+	mockClient := v2.NewMockClient()
+	client := NewClient("x", "x", "x")
+	client.v2, err = v2.NewClientWithResponses("", v2.WithHTTPClient(mockClient))
+	require.NoError(t, err)
+
+	mockClient.RegisterResponder("GET", "/zone",
+		func(_ *http.Request) (*http.Response, error) {
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, struct {
+				Zones *[]v2.Zone `json:"zones,omitempty"`
+			}{
+				Zones: func() *[]v2.Zone {
+					zones := make([]v2.Zone, len(testZones))
+					for i := range testZones {
+						name := testZones[i]
+						zones[i] = v2.Zone{Name: &name}
+					}
+					return &zones
+				}(),
+			})
+			if err != nil {
+				t.Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+			return resp, nil
+		})
+
+	expected := testZones
+	actual, err := client.ListZones(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
This changes implements the public API v2 `list-zones` operation.