### PR TITLE
SKS: add SKSCluster.RotateCCMCredentials()

### DIFF
--- a/v2/sks.go
+++ b/v2/sks.go
@@ -112,6 +112,13 @@ func sksClusterFromAPI(c *papi.SksCluster) *SKSCluster {
 	}
 }
 
+// RotateCCMCredentials rotates the Exoscale IAM credentials managed by the SKS control plane for the
+// Kubernetes Exoscale Cloud Controller Manager.
+func (c *SKSCluster) RotateCCMCredentials(ctx context.Context) error {
+	_, err := c.c.RotateSksCcmCredentialsWithResponse(apiv2.WithZone(ctx, c.zone), c.ID)
+	return err
+}
+
 // AuthorityCert returns the SKS cluster base64-encoded certificate content for the specified authority.
 func (c *SKSCluster) AuthorityCert(ctx context.Context, authority string) (string, error) {
 	if authority == "" {

--- a/v2/sks_test.go
+++ b/v2/sks_test.go
@@ -38,6 +38,28 @@ var (
 	testSKSNodepoolVersion                   = "1.18.6"
 )
 
+func (ts *clientTestSuite) TestSKSCluster_RotateCCMCredentials() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = "success"
+	)
+
+	cluster := &SKSCluster{
+		ID:   testSKSClusterID,
+		c:    ts.client,
+		zone: testZone,
+	}
+
+	ts.mockAPIRequest("PUT", fmt.Sprintf("/sks-cluster/%s/rotate-ccm-credentials", cluster.ID),
+		papi.Operation{
+			Id:        &testOperationID,
+			State:     &testOperationState,
+			Reference: &papi.Reference{Id: &testSKSNodepoolID},
+		})
+
+	ts.Require().NoError(cluster.RotateCCMCredentials(context.Background()))
+}
+
 func (ts *clientTestSuite) TestSKSCluster_AuthorityCert() {
 	var (
 		testAuthority   = "aggregation"


### PR DESCRIPTION
This change adds a new `RotateCCMCredentials()` method to the
`SKSCluster` struct.