### PR TITLE
v2: support InstancePool.IPv6Enabled field reset

### DIFF
--- a/v2/instance_pool.go
+++ b/v2/instance_pool.go
@@ -15,7 +15,7 @@ type InstancePool struct {
 	DiskSize             int64
 	ElasticIPIDs         []string `reset:"elastic-ips"`
 	ID                   string
-	IPv6Enabled          bool
+	IPv6Enabled          bool `reset:"ipv6-enabled"`
 	InstanceIDs          []string
 	InstancePrefix       string
 	InstanceTypeID       string


### PR DESCRIPTION
This change adds support for `InstancePool.IPv6Enabled` field resetting.