### PR TITLE
SKS: add SKSCluster.AuthorityCert() method

### DIFF
--- a/v2/sks.go
+++ b/v2/sks.go
@@ -112,6 +112,20 @@ func sksClusterFromAPI(c *papi.SksCluster) *SKSCluster {
 	}
 }
 
+// AuthorityCert returns the SKS cluster base64-encoded certificate content for the specified authority.
+func (c *SKSCluster) AuthorityCert(ctx context.Context, authority string) (string, error) {
+	if authority == "" {
+		return "", errors.New("authority not specified")
+	}
+
+	resp, err := c.c.GetSksClusterAuthorityCertWithResponse(apiv2.WithZone(ctx, c.zone), c.ID, authority)
+	if err != nil {
+		return "", err
+	}
+
+	return papi.OptionalString(resp.JSON200.Cacert), nil
+}
+
 // RequestKubeconfig returns a base64-encoded kubeconfig content for the specified user name,
 // optionally associated to specified groups for a duration d (default API-set TTL applies if not specified).
 // Fore more information: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

--- a/v2/sks_test.go
+++ b/v2/sks_test.go
@@ -38,6 +38,31 @@ var (
 	testSKSNodepoolVersion                   = "1.18.6"
 )
 
+func (ts *clientTestSuite) TestSKSCluster_AuthorityCert() {
+	var (
+		testAuthority   = "aggregation"
+		testCertificate = base64.StdEncoding.EncodeToString([]byte("test"))
+	)
+
+	cluster := &SKSCluster{
+		ID:   testSKSClusterID,
+		c:    ts.client,
+		zone: testZone,
+	}
+
+	ts.mockAPIRequest("GET",
+		fmt.Sprintf("/sks-cluster/%s/authority/%s/cert", cluster.ID, testAuthority),
+		struct {
+			Cacert string `json:"cacert,omitempty"`
+		}{
+			Cacert: testCertificate,
+		})
+
+	actual, err := cluster.AuthorityCert(context.Background(), testAuthority)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testCertificate, actual)
+}
+
 func (ts *clientTestSuite) TestSKSCluster_RequestKubeconfig() {
 	var (
 		testRequestUser   = "test-user"


### PR DESCRIPTION
This change adds a new `AuthorityCert()` method to the `SKSCluster`
struct.