### PR TITLE
v2: add client property setters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 ops.asc
 vendor
 listApis.json
+public-api.json

--- a/v2/client.go
+++ b/v2/client.go
@@ -146,6 +146,21 @@ func NewClient(apiKey, apiSecret string, opts ...ClientOpt) (*Client, error) {
 	return &client, nil
 }
 
+// SetHTTPClient overrides the current HTTP client.
+func (c *Client) SetHTTPClient(client *http.Client) {
+	c.httpClient = client
+}
+
+// SetTimeout overrides the current client timeout value.
+func (c *Client) SetTimeout(v time.Duration) {
+	c.timeout = v
+}
+
+// SetTrace enables or disables HTTP request/reponse tracing.
+func (c *Client) SetTrace(enabled bool) {
+	c.trace = enabled
+}
+
 // setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
 // with information from a request endpoint optionally set in the context instance. If none is
 // found, the request is left untouched.

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -74,6 +74,31 @@ func (ts *clientTestSuite) unmarshalJSONRequestBody(req *http.Request, v interfa
 	}
 }
 
+func (ts *clientTestSuite) TestClient_SetHTTPClient() {
+	testHTTPClient := http.DefaultClient
+
+	client := new(Client)
+	client.SetHTTPClient(testHTTPClient)
+
+	ts.Require().Equal(testHTTPClient, client.httpClient)
+}
+
+func (ts *clientTestSuite) TestClient_SetTimeout() {
+	testTimeout := 5 * time.Minute
+
+	client := new(Client)
+	client.SetTimeout(testTimeout)
+
+	ts.Require().Equal(testTimeout, client.timeout)
+}
+
+func (ts *clientTestSuite) TestClient_SetTrace() {
+	client := new(Client)
+	client.SetTrace(true)
+
+	ts.Require().Equal(true, client.trace)
+}
+
 func TestSetEndpointFromContext(t *testing.T) {
 	var (
 		ctx                = context.Background()


### PR DESCRIPTION
This change introduces new `v2.Client` property setters allowing users
to override properties of a client at runtime.