### PR TITLE
SKS: add Anti-Affinity Groups support to Nodepools 

### DIFF
--- a/internal/v2/sks_nodepool.go
+++ b/internal/v2/sks_nodepool.go
@@ -10,18 +10,19 @@ import (
 // only supports RFC 3339 format.
 func (n *SksNodepool) UnmarshalJSON(data []byte) error {
 	raw := struct {
-		CreatedAt      *string          `json:"created-at,omitempty"`
-		Description    *string          `json:"description,omitempty"`
-		DiskSize       *int64           `json:"disk-size,omitempty"`
-		Id             *string          `json:"id,omitempty"` // nolint:golint
-		InstancePool   *InstancePool    `json:"instance-pool,omitempty"`
-		InstanceType   *InstanceType    `json:"instance-type,omitempty"`
-		Name           *string          `json:"name,omitempty"`
-		SecurityGroups *[]SecurityGroup `json:"security-groups,omitempty"`
-		Size           *int64           `json:"size,omitempty"`
-		State          *string          `json:"state,omitempty"`
-		Template       *Template        `json:"template,omitempty"`
-		Version        *string          `json:"version,omitempty"`
+		AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+		CreatedAt          *string              `json:"created-at,omitempty"`
+		Description        *string              `json:"description,omitempty"`
+		DiskSize           *int64               `json:"disk-size,omitempty"`
+		Id                 *string              `json:"id,omitempty"` // nolint:golint
+		InstancePool       *InstancePool        `json:"instance-pool,omitempty"`
+		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
+		Name               *string              `json:"name,omitempty"`
+		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+		Size               *int64               `json:"size,omitempty"`
+		State              *string              `json:"state,omitempty"`
+		Template           *Template            `json:"template,omitempty"`
+		Version            *string              `json:"version,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -36,6 +37,7 @@ func (n *SksNodepool) UnmarshalJSON(data []byte) error {
 		n.CreatedAt = &createdAt
 	}
 
+	n.AntiAffinityGroups = raw.AntiAffinityGroups
 	n.Description = raw.Description
 	n.DiskSize = raw.DiskSize
 	n.Id = raw.Id
@@ -55,18 +57,19 @@ func (n *SksNodepool) UnmarshalJSON(data []byte) error {
 // in the original timestamp (ISO 8601), since time.MarshalJSON() only supports RFC 3339 format.
 func (n *SksNodepool) MarshalJSON() ([]byte, error) {
 	raw := struct {
-		CreatedAt      *string          `json:"created-at,omitempty"`
-		Description    *string          `json:"description,omitempty"`
-		DiskSize       *int64           `json:"disk-size,omitempty"`
-		Id             *string          `json:"id,omitempty"` // nolint:golint
-		InstancePool   *InstancePool    `json:"instance-pool,omitempty"`
-		InstanceType   *InstanceType    `json:"instance-type,omitempty"`
-		Name           *string          `json:"name,omitempty"`
-		SecurityGroups *[]SecurityGroup `json:"security-groups,omitempty"`
-		Size           *int64           `json:"size,omitempty"`
-		State          *string          `json:"state,omitempty"`
-		Template       *Template        `json:"template,omitempty"`
-		Version        *string          `json:"version,omitempty"`
+		AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+		CreatedAt          *string              `json:"created-at,omitempty"`
+		Description        *string              `json:"description,omitempty"`
+		DiskSize           *int64               `json:"disk-size,omitempty"`
+		Id                 *string              `json:"id,omitempty"` // nolint:golint
+		InstancePool       *InstancePool        `json:"instance-pool,omitempty"`
+		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
+		Name               *string              `json:"name,omitempty"`
+		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
+		Size               *int64               `json:"size,omitempty"`
+		State              *string              `json:"state,omitempty"`
+		Template           *Template            `json:"template,omitempty"`
+		Version            *string              `json:"version,omitempty"`
 	}{}
 
 	if n.CreatedAt != nil {
@@ -74,6 +77,7 @@ func (n *SksNodepool) MarshalJSON() ([]byte, error) {
 		raw.CreatedAt = &createdAt
 	}
 
+	raw.AntiAffinityGroups = n.AntiAffinityGroups
 	raw.Description = n.Description
 	raw.DiskSize = n.DiskSize
 	raw.Id = n.Id

--- a/internal/v2/sks_nodepool_test.go
+++ b/internal/v2/sks_nodepool_test.go
@@ -11,37 +11,40 @@ import (
 
 func TestSksNodepool_UnmarshalJSON(t *testing.T) {
 	var (
-		testID                    = "c19542b7-d269-4bd4-bf7c-2cae36d066d3"
-		testName                  = "test-nodepool"
-		testCreatedAt, _          = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
-		testDescription           = "Test Nodepool description"
-		testSize            int64 = 3
-		testDiskSize        int64 = 15
-		testInstancePoolID        = "f1f67118-43b6-4632-a709-d55fada62f21"
-		testInstanceTypeID        = "21624abb-764e-4def-81d7-9fc54b5957fb"
-		testSecurityGroupID       = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
-		testState                 = "running"
-		testTemplateID            = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
-		testVersion               = "1.18.6"
+		testAntiAffinityGroupID       = "a266eadc-1e5c-4b0a-a31c-1325d2060434"
+		testCreatedAt, _              = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
+		testDescription               = "Test Nodepool description"
+		testDiskSize            int64 = 15
+		testID                        = "c19542b7-d269-4bd4-bf7c-2cae36d066d3"
+		testInstancePoolID            = "f1f67118-43b6-4632-a709-d55fada62f21"
+		testInstanceTypeID            = "21624abb-764e-4def-81d7-9fc54b5957fb"
+		testName                      = "test-nodepool"
+		testSecurityGroupID           = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
+		testSize                int64 = 3
+		testState                     = "running"
+		testTemplateID                = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
+		testVersion                   = "1.18.6"
 
 		expected = SksNodepool{
-			CreatedAt:      &testCreatedAt,
-			Description:    &testDescription,
-			DiskSize:       &testDiskSize,
-			Id:             &testID,
-			InstancePool:   &InstancePool{Id: &testInstancePoolID},
-			InstanceType:   &InstanceType{Id: &testInstanceTypeID},
-			Name:           &testName,
-			SecurityGroups: &[]SecurityGroup{{Id: &testSecurityGroupID}},
-			Size:           &testSize,
-			State:          &testState,
-			Template:       &Template{Id: &testTemplateID},
-			Version:        &testVersion,
+			AntiAffinityGroups: &[]AntiAffinityGroup{{Id: &testAntiAffinityGroupID}},
+			CreatedAt:          &testCreatedAt,
+			Description:        &testDescription,
+			DiskSize:           &testDiskSize,
+			Id:                 &testID,
+			InstancePool:       &InstancePool{Id: &testInstancePoolID},
+			InstanceType:       &InstanceType{Id: &testInstanceTypeID},
+			Name:               &testName,
+			SecurityGroups:     &[]SecurityGroup{{Id: &testSecurityGroupID}},
+			Size:               &testSize,
+			State:              &testState,
+			Template:           &Template{Id: &testTemplateID},
+			Version:            &testVersion,
 		}
 
 		actual SksNodepool
 
 		jsonSksNodepool = `{
+  "anti-affinity-groups": [{"id":"` + testAntiAffinityGroupID + `"}],
   "created-at": "` + testCreatedAt.Format(iso8601Format) + `",
   "description": "` + testDescription + `",
   "disk-size": ` + fmt.Sprint(testDiskSize) + `,
@@ -63,35 +66,38 @@ func TestSksNodepool_UnmarshalJSON(t *testing.T) {
 
 func TestSksNodepool_MarshalJSON(t *testing.T) {
 	var (
-		testID                    = "c19542b7-d269-4bd4-bf7c-2cae36d066d3"
-		testName                  = "test-nodepool"
-		testCreatedAt, _          = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
-		testDescription           = "Test Nodepool description"
-		testSize            int64 = 3
-		testDiskSize        int64 = 15
-		testInstancePoolID        = "f1f67118-43b6-4632-a709-d55fada62f21"
-		testInstanceTypeID        = "21624abb-764e-4def-81d7-9fc54b5957fb"
-		testSecurityGroupID       = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
-		testState                 = "running"
-		testTemplateID            = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
-		testVersion               = "1.18.6"
+		testAntiAffinityGroupID       = "a266eadc-1e5c-4b0a-a31c-1325d2060434"
+		testCreatedAt, _              = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
+		testDescription               = "Test Nodepool description"
+		testDiskSize            int64 = 15
+		testID                        = "c19542b7-d269-4bd4-bf7c-2cae36d066d3"
+		testInstancePoolID            = "f1f67118-43b6-4632-a709-d55fada62f21"
+		testInstanceTypeID            = "21624abb-764e-4def-81d7-9fc54b5957fb"
+		testName                      = "test-nodepool"
+		testSecurityGroupID           = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
+		testSize                int64 = 3
+		testState                     = "running"
+		testTemplateID                = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
+		testVersion                   = "1.18.6"
 
 		sksNodepool = SksNodepool{
-			CreatedAt:      &testCreatedAt,
-			Description:    &testDescription,
-			DiskSize:       &testDiskSize,
-			Id:             &testID,
-			InstancePool:   &InstancePool{Id: &testInstancePoolID},
-			InstanceType:   &InstanceType{Id: &testInstanceTypeID},
-			Name:           &testName,
-			SecurityGroups: &[]SecurityGroup{{Id: &testSecurityGroupID}},
-			Size:           &testSize,
-			State:          &testState,
-			Template:       &Template{Id: &testTemplateID},
-			Version:        &testVersion,
+			AntiAffinityGroups: &[]AntiAffinityGroup{{Id: &testAntiAffinityGroupID}},
+			CreatedAt:          &testCreatedAt,
+			Description:        &testDescription,
+			DiskSize:           &testDiskSize,
+			Id:                 &testID,
+			InstancePool:       &InstancePool{Id: &testInstancePoolID},
+			InstanceType:       &InstanceType{Id: &testInstanceTypeID},
+			Name:               &testName,
+			SecurityGroups:     &[]SecurityGroup{{Id: &testSecurityGroupID}},
+			Size:               &testSize,
+			State:              &testState,
+			Template:           &Template{Id: &testTemplateID},
+			Version:            &testVersion,
 		}
 
 		expected = []byte(`{` +
+			`"anti-affinity-groups":[{"id":"` + testAntiAffinityGroupID + `"}],` +
 			`"created-at":"` + testCreatedAt.Format(iso8601Format) + `",` +
 			`"description":"` + testDescription + `",` +
 			`"disk-size":` + fmt.Sprint(testDiskSize) + `,` +

--- a/internal/v2/v2.gen.go
+++ b/internal/v2/v2.gen.go
@@ -26,6 +26,17 @@ type AntiAffinityGroup struct {
 	Name        *string     `json:"name,omitempty"`
 }
 
+// CopyTemplateInput defines model for copy-template-input.
+type CopyTemplateInput struct {
+	TargetZone *string `json:"target-zone,omitempty"`
+}
+
+// ElasticIp defines model for elastic-ip.
+type ElasticIp struct {
+	Id *string `json:"id,omitempty"`
+	Ip *string `json:"ip,omitempty"`
+}
+
 // Event defines model for event.
 type Event struct {
 	Payload   *Event_Payload `json:"payload,omitempty"`
@@ -59,6 +70,7 @@ type InstancePool struct {
 	AntiAffinityGroups *[]AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
 	Description        *string              `json:"description,omitempty"`
 	DiskSize           *int64               `json:"disk-size,omitempty"`
+	ElasticIps         *[]ElasticIp         `json:"elastic-ips,omitempty"`
 	Id                 *string              `json:"id,omitempty"`
 	InstanceType       *InstanceType        `json:"instance-type,omitempty"`
 	Instances          *[]Instance          `json:"instances,omitempty"`
@@ -279,6 +291,20 @@ type CreateInstanceParams struct {
 	Start *bool `json:"start,omitempty"`
 }
 
+// CreateInstancePoolJSONBody defines parameters for CreateInstancePool.
+type CreateInstancePoolJSONBody InstancePool
+
+// UpdateInstancePoolJSONBody defines parameters for UpdateInstancePool.
+type UpdateInstancePoolJSONBody InstancePool
+
+// EvictInstancePoolMembersJSONBody defines parameters for EvictInstancePoolMembers.
+type EvictInstancePoolMembersJSONBody struct {
+	Instances *[]string `json:"instances,omitempty"`
+}
+
+// ScaleInstancePoolJSONBody defines parameters for ScaleInstancePool.
+type ScaleInstancePoolJSONBody InstancePool
+
 // RevertInstanceToSnapshotJSONBody defines parameters for RevertInstanceToSnapshot.
 type RevertInstanceToSnapshotJSONBody Snapshot
 
@@ -352,11 +378,26 @@ type ListTemplatesParams struct {
 // RegisterTemplateJSONBody defines parameters for RegisterTemplate.
 type RegisterTemplateJSONBody Template
 
+// CopyTemplateJSONBody defines parameters for CopyTemplate.
+type CopyTemplateJSONBody CopyTemplateInput
+
 // CreateAntiAffinityGroupRequestBody defines body for CreateAntiAffinityGroup for application/json ContentType.
 type CreateAntiAffinityGroupJSONRequestBody CreateAntiAffinityGroupJSONBody
 
 // CreateInstanceRequestBody defines body for CreateInstance for application/json ContentType.
 type CreateInstanceJSONRequestBody CreateInstanceJSONBody
+
+// CreateInstancePoolRequestBody defines body for CreateInstancePool for application/json ContentType.
+type CreateInstancePoolJSONRequestBody CreateInstancePoolJSONBody
+
+// UpdateInstancePoolRequestBody defines body for UpdateInstancePool for application/json ContentType.
+type UpdateInstancePoolJSONRequestBody UpdateInstancePoolJSONBody
+
+// EvictInstancePoolMembersRequestBody defines body for EvictInstancePoolMembers for application/json ContentType.
+type EvictInstancePoolMembersJSONRequestBody EvictInstancePoolMembersJSONBody
+
+// ScaleInstancePoolRequestBody defines body for ScaleInstancePool for application/json ContentType.
+type ScaleInstancePoolJSONRequestBody ScaleInstancePoolJSONBody
 
 // RevertInstanceToSnapshotRequestBody defines body for RevertInstanceToSnapshot for application/json ContentType.
 type RevertInstanceToSnapshotJSONRequestBody RevertInstanceToSnapshotJSONBody
@@ -411,6 +452,9 @@ type UpgradeSksClusterJSONRequestBody UpgradeSksClusterJSONBody
 
 // RegisterTemplateRequestBody defines body for RegisterTemplate for application/json ContentType.
 type RegisterTemplateJSONRequestBody RegisterTemplateJSONBody
+
+// CopyTemplateRequestBody defines body for CopyTemplate for application/json ContentType.
+type CopyTemplateJSONRequestBody CopyTemplateJSONBody
 
 // Getter for additional properties for Event_Payload. Returns the specified
 // element and whether it was found
@@ -550,6 +594,9 @@ type ClientInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroup(ctx context.Context, id string) (*http.Response, error)
 
+	// GetElasticIp request
+	GetElasticIp(ctx context.Context, id string) (*http.Response, error)
+
 	// ListEvents request
 	ListEvents(ctx context.Context, params *ListEventsParams) (*http.Response, error)
 
@@ -557,6 +604,35 @@ type ClientInterface interface {
 	CreateInstanceWithBody(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*http.Response, error)
 
 	CreateInstance(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*http.Response, error)
+
+	// ListInstancePools request
+	ListInstancePools(ctx context.Context) (*http.Response, error)
+
+	// CreateInstancePool request  with any body
+	CreateInstancePoolWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error)
+
+	CreateInstancePool(ctx context.Context, body CreateInstancePoolJSONRequestBody) (*http.Response, error)
+
+	// DeleteInstancePool request
+	DeleteInstancePool(ctx context.Context, id string) (*http.Response, error)
+
+	// GetInstancePool request
+	GetInstancePool(ctx context.Context, id string) (*http.Response, error)
+
+	// UpdateInstancePool request  with any body
+	UpdateInstancePoolWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	UpdateInstancePool(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*http.Response, error)
+
+	// EvictInstancePoolMembers request  with any body
+	EvictInstancePoolMembersWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	EvictInstancePoolMembers(ctx context.Context, id string, body EvictInstancePoolMembersJSONRequestBody) (*http.Response, error)
+
+	// ScaleInstancePool request  with any body
+	ScaleInstancePoolWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	ScaleInstancePool(ctx context.Context, id string, body ScaleInstancePoolJSONRequestBody) (*http.Response, error)
 
 	// ListInstanceTypes request
 	ListInstanceTypes(ctx context.Context) (*http.Response, error)
@@ -738,6 +814,11 @@ type ClientInterface interface {
 	// GetTemplate request
 	GetTemplate(ctx context.Context, id string) (*http.Response, error)
 
+	// CopyTemplate request  with any body
+	CopyTemplateWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error)
+
+	CopyTemplate(ctx context.Context, id string, body CopyTemplateJSONRequestBody) (*http.Response, error)
+
 	// ListZones request
 	ListZones(ctx context.Context) (*http.Response, error)
 }
@@ -817,6 +898,21 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, id string) (*http.Res
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetElasticIp(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewGetElasticIpRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*http.Response, error) {
 	req, err := NewListEventsRequest(c.Server, params)
 	if err != nil {
@@ -849,6 +945,171 @@ func (c *Client) CreateInstanceWithBody(ctx context.Context, params *CreateInsta
 
 func (c *Client) CreateInstance(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*http.Response, error) {
 	req, err := NewCreateInstanceRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListInstancePools(ctx context.Context) (*http.Response, error) {
+	req, err := NewListInstancePoolsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateInstancePoolWithBody(ctx context.Context, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewCreateInstancePoolRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateInstancePool(ctx context.Context, body CreateInstancePoolJSONRequestBody) (*http.Response, error) {
+	req, err := NewCreateInstancePoolRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteInstancePool(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewDeleteInstancePoolRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetInstancePool(ctx context.Context, id string) (*http.Response, error) {
+	req, err := NewGetInstancePoolRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateInstancePoolWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewUpdateInstancePoolRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateInstancePool(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*http.Response, error) {
+	req, err := NewUpdateInstancePoolRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EvictInstancePoolMembersWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewEvictInstancePoolMembersRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EvictInstancePoolMembers(ctx context.Context, id string, body EvictInstancePoolMembersJSONRequestBody) (*http.Response, error) {
+	req, err := NewEvictInstancePoolMembersRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScaleInstancePoolWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewScaleInstancePoolRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ScaleInstancePool(ctx context.Context, id string, body ScaleInstancePoolJSONRequestBody) (*http.Response, error) {
+	req, err := NewScaleInstancePoolRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1852,6 +2113,36 @@ func (c *Client) GetTemplate(ctx context.Context, id string) (*http.Response, er
 	return c.Client.Do(req)
 }
 
+func (c *Client) CopyTemplateWithBody(ctx context.Context, id string, contentType string, body io.Reader) (*http.Response, error) {
+	req, err := NewCopyTemplateRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CopyTemplate(ctx context.Context, id string, body CopyTemplateJSONRequestBody) (*http.Response, error) {
+	req, err := NewCopyTemplateRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if c.RequestEditor != nil {
+		err = c.RequestEditor(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListZones(ctx context.Context) (*http.Response, error) {
 	req, err := NewListZonesRequest(c.Server)
 	if err != nil {
@@ -2001,6 +2292,40 @@ func NewGetAntiAffinityGroupRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewGetElasticIpRequest generates requests for GetElasticIp
+func NewGetElasticIpRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/elastic-ip/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListEventsRequest generates requests for ListEvents
 func NewListEventsRequest(server string, params *ListEventsParams) (*http.Request, error) {
 	var err error
@@ -2115,6 +2440,278 @@ func NewCreateInstanceRequestWithBody(server string, params *CreateInstanceParam
 	queryUrl.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewListInstancePoolsRequest generates requests for ListInstancePools
+func NewListInstancePoolsRequest(server string) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateInstancePoolRequest calls the generic CreateInstancePool builder with application/json body
+func NewCreateInstancePoolRequest(server string, body CreateInstancePoolJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateInstancePoolRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateInstancePoolRequestWithBody generates requests for CreateInstancePool with any type of body
+func NewCreateInstancePoolRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool")
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewDeleteInstancePoolRequest generates requests for DeleteInstancePool
+func NewDeleteInstancePoolRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetInstancePoolRequest generates requests for GetInstancePool
+func NewGetInstancePoolRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateInstancePoolRequest calls the generic UpdateInstancePool builder with application/json body
+func NewUpdateInstancePoolRequest(server string, id string, body UpdateInstancePoolJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateInstancePoolRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateInstancePoolRequestWithBody generates requests for UpdateInstancePool with any type of body
+func NewUpdateInstancePoolRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewEvictInstancePoolMembersRequest calls the generic EvictInstancePoolMembers builder with application/json body
+func NewEvictInstancePoolMembersRequest(server string, id string, body EvictInstancePoolMembersJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewEvictInstancePoolMembersRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewEvictInstancePoolMembersRequestWithBody generates requests for EvictInstancePoolMembers with any type of body
+func NewEvictInstancePoolMembersRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool/%s:evict", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
+// NewScaleInstancePoolRequest calls the generic ScaleInstancePool builder with application/json body
+func NewScaleInstancePoolRequest(server string, id string, body ScaleInstancePoolJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewScaleInstancePoolRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewScaleInstancePoolRequestWithBody generates requests for ScaleInstancePool with any type of body
+func NewScaleInstancePoolRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/instance-pool/%s:scale", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryUrl.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -3979,6 +4576,52 @@ func NewGetTemplateRequest(server string, id string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCopyTemplateRequest calls the generic CopyTemplate builder with application/json body
+func NewCopyTemplateRequest(server string, id string, body CopyTemplateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCopyTemplateRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewCopyTemplateRequestWithBody generates requests for CopyTemplate with any type of body
+func NewCopyTemplateRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParam("simple", false, "id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	queryUrl, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath := fmt.Sprintf("/template/%s", pathParam0)
+	if basePath[0] == '/' {
+		basePath = basePath[1:]
+	}
+
+	queryUrl, err = queryUrl.Parse(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryUrl.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+	return req, nil
+}
+
 // NewListZonesRequest generates requests for ListZones
 func NewListZonesRequest(server string) (*http.Request, error) {
 	var err error
@@ -4049,6 +4692,9 @@ type ClientWithResponsesInterface interface {
 	// GetAntiAffinityGroup request
 	GetAntiAffinityGroupWithResponse(ctx context.Context, id string) (*GetAntiAffinityGroupResponse, error)
 
+	// GetElasticIp request
+	GetElasticIpWithResponse(ctx context.Context, id string) (*GetElasticIpResponse, error)
+
 	// ListEvents request
 	ListEventsWithResponse(ctx context.Context, params *ListEventsParams) (*ListEventsResponse, error)
 
@@ -4056,6 +4702,35 @@ type ClientWithResponsesInterface interface {
 	CreateInstanceWithBodyWithResponse(ctx context.Context, params *CreateInstanceParams, contentType string, body io.Reader) (*CreateInstanceResponse, error)
 
 	CreateInstanceWithResponse(ctx context.Context, params *CreateInstanceParams, body CreateInstanceJSONRequestBody) (*CreateInstanceResponse, error)
+
+	// ListInstancePools request
+	ListInstancePoolsWithResponse(ctx context.Context) (*ListInstancePoolsResponse, error)
+
+	// CreateInstancePool request  with any body
+	CreateInstancePoolWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateInstancePoolResponse, error)
+
+	CreateInstancePoolWithResponse(ctx context.Context, body CreateInstancePoolJSONRequestBody) (*CreateInstancePoolResponse, error)
+
+	// DeleteInstancePool request
+	DeleteInstancePoolWithResponse(ctx context.Context, id string) (*DeleteInstancePoolResponse, error)
+
+	// GetInstancePool request
+	GetInstancePoolWithResponse(ctx context.Context, id string) (*GetInstancePoolResponse, error)
+
+	// UpdateInstancePool request  with any body
+	UpdateInstancePoolWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateInstancePoolResponse, error)
+
+	UpdateInstancePoolWithResponse(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*UpdateInstancePoolResponse, error)
+
+	// EvictInstancePoolMembers request  with any body
+	EvictInstancePoolMembersWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*EvictInstancePoolMembersResponse, error)
+
+	EvictInstancePoolMembersWithResponse(ctx context.Context, id string, body EvictInstancePoolMembersJSONRequestBody) (*EvictInstancePoolMembersResponse, error)
+
+	// ScaleInstancePool request  with any body
+	ScaleInstancePoolWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*ScaleInstancePoolResponse, error)
+
+	ScaleInstancePoolWithResponse(ctx context.Context, id string, body ScaleInstancePoolJSONRequestBody) (*ScaleInstancePoolResponse, error)
 
 	// ListInstanceTypes request
 	ListInstanceTypesWithResponse(ctx context.Context) (*ListInstanceTypesResponse, error)
@@ -4237,6 +4912,11 @@ type ClientWithResponsesInterface interface {
 	// GetTemplate request
 	GetTemplateWithResponse(ctx context.Context, id string) (*GetTemplateResponse, error)
 
+	// CopyTemplate request  with any body
+	CopyTemplateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*CopyTemplateResponse, error)
+
+	CopyTemplateWithResponse(ctx context.Context, id string, body CopyTemplateJSONRequestBody) (*CopyTemplateResponse, error)
+
 	// ListZones request
 	ListZonesWithResponse(ctx context.Context) (*ListZonesResponse, error)
 }
@@ -4331,6 +5011,28 @@ func (r GetAntiAffinityGroupResponse) StatusCode() int {
 	return 0
 }
 
+type GetElasticIpResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ElasticIp
+}
+
+// Status returns HTTPResponse.Status
+func (r GetElasticIpResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetElasticIpResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListEventsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -4369,6 +5071,162 @@ func (r CreateInstanceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateInstanceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListInstancePoolsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		InstancePools *[]InstancePool `json:"instance-pools,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ListInstancePoolsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListInstancePoolsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateInstancePoolResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateInstancePoolResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateInstancePoolResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteInstancePoolResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteInstancePoolResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteInstancePoolResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetInstancePoolResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *InstancePool
+}
+
+// Status returns HTTPResponse.Status
+func (r GetInstancePoolResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetInstancePoolResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateInstancePoolResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateInstancePoolResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateInstancePoolResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EvictInstancePoolMembersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r EvictInstancePoolMembersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EvictInstancePoolMembersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ScaleInstancePoolResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r ScaleInstancePoolResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ScaleInstancePoolResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -5449,6 +6307,28 @@ func (r GetTemplateResponse) StatusCode() int {
 	return 0
 }
 
+type CopyTemplateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Operation
+}
+
+// Status returns HTTPResponse.Status
+func (r CopyTemplateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CopyTemplateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListZonesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -5517,6 +6397,15 @@ func (c *ClientWithResponses) GetAntiAffinityGroupWithResponse(ctx context.Conte
 	return ParseGetAntiAffinityGroupResponse(rsp)
 }
 
+// GetElasticIpWithResponse request returning *GetElasticIpResponse
+func (c *ClientWithResponses) GetElasticIpWithResponse(ctx context.Context, id string) (*GetElasticIpResponse, error) {
+	rsp, err := c.GetElasticIp(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetElasticIpResponse(rsp)
+}
+
 // ListEventsWithResponse request returning *ListEventsResponse
 func (c *ClientWithResponses) ListEventsWithResponse(ctx context.Context, params *ListEventsParams) (*ListEventsResponse, error) {
 	rsp, err := c.ListEvents(ctx, params)
@@ -5541,6 +6430,101 @@ func (c *ClientWithResponses) CreateInstanceWithResponse(ctx context.Context, pa
 		return nil, err
 	}
 	return ParseCreateInstanceResponse(rsp)
+}
+
+// ListInstancePoolsWithResponse request returning *ListInstancePoolsResponse
+func (c *ClientWithResponses) ListInstancePoolsWithResponse(ctx context.Context) (*ListInstancePoolsResponse, error) {
+	rsp, err := c.ListInstancePools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListInstancePoolsResponse(rsp)
+}
+
+// CreateInstancePoolWithBodyWithResponse request with arbitrary body returning *CreateInstancePoolResponse
+func (c *ClientWithResponses) CreateInstancePoolWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader) (*CreateInstancePoolResponse, error) {
+	rsp, err := c.CreateInstancePoolWithBody(ctx, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateInstancePoolResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateInstancePoolWithResponse(ctx context.Context, body CreateInstancePoolJSONRequestBody) (*CreateInstancePoolResponse, error) {
+	rsp, err := c.CreateInstancePool(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateInstancePoolResponse(rsp)
+}
+
+// DeleteInstancePoolWithResponse request returning *DeleteInstancePoolResponse
+func (c *ClientWithResponses) DeleteInstancePoolWithResponse(ctx context.Context, id string) (*DeleteInstancePoolResponse, error) {
+	rsp, err := c.DeleteInstancePool(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteInstancePoolResponse(rsp)
+}
+
+// GetInstancePoolWithResponse request returning *GetInstancePoolResponse
+func (c *ClientWithResponses) GetInstancePoolWithResponse(ctx context.Context, id string) (*GetInstancePoolResponse, error) {
+	rsp, err := c.GetInstancePool(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetInstancePoolResponse(rsp)
+}
+
+// UpdateInstancePoolWithBodyWithResponse request with arbitrary body returning *UpdateInstancePoolResponse
+func (c *ClientWithResponses) UpdateInstancePoolWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*UpdateInstancePoolResponse, error) {
+	rsp, err := c.UpdateInstancePoolWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateInstancePoolResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateInstancePoolWithResponse(ctx context.Context, id string, body UpdateInstancePoolJSONRequestBody) (*UpdateInstancePoolResponse, error) {
+	rsp, err := c.UpdateInstancePool(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateInstancePoolResponse(rsp)
+}
+
+// EvictInstancePoolMembersWithBodyWithResponse request with arbitrary body returning *EvictInstancePoolMembersResponse
+func (c *ClientWithResponses) EvictInstancePoolMembersWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*EvictInstancePoolMembersResponse, error) {
+	rsp, err := c.EvictInstancePoolMembersWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEvictInstancePoolMembersResponse(rsp)
+}
+
+func (c *ClientWithResponses) EvictInstancePoolMembersWithResponse(ctx context.Context, id string, body EvictInstancePoolMembersJSONRequestBody) (*EvictInstancePoolMembersResponse, error) {
+	rsp, err := c.EvictInstancePoolMembers(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEvictInstancePoolMembersResponse(rsp)
+}
+
+// ScaleInstancePoolWithBodyWithResponse request with arbitrary body returning *ScaleInstancePoolResponse
+func (c *ClientWithResponses) ScaleInstancePoolWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*ScaleInstancePoolResponse, error) {
+	rsp, err := c.ScaleInstancePoolWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScaleInstancePoolResponse(rsp)
+}
+
+func (c *ClientWithResponses) ScaleInstancePoolWithResponse(ctx context.Context, id string, body ScaleInstancePoolJSONRequestBody) (*ScaleInstancePoolResponse, error) {
+	rsp, err := c.ScaleInstancePool(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseScaleInstancePoolResponse(rsp)
 }
 
 // ListInstanceTypesWithResponse request returning *ListInstanceTypesResponse
@@ -6119,6 +7103,23 @@ func (c *ClientWithResponses) GetTemplateWithResponse(ctx context.Context, id st
 	return ParseGetTemplateResponse(rsp)
 }
 
+// CopyTemplateWithBodyWithResponse request with arbitrary body returning *CopyTemplateResponse
+func (c *ClientWithResponses) CopyTemplateWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader) (*CopyTemplateResponse, error) {
+	rsp, err := c.CopyTemplateWithBody(ctx, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCopyTemplateResponse(rsp)
+}
+
+func (c *ClientWithResponses) CopyTemplateWithResponse(ctx context.Context, id string, body CopyTemplateJSONRequestBody) (*CopyTemplateResponse, error) {
+	rsp, err := c.CopyTemplate(ctx, id, body)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCopyTemplateResponse(rsp)
+}
+
 // ListZonesWithResponse request returning *ListZonesResponse
 func (c *ClientWithResponses) ListZonesWithResponse(ctx context.Context) (*ListZonesResponse, error) {
 	rsp, err := c.ListZones(ctx)
@@ -6234,6 +7235,32 @@ func ParseGetAntiAffinityGroupResponse(rsp *http.Response) (*GetAntiAffinityGrou
 	return response, nil
 }
 
+// ParseGetElasticIpResponse parses an HTTP response from a GetElasticIpWithResponse call
+func ParseGetElasticIpResponse(rsp *http.Response) (*GetElasticIpResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetElasticIpResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ElasticIp
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListEventsResponse parses an HTTP response from a ListEventsWithResponse call
 func ParseListEventsResponse(rsp *http.Response) (*ListEventsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
@@ -6269,6 +7296,190 @@ func ParseCreateInstanceResponse(rsp *http.Response) (*CreateInstanceResponse, e
 	}
 
 	response := &CreateInstanceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListInstancePoolsResponse parses an HTTP response from a ListInstancePoolsWithResponse call
+func ParseListInstancePoolsResponse(rsp *http.Response) (*ListInstancePoolsResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListInstancePoolsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			InstancePools *[]InstancePool `json:"instance-pools,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateInstancePoolResponse parses an HTTP response from a CreateInstancePoolWithResponse call
+func ParseCreateInstancePoolResponse(rsp *http.Response) (*CreateInstancePoolResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateInstancePoolResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteInstancePoolResponse parses an HTTP response from a DeleteInstancePoolWithResponse call
+func ParseDeleteInstancePoolResponse(rsp *http.Response) (*DeleteInstancePoolResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteInstancePoolResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetInstancePoolResponse parses an HTTP response from a GetInstancePoolWithResponse call
+func ParseGetInstancePoolResponse(rsp *http.Response) (*GetInstancePoolResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetInstancePoolResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest InstancePool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateInstancePoolResponse parses an HTTP response from a UpdateInstancePoolWithResponse call
+func ParseUpdateInstancePoolResponse(rsp *http.Response) (*UpdateInstancePoolResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateInstancePoolResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEvictInstancePoolMembersResponse parses an HTTP response from a EvictInstancePoolMembersWithResponse call
+func ParseEvictInstancePoolMembersResponse(rsp *http.Response) (*EvictInstancePoolMembersResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EvictInstancePoolMembersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseScaleInstancePoolResponse parses an HTTP response from a ScaleInstancePoolWithResponse call
+func ParseScaleInstancePoolResponse(rsp *http.Response) (*ScaleInstancePoolResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ScaleInstancePoolResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -7542,6 +8753,32 @@ func ParseGetTemplateResponse(rsp *http.Response) (*GetTemplateResponse, error) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Template
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCopyTemplateResponse parses an HTTP response from a CopyTemplateWithResponse call
+func ParseCopyTemplateResponse(rsp *http.Response) (*CopyTemplateResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CopyTemplateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Operation
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/sks.go
+++ b/sks.go
@@ -56,17 +56,17 @@ func sksNodepoolFromAPI(n *v2.SksNodepool) *SKSNodepool {
 
 // SKSCluster represents a SKS cluster.
 type SKSCluster struct {
-	ID          string
-	Name        string
-	Description string
-	CreatedAt   time.Time
-	Endpoint    string
-	Nodepools   []*SKSNodepool
-	Version     string
-	Level       string
-	CNI         string
-	AddOns      []string
-	State       string
+	ID           string
+	Name         string
+	Description  string
+	CreatedAt    time.Time
+	Endpoint     string
+	Nodepools    []*SKSNodepool
+	Version      string
+	ServiceLevel string
+	CNI          string
+	AddOns       []string
+	State        string
 
 	c    *Client
 	zone string
@@ -91,9 +91,9 @@ func sksClusterFromAPI(c *v2.SksCluster) *SKSCluster {
 
 			return nodepools
 		}(),
-		Version: optionalString(c.Version),
-		Level:   optionalString(c.Level),
-		CNI:     optionalString(c.Cni),
+		Version:      optionalString(c.Version),
+		ServiceLevel: optionalString(c.Level),
+		CNI:          optionalString(c.Cni),
 		AddOns: func() []string {
 			addOns := make([]string, 0)
 			if c.Addons != nil {
@@ -274,7 +274,7 @@ func (c *Client) CreateSKSCluster(ctx context.Context, zone string, cluster *SKS
 			Name:        &cluster.Name,
 			Description: &cluster.Description,
 			Version:     &cluster.Version,
-			Level:       &cluster.Level,
+			Level:       &cluster.ServiceLevel,
 			Cni: func() *string {
 				var cni *string
 				if cluster.CNI != "" {

--- a/sks_test.go
+++ b/sks_test.go
@@ -22,7 +22,7 @@ var (
 	testSKSClusterCreatedAt, _           = time.Parse(iso8601Format, "2020-11-16T10:41:58Z")
 	testSKSClusterState                  = "running"
 	testSKSClusterVersion                = "1.18.6"
-	testSKSClusterLevel                  = "pro"
+	testSKSClusterServiceLevel           = "pro"
 	testSKSClusterCNI                    = "calico"
 	testSKSClusterAddons                 = []string{"exoscale-cloud-controller"}
 	testSKSNodepoolCreatedAt, _          = time.Parse(iso8601Format, "2020-11-18T07:54:36Z")
@@ -464,7 +464,7 @@ func TestClient_CreateSKSCluster(t *testing.T) {
 				CreatedAt:   &testSKSClusterCreatedAt,
 				Description: &testSKSClusterDescription,
 				Id:          &testSKSClusterID,
-				Level:       &testSKSClusterLevel,
+				Level:       &testSKSClusterServiceLevel,
 				Name:        &testSKSClusterName,
 				State:       &testSKSClusterState,
 				Version:     &testSKSClusterVersion,
@@ -476,28 +476,28 @@ func TestClient_CreateSKSCluster(t *testing.T) {
 		})
 
 	expected := &SKSCluster{
-		AddOns:      testSKSClusterAddons,
-		CNI:         testSKSClusterCNI,
-		CreatedAt:   testSKSClusterCreatedAt,
-		Description: testSKSClusterDescription,
-		ID:          testSKSClusterID,
-		Level:       testSKSClusterLevel,
-		Name:        testSKSClusterName,
-		Nodepools:   []*SKSNodepool{},
-		State:       testSKSClusterState,
-		Version:     testSKSClusterVersion,
+		AddOns:       testSKSClusterAddons,
+		CNI:          testSKSClusterCNI,
+		CreatedAt:    testSKSClusterCreatedAt,
+		Description:  testSKSClusterDescription,
+		ID:           testSKSClusterID,
+		Name:         testSKSClusterName,
+		Nodepools:    []*SKSNodepool{},
+		ServiceLevel: testSKSClusterServiceLevel,
+		State:        testSKSClusterState,
+		Version:      testSKSClusterVersion,
 
 		c:    client,
 		zone: testZone,
 	}
 
 	actual, err := client.CreateSKSCluster(context.Background(), testZone, &SKSCluster{
-		Name:        testSKSClusterName,
-		Description: testSKSClusterDescription,
-		Version:     testSKSClusterVersion,
-		Level:       testSKSClusterLevel,
-		CNI:         testSKSClusterCNI,
-		AddOns:      testSKSClusterAddons,
+		AddOns:       testSKSClusterAddons,
+		CNI:          testSKSClusterCNI,
+		Description:  testSKSClusterDescription,
+		Name:         testSKSClusterName,
+		ServiceLevel: testSKSClusterServiceLevel,
+		Version:      testSKSClusterVersion,
 	})
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
@@ -523,7 +523,7 @@ func TestClient_ListSKSClusters(t *testing.T) {
 					Description: &testSKSClusterDescription,
 					Endpoint:    &testSKSClusterEndpoint,
 					Id:          &testSKSClusterID,
-					Level:       &testSKSClusterLevel,
+					Level:       &testSKSClusterServiceLevel,
 					Name:        &testSKSClusterName,
 					Nodepools: &[]v2.SksNodepool{{
 						CreatedAt:      &testSKSNodepoolCreatedAt,
@@ -569,11 +569,11 @@ func TestClient_ListSKSClusters(t *testing.T) {
 			TemplateID:       testSKSNodepoolTemplateID,
 			Version:          testSKSNodepoolVersion,
 		}},
-		Version: testSKSClusterVersion,
-		Level:   testSKSClusterLevel,
-		CNI:     testSKSClusterCNI,
-		AddOns:  testSKSClusterAddons,
-		State:   testSKSClusterState,
+		Version:      testSKSClusterVersion,
+		ServiceLevel: testSKSClusterServiceLevel,
+		CNI:          testSKSClusterCNI,
+		AddOns:       testSKSClusterAddons,
+		State:        testSKSClusterState,
 
 		c:    client,
 		zone: testZone,

--- a/sks_test.go
+++ b/sks_test.go
@@ -15,28 +15,29 @@ import (
 )
 
 var (
-	testSKSClusterID                     = "df421958-3679-4e9c-afb9-02fb6f331301"
-	testSKSClusterEndpoint               = fmt.Sprintf("%s.sks-%s.exo.io", testSKSClusterID, testZone)
-	testSKSClusterName                   = "test-cluster"
-	testSKSClusterDescription            = "Test Cluster description"
-	testSKSClusterCreatedAt, _           = time.Parse(iso8601Format, "2020-11-16T10:41:58Z")
-	testSKSClusterState                  = "running"
-	testSKSClusterVersion                = "1.18.6"
-	testSKSClusterServiceLevel           = "pro"
-	testSKSClusterCNI                    = "calico"
-	testSKSClusterAddons                 = []string{"exoscale-cloud-controller"}
-	testSKSNodepoolCreatedAt, _          = time.Parse(iso8601Format, "2020-11-18T07:54:36Z")
-	testSKSNodepoolDescription           = "Test Nodepool description"
-	testSKSNodepoolDiskSize        int64 = 15
-	testSKSNodepoolID                    = "6d1eecee-397c-4e16-b103-2d1353bf4ecc"
-	testSKSNodepoolInstancePoolID        = "f1f67118-43b6-4632-a709-d55fada62f21"
-	testSKSNodepoolInstanceTypeID        = "21624abb-764e-4def-81d7-9fc54b5957fb"
-	testSKSNodepoolName                  = "test-nodepool"
-	testSKSNodepoolSize            int64 = 3
-	testSKSNodepoolSecurityGroupID       = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
-	testSKSNodepoolState                 = "running"
-	testSKSNodepoolTemplateID            = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
-	testSKSNodepoolVersion               = "1.18.6"
+	testSKSClusterAddons                     = []string{"exoscale-cloud-controller"}
+	testSKSClusterCNI                        = "calico"
+	testSKSClusterCreatedAt, _               = time.Parse(iso8601Format, "2020-11-16T10:41:58Z")
+	testSKSClusterDescription                = "Test Cluster description"
+	testSKSClusterEndpoint                   = fmt.Sprintf("%s.sks-%s.exo.io", testSKSClusterID, testZone)
+	testSKSClusterID                         = "df421958-3679-4e9c-afb9-02fb6f331301"
+	testSKSClusterName                       = "test-cluster"
+	testSKSClusterServiceLevel               = "pro"
+	testSKSClusterState                      = "running"
+	testSKSClusterVersion                    = "1.18.6"
+	testSKSNodepoolAntiAffinityGroupID       = "a266eadc-1e5c-4b0a-a31c-1325d2060434"
+	testSKSNodepoolCreatedAt, _              = time.Parse(iso8601Format, "2020-11-18T07:54:36Z")
+	testSKSNodepoolDescription               = "Test Nodepool description"
+	testSKSNodepoolDiskSize            int64 = 15
+	testSKSNodepoolID                        = "6d1eecee-397c-4e16-b103-2d1353bf4ecc"
+	testSKSNodepoolInstancePoolID            = "f1f67118-43b6-4632-a709-d55fada62f21"
+	testSKSNodepoolInstanceTypeID            = "21624abb-764e-4def-81d7-9fc54b5957fb"
+	testSKSNodepoolName                      = "test-nodepool"
+	testSKSNodepoolSecurityGroupID           = "efb4f4df-87ce-44e9-b5ee-59a9c1628edf"
+	testSKSNodepoolSize                int64 = 3
+	testSKSNodepoolState                     = "running"
+	testSKSNodepoolTemplateID                = "f270d9a2-db64-4e8e-9cd3-5125887e91aa"
+	testSKSNodepoolVersion                   = "1.18.6"
 )
 
 func TestSKSCluster_RequestKubeconfig(t *testing.T) {
@@ -118,18 +119,19 @@ func TestSKSCluster_AddNodepool(t *testing.T) {
 		testSKSClusterID, testSKSNodepoolID),
 		func(_ *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(http.StatusOK, v2.SksNodepool{
-				CreatedAt:      &testSKSNodepoolCreatedAt,
-				Description:    &testSKSNodepoolDescription,
-				DiskSize:       &testSKSNodepoolDiskSize,
-				Id:             &testSKSNodepoolID,
-				InstancePool:   &v2.InstancePool{Id: &testSKSNodepoolInstancePoolID},
-				InstanceType:   &v2.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
-				Name:           &testSKSNodepoolName,
-				SecurityGroups: &[]v2.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
-				Size:           &testSKSNodepoolSize,
-				State:          &testSKSNodepoolState,
-				Template:       &v2.Template{Id: &testSKSNodepoolTemplateID},
-				Version:        &testSKSNodepoolVersion,
+				AntiAffinityGroups: &[]v2.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
+				CreatedAt:          &testSKSNodepoolCreatedAt,
+				Description:        &testSKSNodepoolDescription,
+				DiskSize:           &testSKSNodepoolDiskSize,
+				Id:                 &testSKSNodepoolID,
+				InstancePool:       &v2.InstancePool{Id: &testSKSNodepoolInstancePoolID},
+				InstanceType:       &v2.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
+				Name:               &testSKSNodepoolName,
+				SecurityGroups:     &[]v2.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
+				Size:               &testSKSNodepoolSize,
+				State:              &testSKSNodepoolState,
+				Template:           &v2.Template{Id: &testSKSNodepoolTemplateID},
+				Version:            &testSKSNodepoolVersion,
 			})
 			if err != nil {
 				t.Fatalf("error initializing mock HTTP responder: %s", err)
@@ -145,18 +147,19 @@ func TestSKSCluster_AddNodepool(t *testing.T) {
 	}
 
 	expected := &SKSNodepool{
-		ID:               testSKSNodepoolID,
-		Name:             testSKSNodepoolName,
-		Description:      testSKSNodepoolDescription,
-		CreatedAt:        testSKSNodepoolCreatedAt,
-		InstancePoolID:   testSKSNodepoolInstancePoolID,
-		InstanceTypeID:   testSKSNodepoolInstanceTypeID,
-		TemplateID:       testSKSNodepoolTemplateID,
-		DiskSize:         testSKSNodepoolDiskSize,
-		SecurityGroupIDs: []string{testSKSNodepoolSecurityGroupID},
-		Version:          testSKSNodepoolVersion,
-		Size:             testSKSNodepoolSize,
-		State:            testSKSNodepoolState,
+		ID:                   testSKSNodepoolID,
+		Name:                 testSKSNodepoolName,
+		Description:          testSKSNodepoolDescription,
+		CreatedAt:            testSKSNodepoolCreatedAt,
+		InstancePoolID:       testSKSNodepoolInstancePoolID,
+		InstanceTypeID:       testSKSNodepoolInstanceTypeID,
+		TemplateID:           testSKSNodepoolTemplateID,
+		DiskSize:             testSKSNodepoolDiskSize,
+		AntiAffinityGroupIDs: []string{testSKSNodepoolAntiAffinityGroupID},
+		SecurityGroupIDs:     []string{testSKSNodepoolSecurityGroupID},
+		Version:              testSKSNodepoolVersion,
+		Size:                 testSKSNodepoolSize,
+		State:                testSKSNodepoolState,
 	}
 
 	actual, err := cluster.AddNodepool(context.Background(), expected)
@@ -526,18 +529,19 @@ func TestClient_ListSKSClusters(t *testing.T) {
 					Level:       &testSKSClusterServiceLevel,
 					Name:        &testSKSClusterName,
 					Nodepools: &[]v2.SksNodepool{{
-						CreatedAt:      &testSKSNodepoolCreatedAt,
-						Description:    &testSKSNodepoolDescription,
-						DiskSize:       &testSKSNodepoolDiskSize,
-						Id:             &testSKSNodepoolID,
-						InstancePool:   &v2.InstancePool{Id: &testSKSNodepoolInstancePoolID},
-						InstanceType:   &v2.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
-						Name:           &testSKSNodepoolName,
-						SecurityGroups: &[]v2.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
-						Size:           &testSKSNodepoolSize,
-						State:          &testSKSNodepoolState,
-						Template:       &v2.Template{Id: &testSKSNodepoolTemplateID},
-						Version:        &testSKSNodepoolVersion,
+						AntiAffinityGroups: &[]v2.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
+						CreatedAt:          &testSKSNodepoolCreatedAt,
+						Description:        &testSKSNodepoolDescription,
+						DiskSize:           &testSKSNodepoolDiskSize,
+						Id:                 &testSKSNodepoolID,
+						InstancePool:       &v2.InstancePool{Id: &testSKSNodepoolInstancePoolID},
+						InstanceType:       &v2.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
+						Name:               &testSKSNodepoolName,
+						SecurityGroups:     &[]v2.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
+						Size:               &testSKSNodepoolSize,
+						State:              &testSKSNodepoolState,
+						Template:           &v2.Template{Id: &testSKSNodepoolTemplateID},
+						Version:            &testSKSNodepoolVersion,
 					}},
 					State:   &testSKSClusterState,
 					Version: &testSKSClusterVersion,
@@ -556,18 +560,19 @@ func TestClient_ListSKSClusters(t *testing.T) {
 		ID:          testSKSClusterID,
 		Name:        testSKSClusterName,
 		Nodepools: []*SKSNodepool{{
-			CreatedAt:        testSKSNodepoolCreatedAt,
-			Description:      testSKSNodepoolDescription,
-			DiskSize:         testSKSNodepoolDiskSize,
-			ID:               testSKSNodepoolID,
-			InstancePoolID:   testSKSNodepoolInstancePoolID,
-			InstanceTypeID:   testSKSNodepoolInstanceTypeID,
-			Name:             testSKSNodepoolName,
-			SecurityGroupIDs: []string{testSKSNodepoolSecurityGroupID},
-			Size:             testSKSNodepoolSize,
-			State:            testSKSClusterState,
-			TemplateID:       testSKSNodepoolTemplateID,
-			Version:          testSKSNodepoolVersion,
+			CreatedAt:            testSKSNodepoolCreatedAt,
+			Description:          testSKSNodepoolDescription,
+			DiskSize:             testSKSNodepoolDiskSize,
+			ID:                   testSKSNodepoolID,
+			InstancePoolID:       testSKSNodepoolInstancePoolID,
+			InstanceTypeID:       testSKSNodepoolInstanceTypeID,
+			Name:                 testSKSNodepoolName,
+			AntiAffinityGroupIDs: []string{testSKSNodepoolAntiAffinityGroupID},
+			SecurityGroupIDs:     []string{testSKSNodepoolSecurityGroupID},
+			Size:                 testSKSNodepoolSize,
+			State:                testSKSClusterState,
+			TemplateID:           testSKSNodepoolTemplateID,
+			Version:              testSKSNodepoolVersion,
 		}},
 		Version:      testSKSClusterVersion,
 		ServiceLevel: testSKSClusterServiceLevel,


### PR DESCRIPTION
* Update API v2 generated code
* SKS: rename `SKSCluster.Level` into `SKSCluster.ServiceLevel`
* SKS: add Anti-Affinity Groups support to SKS Nodepools 