### PR TITLE
Relocating version + default HTTP v2 client transport 

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	v2 "github.com/exoscale/egoscale/v2"
+	"github.com/exoscale/egoscale/version"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 
 // UserAgent is the "User-Agent" HTTP request header added to outgoing HTTP requests.
 var UserAgent = fmt.Sprintf("egoscale/%s (%s; %s/%s)",
-	Version,
+	version.Version,
 	runtime.Version(),
 	runtime.GOOS,
 	runtime.GOARCH)

--- a/version.go
+++ b/version.go
@@ -1,4 +1,7 @@
 package egoscale
 
+import "github.com/exoscale/egoscale/version"
+
 // Version of the library
-const Version = "0.48.1"
+// Deprecated: use the github.com/exoscale/egoscale/version package.
+const Version = version.Version

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,5 @@
+// Package version stores the current version of the egoscale package.
+package version
+
+// Version represents the current egoscale version.
+const Version = "0.48.1"


### PR DESCRIPTION
##  Move version to a dedicated package

This change moves the egoscale version from `version.go` to a dedicated
`version` package that can be used by both the root package and the `v2`
package.

## v2: add a default HTTP client transport

This change introduces a new default HTTP client transport to the
`v2.Client`, which sets a custom HTTP request `User-Agent` header.

