### PR TITLE
Fix embedded v2.Client initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/deepmap/oapi-codegen v1.3.11
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/jarcoal/httpmock v1.0.6
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/networks_test.go
+++ b/networks_test.go
@@ -57,14 +57,14 @@ func TestCreateNetworkOnBeforeSend(t *testing.T) {
 }
 
 func TestListNetworkEmpty(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listnetworksresponse": {
 	"count": 0,
 	"network": []
   }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	network := new(Network)
 	networks, err := cs.List(network)
@@ -78,14 +78,14 @@ func TestListNetworkEmpty(t *testing.T) {
 }
 
 func TestListNetworkFailure(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listnetworksresponse": {
 	"count": 3456,
 	"network": {}
   }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	network := new(Network)
 	networks, err := cs.List(network)
@@ -99,7 +99,7 @@ func TestListNetworkFailure(t *testing.T) {
 }
 
 func TestFindNetwork(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listnetworksresponse": {
 	"count": 1,
 	"network": [
@@ -135,7 +135,7 @@ func TestFindNetwork(t *testing.T) {
   }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	networks, err := cs.List(&Network{Name: "klmfsdvds", CanUseForDeploy: true, Type: "Isolated"})
 	if err != nil {
@@ -154,5 +154,4 @@ func TestFindNetwork(t *testing.T) {
 	if networks[0].(*Network).Name != "klmfsdvds" {
 		t.Errorf("klmfsdvds network name was expected, got %s", networks[0].(*Network).Name)
 	}
-
 }

--- a/request_test.go
+++ b/request_test.go
@@ -90,7 +90,7 @@ func TestRequest(t *testing.T) {
 	`)
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &ListAPIs{
 		Name: "dummy",
 	}
@@ -105,7 +105,7 @@ func TestRequest(t *testing.T) {
 }
 
 func TestRequestSignatureFailure(t *testing.T) {
-	ts := newServer(response{401, jsonContentType, `
+	ts := newTestServer(response{401, jsonContentType, `
 {"createsshkeypairresponse" : {
 	"uuidList":[],
 	"errorcode":401,
@@ -114,7 +114,7 @@ func TestRequestSignatureFailure(t *testing.T) {
 	`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &CreateSSHKeyPair{
 		Name: "123",
 	}
@@ -134,7 +134,7 @@ func TestRequestSignatureFailure(t *testing.T) {
 }
 
 func TestBooleanAsyncRequest(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {
 	"expungevirtualmachineresponse": {
 		"jobid": "01ed7adc-8b81-4e33-a0f2-4f55a3b880cd",
@@ -162,7 +162,7 @@ func TestBooleanAsyncRequest(t *testing.T) {
 	`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &ExpungeVirtualMachine{
 		ID: MustParseUUID("925207d3-beea-4c56-8594-ef351b526dd3"),
 	}
@@ -172,7 +172,7 @@ func TestBooleanAsyncRequest(t *testing.T) {
 }
 
 func TestBooleanAsyncRequestFailure(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {
 	"expungevirtualmachineresponse": {
 		"jobid": "7bd023bf-d55c-4b27-9918-680f03efc26c",
@@ -202,7 +202,7 @@ func TestBooleanAsyncRequestFailure(t *testing.T) {
 	`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient("ENDPOINT")
 	req := &ExpungeVirtualMachine{
 		ID: MustParseUUID("925207d3-beea-4c56-8594-ef351b526dd3"),
 	}
@@ -212,7 +212,7 @@ func TestBooleanAsyncRequestFailure(t *testing.T) {
 }
 
 func TestBooleanAsyncRequestWithContext(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {
 	"expungevirtualmachineresponse": {
 		"jobid": "a0d421e9-8d99-4896-b22c-ea77abaebf06",
@@ -240,7 +240,7 @@ func TestBooleanAsyncRequestWithContext(t *testing.T) {
 	`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &ExpungeVirtualMachine{
 		ID: MustParseUUID("925207d3-beea-4c56-8594-ef351b526dd3"),
 	}
@@ -267,7 +267,7 @@ func TestBooleanRequestTimeout(t *testing.T) {
 	done := make(chan bool)
 
 	go func() {
-		cs := NewClient(ts.URL, "TOKEN", "SECRET")
+		cs := newTestClient(ts.URL)
 		cs.HTTPClient.Timeout = time.Millisecond
 
 		req := &ExpungeVirtualMachine{
@@ -291,8 +291,7 @@ func TestBooleanRequestTimeout(t *testing.T) {
 }
 
 func TestSyncRequestWithoutContext(t *testing.T) {
-
-	ts := newServer(
+	ts := newTestServer(
 		response{200, jsonContentType, `{
 	"deployvirtualmachineresponse": {
 		"jobid": "6c4077e3-4ec2-4e6d-9806-4ab1a30138ba",
@@ -304,7 +303,7 @@ func TestSyncRequestWithoutContext(t *testing.T) {
 
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &DeployVirtualMachine{
 		Name:              "test",
 		ServiceOfferingID: MustParseUUID("71004023-bb72-4a97-b1e9-bc66dfce9470"),
@@ -329,8 +328,7 @@ func TestSyncRequestWithoutContext(t *testing.T) {
 }
 
 func TestAsyncRequestWithoutContext(t *testing.T) {
-
-	ts := newServer(
+	ts := newTestServer(
 		response{200, jsonContentType, `{
 	"deployvirtualmachineresponse": {
 		"jobid": "56bb40d1-4c65-4608-803b-2fdfcb21fa3b",
@@ -357,7 +355,7 @@ func TestAsyncRequestWithoutContext(t *testing.T) {
 
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &DeployVirtualMachine{
 		Name:              "test",
 		ServiceOfferingID: MustParseUUID("71004023-bb72-4a97-b1e9-bc66dfce9470"),
@@ -390,7 +388,7 @@ func TestAsyncRequestWithoutContext(t *testing.T) {
 }
 
 func TestAsyncRequestWithoutContextFailure(t *testing.T) {
-	ts := newServer(
+	ts := newTestServer(
 		response{200, jsonContentType, `{
 	"deployvirtualmachineresponse": {
 		"jobid": "0a1be26b-415b-4c17-87b6-ffb06c507f8b",
@@ -411,7 +409,7 @@ func TestAsyncRequestWithoutContextFailure(t *testing.T) {
 
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &DeployVirtualMachine{
 		Name:              "test",
 		ServiceOfferingID: MustParseUUID("71004023-bb72-4a97-b1e9-bc66dfce9470"),
@@ -439,8 +437,7 @@ func TestAsyncRequestWithoutContextFailure(t *testing.T) {
 }
 
 func TestAsyncRequestWithoutContextFailureNext(t *testing.T) {
-
-	ts := newServer(
+	ts := newTestServer(
 		response{200, jsonContentType, `{
 	"deployvirtualmachineresponse: {
 		"jobid": "c3f8457b-a10b-4935-a837-68fb53b29008",
@@ -452,7 +449,7 @@ func TestAsyncRequestWithoutContextFailureNext(t *testing.T) {
 
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &DeployVirtualMachine{
 		Name:              "test",
 		ServiceOfferingID: MustParseUUID("71004023-bb72-4a97-b1e9-bc66dfce9470"),
@@ -466,8 +463,7 @@ func TestAsyncRequestWithoutContextFailureNext(t *testing.T) {
 }
 
 func TestAsyncRequestWithoutContextFailureNextNext(t *testing.T) {
-
-	ts := newServer(
+	ts := newTestServer(
 		response{200, jsonContentType, `{
 	"deployvirtualmachineresponse": {
 		"jobid": "8933fb8c-ff24-4ca4-b7d1-ba2154e9f2c4",
@@ -494,7 +490,7 @@ func TestAsyncRequestWithoutContextFailureNextNext(t *testing.T) {
 	)
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 	req := &DeployVirtualMachine{
 		Name:              "test",
 		ServiceOfferingID: MustParseUUID("71004023-bb72-4a97-b1e9-bc66dfce9470"),
@@ -541,7 +537,7 @@ func TestBooleanRequestWithContext(t *testing.T) {
 	done := make(chan bool)
 
 	go func() {
-		cs := NewClient(ts.URL, "TOKEN", "SECRET")
+		cs := newTestClient(ts.URL)
 		req := &ExpungeVirtualMachine{
 			ID: MustParseUUID("925207d3-beea-4c56-8594-ef351b526dd3"),
 		}
@@ -589,7 +585,7 @@ func TestRequestWithContextTimeoutPost(t *testing.T) {
 	}
 
 	go func() {
-		cs := NewClient(ts.URL, "TOKEN", "SECRET")
+		cs := newTestClient(ts.URL)
 		req := &DeployVirtualMachine{
 			ServiceOfferingID: MustParseUUID("925207d3-beea-4c56-8594-ef351b526dd3"),
 			TemplateID:        MustParseUUID("d2fcd819-7f6e-462d-b8c0-bfae83e4d273"),
@@ -634,7 +630,7 @@ func TestBooleanRequestWithContextAndTimeout(t *testing.T) {
 	done := make(chan bool)
 
 	go func() {
-		cs := NewClient(ts.URL, "TOKEN", "SECRET")
+		cs := newTestClient(ts.URL)
 		cs.HTTPClient.Timeout = time.Millisecond
 
 		req := &ExpungeVirtualMachine{
@@ -658,7 +654,7 @@ func TestBooleanRequestWithContextAndTimeout(t *testing.T) {
 }
 
 func TestWrongBodyResponse(t *testing.T) {
-	ts := newServer(response{200, "text/html", `
+	ts := newTestServer(response{200, "text/html", `
 		<html>
 		<header><title>This is title</title></header>
 		<body>
@@ -668,7 +664,7 @@ func TestWrongBodyResponse(t *testing.T) {
 	`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "TOKEN", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	_, err := cs.Request(&ListZones{})
 	if err == nil {
@@ -681,7 +677,7 @@ func TestWrongBodyResponse(t *testing.T) {
 }
 
 func TestRequestNilCommand(t *testing.T) {
-	cs := NewClient("URL", "TOKEN", "SECRET")
+	cs := newTestClient("URL")
 
 	_, err := cs.Request((*ListZones)(nil))
 	if err == nil {
@@ -703,7 +699,11 @@ type response struct {
 	body        string
 }
 
-func newServer(responses ...response) *testServer {
+func newTestClient(endpoint string) *Client {
+	return NewClient(endpoint, "KEY", "SECRET", WithoutV2Client())
+}
+
+func newTestServer(responses ...response) *testServer {
 	mux := http.NewServeMux()
 
 	ts := &testServer{

--- a/runstatus_incident_test.go
+++ b/runstatus_incident_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestRunstatusIncidentGenericError(t *testing.T) { // nolint: dupl
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	p := response{200, jsonContentType, fmt.Sprintf(`{"subdomain": "testpage", "incidents_url": %q}`, ts.URL)}
 	r200 := response{200, jsonContentType, `ERROR`}
@@ -61,10 +61,10 @@ func TestRunstatusIncidentGenericError(t *testing.T) { // nolint: dupl
 }
 
 func TestRunstatusListIncidents(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	is := response{200, jsonContentType, `
 {
@@ -206,10 +206,10 @@ func TestRunstatusListIncidents(t *testing.T) {
 }
 
 func TestRunstatusPaginateIncidents(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	is := response{200, jsonContentType, fmt.Sprintf(`
 	{
@@ -303,7 +303,6 @@ func TestRunstatusPaginateIncidents(t *testing.T) {
 
 	ts.addResponse(is, p)
 	cs.PaginateRunstatusIncidents(context.TODO(), RunstatusPage{IncidentsURL: ts.URL}, func(incident *RunstatusIncident, e error) bool {
-
 		if e != nil {
 			t.Errorf(`reply error not expected: %v`, e)
 		}
@@ -314,14 +313,13 @@ func TestRunstatusPaginateIncidents(t *testing.T) {
 
 		return false
 	})
-
 }
 
 func TestRunstatusIncidentDelete(t *testing.T) {
-	ts := newServer(response{204, jsonContentType, ""})
+	ts := newTestServer(response{204, jsonContentType, ""})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if err := cs.DeleteRunstatusIncident(context.TODO(), RunstatusIncident{}); err == nil {
 		t.Error("incident without a status should fail")
@@ -333,14 +331,14 @@ func TestRunstatusIncidentDelete(t *testing.T) {
 }
 
 func TestRunstatusIncidentCreate(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 	ts.addResponse(
 		response{200, jsonContentType, fmt.Sprintf(`{"incidents_url": %q, "subdomain": "d"}`, ts.URL)},
 		response{201, jsonContentType, `{"url": "...", "name": "hello"}`},
 	)
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if _, err := cs.CreateRunstatusIncident(context.TODO(), RunstatusIncident{}); err == nil {
 		t.Error("incident without a status should fail")

--- a/runstatus_maintenance_test.go
+++ b/runstatus_maintenance_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestRunstatusMaintenanceGenericError(t *testing.T) { // nolint: dupl
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	p := response{200, jsonContentType, fmt.Sprintf(`{"subdomain": "testpage", "services_url": %q}`, ts.URL)}
 	r200 := response{200, jsonContentType, `ERROR`}
@@ -61,10 +61,10 @@ func TestRunstatusMaintenanceGenericError(t *testing.T) { // nolint: dupl
 }
 
 func TestRunstatusListMaintenances(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	ms := response{200, jsonContentType, `
 {
@@ -238,10 +238,10 @@ func TestRunstatusListMaintenances(t *testing.T) {
 }
 
 func TestRunstatusPaginateMaintenances(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	ps := response{200, jsonContentType, fmt.Sprintf(`{
     "next": %q,
@@ -377,10 +377,10 @@ func TestRunstatusPaginateMaintenances(t *testing.T) {
 }
 
 func TestRunstatusMaintenanceDelete(t *testing.T) {
-	ts := newServer(response{204, jsonContentType, ""})
+	ts := newTestServer(response{204, jsonContentType, ""})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if err := cs.DeleteRunstatusMaintenance(context.TODO(), RunstatusMaintenance{}); err == nil {
 		t.Error("service without a status should fail")
@@ -392,14 +392,14 @@ func TestRunstatusMaintenanceDelete(t *testing.T) {
 }
 
 func TestRunstatusMaintenanceCreate(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 	ts.addResponse(
 		response{200, jsonContentType, fmt.Sprintf(`{"maintenances_url": %q, "subdomain": "d"}`, ts.URL)},
 		response{201, jsonContentType, `{"id": 1, "url": "...", "name": "hello"}`},
 	)
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if _, err := cs.CreateRunstatusMaintenance(context.TODO(), RunstatusMaintenance{}); err == nil {
 		t.Error("service without a status should fail")

--- a/runstatus_page_test.go
+++ b/runstatus_page_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestRunstatusError(t *testing.T) {
-	ts := newServer(
+	ts := newTestServer(
 		response{401, jsonContentType, `{"detail":"Invalid Authorization header"}`},
 	)
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	_, err := cs.GetRunstatusPage(context.TODO(), RunstatusPage{URL: ts.URL})
 	if err == nil {
@@ -24,12 +24,12 @@ func TestRunstatusError(t *testing.T) {
 }
 
 func TestRunstatusValidationError(t *testing.T) {
-	ts := newServer(
+	ts := newTestServer(
 		response{401, jsonContentType, `{"foo":["bad mojo"]}`},
 	)
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	_, err := cs.GetRunstatusPage(context.TODO(), RunstatusPage{URL: ts.URL})
 	if err == nil {
@@ -41,7 +41,7 @@ func TestRunstatusValidationError(t *testing.T) {
 }
 
 func TestRunstatusPage(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {
   "id": 102,
   "url": "https://example.org/pages/testpage",
@@ -114,7 +114,7 @@ func TestRunstatusPage(t *testing.T) {
 }`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	page, err := cs.GetRunstatusPage(context.TODO(), RunstatusPage{URL: ts.URL})
 	if err != nil {
@@ -127,7 +127,7 @@ func TestRunstatusPage(t *testing.T) {
 }
 
 func TestCreateRunstatusPage(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {
   "id": 102,
   "url": "https://example.org/pages/testpage",
@@ -200,7 +200,7 @@ func TestCreateRunstatusPage(t *testing.T) {
 }`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	page, err := cs.CreateRunstatusPage(context.TODO(), RunstatusPage{})
 	if err != nil {
@@ -213,10 +213,10 @@ func TestCreateRunstatusPage(t *testing.T) {
 }
 
 func TestListRunstatusPage(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	p := response{200, jsonContentType, `
 {
@@ -275,10 +275,10 @@ func TestListRunstatusPage(t *testing.T) {
 }
 
 func TestPaginateRunstatusPage(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	p := response{200, jsonContentType, fmt.Sprintf(`
   {
@@ -316,7 +316,6 @@ func TestPaginateRunstatusPage(t *testing.T) {
 
 	ts.addResponse(p, ps)
 	cs.PaginateRunstatusPages(context.TODO(), func(pages []RunstatusPage, e error) bool {
-
 		if e != nil {
 			t.Errorf(`reply error not expected: %v`, e)
 		}

--- a/runstatus_service_test.go
+++ b/runstatus_service_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestRunstatusServiceGenericError(t *testing.T) { // nolint: dupl
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	p := response{200, jsonContentType, fmt.Sprintf(`{"subdomain": "testpage", "services_url": %q}`, ts.URL)}
 	r200 := response{200, jsonContentType, `ERROR`}
@@ -61,10 +61,10 @@ func TestRunstatusServiceGenericError(t *testing.T) { // nolint: dupl
 }
 
 func TestRunstatusListServices(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	ss := response{200, jsonContentType, `
 {
@@ -147,10 +147,10 @@ func TestRunstatusListServices(t *testing.T) {
 }
 
 func TestRunstatusServiceDelete(t *testing.T) {
-	ts := newServer(response{204, jsonContentType, ""})
+	ts := newTestServer(response{204, jsonContentType, ""})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if err := cs.DeleteRunstatusService(context.TODO(), RunstatusService{}); err == nil {
 		t.Error("service without a status should fail")
@@ -162,14 +162,14 @@ func TestRunstatusServiceDelete(t *testing.T) {
 }
 
 func TestRunstatusServiceCreate(t *testing.T) {
-	ts := newServer()
+	ts := newTestServer()
 	defer ts.Close()
 	ts.addResponse(
 		response{200, jsonContentType, fmt.Sprintf(`{"services_url": %q, "subdomain": "d"}`, ts.URL)},
 		response{201, jsonContentType, `{"url": "...", "name": "hello"}`},
 	)
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	if _, err := cs.CreateRunstatusService(context.TODO(), RunstatusService{}); err == nil {
 		t.Error("service without a status should fail")

--- a/security_groups_test.go
+++ b/security_groups_test.go
@@ -109,7 +109,7 @@ func TestAuthorizeSecurityGroupEgressOnBeforeSendTCP(t *testing.T) {
 }
 
 func TestGetSecurityGroup(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listsecuritygroupsresponse": {
 	"count": 1,
 	"securitygroup": [
@@ -135,7 +135,7 @@ func TestGetSecurityGroup(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	sg := &SecurityGroup{
 		ID: MustParseUUID("4bfe1073-a6d4-48bd-8f24-2ab586674092"),
 	}
@@ -150,7 +150,7 @@ func TestGetSecurityGroup(t *testing.T) {
 }
 
 func TestListSecurityGroups(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 		{"listsecuritygroupsresponse":{
 			"count": 2,
 			"securitygroup": [
@@ -209,7 +209,7 @@ func TestListSecurityGroups(t *testing.T) {
 
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	sgs, err := cs.List(&SecurityGroup{})
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/v2/api/middleware.go
+++ b/v2/api/middleware.go
@@ -18,6 +18,10 @@ type ErrorHandlerMiddleware struct {
 }
 
 func NewAPIErrorHandlerMiddleware(next http.RoundTripper) Middleware {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+
 	return &ErrorHandlerMiddleware{next: next}
 }
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -45,7 +45,12 @@ func ClientOptWithTimeout(v time.Duration) ClientOpt {
 	}
 }
 
-// ClientOptWithTimeout returns a ClientOpt overriding the default http.Client.
+// ClientOptWithHTTPClient returns a ClientOpt overriding the default http.Client.
+// Note: the Exoscale API client will chain additional middleware
+// (http.RoundTripper) on the HTTP client internally, which can alter the HTTP
+// requests and responses. If you don't want any other middleware than the ones
+// currently set to your HTTP client, you should duplicate it and pass a copy
+// instead.
 func ClientOptWithHTTPClient(v *http.Client) ClientOpt {
 	return func(c *Client) error {
 		c.httpClient = v

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package egoscale
 
 // Version of the library
-const Version = "0.42.0"
+const Version = "0.43.0"

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -23,14 +23,14 @@ func TestResizeVolume(t *testing.T) {
 }
 
 func TestListVolumeFailure(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listvolumesresponse": {
 	"count": 1,
 	"volume": {}
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	volume := &Volume{
 		VirtualMachineID: MustParseUUID("9ccc3d5b-9dce-4302-a955-24b80b402f88"),
@@ -43,7 +43,7 @@ func TestListVolumeFailure(t *testing.T) {
 }
 
 func TestListVolumePaginate(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listvolumesresponse": {
 	"count": 1,
 	"volume": [
@@ -109,7 +109,7 @@ func TestListVolumePaginate(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	volume := &Volume{
 		VirtualMachineID: MustParseUUID("9ccc3d5b-9dce-4302-a955-24b80b402f88"),
@@ -136,7 +136,7 @@ func TestListVolumePaginate(t *testing.T) {
 }
 
 func TestListVolumeError(t *testing.T) {
-	ts := newServer(response{431, jsonContentType, `
+	ts := newTestServer(response{431, jsonContentType, `
 {"listvolumeresponse": {
 	"cserrorcode": 9999,
 	"errorcode": 431,
@@ -145,7 +145,7 @@ func TestListVolumeError(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	volume := new(Volume)
 	_, err := cs.List(volume)

--- a/zones_test.go
+++ b/zones_test.go
@@ -12,11 +12,11 @@ func TestListZonesAPIName(t *testing.T) {
 }
 
 func TestListZonesTypeError(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listzonesresponse": []}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	_, err := cs.List(&Zone{})
 	if err == nil {
@@ -25,7 +25,7 @@ func TestListZonesTypeError(t *testing.T) {
 }
 
 func TestListZonesPaginateBreak(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listzonesresponse": {
 	"count": 4,
 	"zone": [
@@ -43,7 +43,7 @@ func TestListZonesPaginateBreak(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	zone := new(Zone)
 	req, _ := zone.ListRequest()
@@ -62,7 +62,7 @@ func TestListZonesPaginateBreak(t *testing.T) {
 }
 
 func TestListZonesAsyncError(t *testing.T) {
-	ts := newServer(response{431, jsonContentType, `
+	ts := newTestServer(response{431, jsonContentType, `
 {
 	"listzonesresponse": {
 		"cserrorcode": 9999,
@@ -74,7 +74,7 @@ func TestListZonesAsyncError(t *testing.T) {
 `})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	zone := &Zone{
 		ID: MustParseUUID("1747ef5e-5451-41fd-9f1a-58913bae9701"),
@@ -107,7 +107,7 @@ func TestListZonesAsyncError(t *testing.T) {
 }
 
 func TestListZonesAsync(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listzonesresponse": {
 	"count": 4,
 	"zone": [
@@ -135,7 +135,7 @@ func TestListZonesAsync(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 
 	zone := new(Zone)
 
@@ -175,7 +175,7 @@ func TestListZonesAsync(t *testing.T) {
 }
 
 func TestListZonesTwoPages(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listzonesresponse": {
 	"count": 4,
 	"zone": [
@@ -212,7 +212,7 @@ func TestListZonesTwoPages(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	cs.PageSize = 2
 
 	zone := new(Zone)
@@ -227,7 +227,7 @@ func TestListZonesTwoPages(t *testing.T) {
 }
 
 func TestListZonesError(t *testing.T) {
-	ts := newServer(response{200, jsonContentType, `
+	ts := newTestServer(response{200, jsonContentType, `
 {"listzonesresponse": {
 	"count": 4,
 	"zone": [
@@ -251,7 +251,7 @@ func TestListZonesError(t *testing.T) {
 }}`})
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	cs.PageSize = 2
 
 	zone := new(Zone)
@@ -268,7 +268,7 @@ func TestListZonesTimeout(t *testing.T) {
 }}`)
 	defer ts.Close()
 
-	cs := NewClient(ts.URL, "KEY", "SECRET")
+	cs := newTestClient(ts.URL)
 	cs.HTTPClient.Timeout = time.Millisecond
 
 	zone := new(Zone)


### PR DESCRIPTION
This change removes the http.Client deep-copying performed during the
embedded `v2.Client` initialization in `egoscale.NewClient()`, as it
didn't work properly with middleware (`http.Transport`) containing
unexported fields. Instead, we document the fact that the `http.Client`
passed via `v2.ClientOptWithHTTPClient()` could be altered and the
caller should then pass a copy of it if they don't want it changed
without their permission.

Also, this change refactors the `egoscale` package tests client
initialization disabling `v2.Client` embedding to avoid side-effects.