### PR TITLE
v2: make SKSCluster.RotateCCMCredentials() synchronous

### DIFF
--- a/v2/sks_test.go
+++ b/v2/sks_test.go
@@ -57,6 +57,12 @@ func (ts *clientTestSuite) TestSKSCluster_RotateCCMCredentials() {
 			Reference: &papi.Reference{Id: &testSKSNodepoolID},
 		})
 
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
 	ts.Require().NoError(cluster.RotateCCMCredentials(context.Background()))
 }
 


### PR DESCRIPTION
This change makes the `SKSCluster.RotateCCMCredentials()` method
implementation wait for the API response before returning to the caller.