### PR TITLE
v2: add support for Anti-Affinity Groups management

### DIFF
--- a/v2/anti_affinity_group.go
+++ b/v2/anti_affinity_group.go
@@ -1,0 +1,95 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// AntiAffinityGroup represents an Anti-Affinity Group.
+type AntiAffinityGroup struct {
+	Description string
+	ID          string
+	Name        string
+}
+
+func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
+	return &AntiAffinityGroup{
+		Description: papi.OptionalString(a.Description),
+		ID:          papi.OptionalString(a.Id),
+		Name:        papi.OptionalString(a.Name),
+	}
+}
+
+// CreateAntiAffinityGroup creates an Anti-Affinity Group in the specified zone.
+func (c *Client) CreateAntiAffinityGroup(ctx context.Context, zone string,
+	antiAffinityGroup *AntiAffinityGroup) (*AntiAffinityGroup, error) {
+	resp, err := c.CreateAntiAffinityGroupWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreateAntiAffinityGroupJSONRequestBody{
+			Description: &antiAffinityGroup.Description,
+			Name:        antiAffinityGroup.Name,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetAntiAffinityGroup(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListAntiAffinityGroups returns the list of existing Anti-Affinity Groups in the specified zone.
+func (c *Client) ListAntiAffinityGroups(ctx context.Context, zone string) ([]*AntiAffinityGroup, error) {
+	list := make([]*AntiAffinityGroup, 0)
+
+	resp, err := c.ListAntiAffinityGroupsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.AntiAffinityGroups != nil {
+		for i := range *resp.JSON200.AntiAffinityGroups {
+			cluster := antiAffinityGroupFromAPI(&(*resp.JSON200.AntiAffinityGroups)[i])
+
+			list = append(list, cluster)
+		}
+	}
+
+	return list, nil
+}
+
+// GetAntiAffinityGroup returns the Anti-Affinity Group corresponding to the specified ID in the specified zone.
+func (c *Client) GetAntiAffinityGroup(ctx context.Context, zone, id string) (*AntiAffinityGroup, error) {
+	resp, err := c.GetAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	antiAffinityGroup := antiAffinityGroupFromAPI(resp.JSON200)
+
+	return antiAffinityGroup, nil
+}
+
+// DeleteAntiAffinityGroup deletes the specified Anti-Affinity Group in the specified zone.
+func (c *Client) DeleteAntiAffinityGroup(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/anti_affinity_group_test.go
+++ b/v2/anti_affinity_group_test.go
@@ -1,0 +1,127 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jarcoal/httpmock"
+
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+var (
+	testAntiAffinityGroupDescription = "Test Anti-Affinity Group description"
+	testAntiAffinityGroupID          = new(clientTestSuite).randomID()
+	testAntiAffinityGroupName        = "test-anti-affinity-group"
+)
+
+func (ts *clientTestSuite) TestClient_CreateAntiAffinityGroup() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = "success"
+	)
+
+	ts.mockAPIRequest("POST", "/anti-affinity-group", papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testAntiAffinityGroupID},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testAntiAffinityGroupID},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/anti-affinity-group/%s", testAntiAffinityGroupID), papi.AntiAffinityGroup{
+		Description: &testAntiAffinityGroupDescription,
+		Id:          &testAntiAffinityGroupID,
+		Name:        &testAntiAffinityGroupName,
+	})
+
+	expected := &AntiAffinityGroup{
+		Description: testAntiAffinityGroupDescription,
+		ID:          testAntiAffinityGroupID,
+		Name:        testAntiAffinityGroupName,
+	}
+
+	actual, err := ts.client.CreateAntiAffinityGroup(context.Background(), testZone, &AntiAffinityGroup{
+		Description: testAntiAffinityGroupDescription,
+		ID:          testAntiAffinityGroupID,
+		Name:        testAntiAffinityGroupName,
+	})
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListAntiAffinityGroups() {
+	ts.mockAPIRequest("GET", "/anti-affinity-group", struct {
+		AntiAffinityGroups *[]papi.AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	}{
+		AntiAffinityGroups: &[]papi.AntiAffinityGroup{{
+			Description: &testAntiAffinityGroupDescription,
+			Id:          &testAntiAffinityGroupID,
+			Name:        &testAntiAffinityGroupName,
+		}},
+	})
+
+	expected := []*AntiAffinityGroup{{
+		Description: testAntiAffinityGroupDescription,
+		ID:          testAntiAffinityGroupID,
+		Name:        testAntiAffinityGroupName,
+	}}
+
+	actual, err := ts.client.ListAntiAffinityGroups(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetAntiAffinityGroup() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/anti-affinity-group/%s", testAntiAffinityGroupID), papi.AntiAffinityGroup{
+		Description: &testAntiAffinityGroupDescription,
+		Id:          &testAntiAffinityGroupID,
+		Name:        &testAntiAffinityGroupName,
+	})
+
+	expected := &AntiAffinityGroup{
+		Description: testAntiAffinityGroupDescription,
+		ID:          testAntiAffinityGroupID,
+		Name:        testAntiAffinityGroupName,
+	}
+
+	actual, err := ts.client.GetAntiAffinityGroup(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_DeleteAntiAffinityGroup() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = "success"
+	)
+
+	httpmock.RegisterResponder("DELETE", "=~^/anti-affinity-group/.*",
+		func(req *http.Request) (*http.Response, error) {
+			ts.Require().Equal(fmt.Sprintf("/anti-affinity-group/%s", testAntiAffinityGroupID), req.URL.String())
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testAntiAffinityGroupID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testAntiAffinityGroupID},
+	})
+
+	ts.Require().NoError(ts.client.DeleteAntiAffinityGroup(context.Background(), testZone, testAntiAffinityGroupID))
+}


### PR DESCRIPTION
This change introduces support for Anti-Affinity Group resources
management via the Exoscale V2 API.