### PR TITLE
v2: expose Instance manger via dedicated type

### DIFF
--- a/v2/instance.go
+++ b/v2/instance.go
@@ -9,6 +9,12 @@ import (
 	papi "github.com/exoscale/egoscale/v2/internal/public-api"
 )
 
+// InstanceManager represents a Compute instance manager.
+type InstanceManager struct {
+	ID   string
+	Type string
+}
+
 // Instance represents a Compute instance.
 type Instance struct {
 	AntiAffinityGroupIDs []string
@@ -19,7 +25,7 @@ type Instance struct {
 	IPv6Address          net.IP
 	IPv6Enabled          bool
 	InstanceTypeID       string
-	ManagerID            string
+	Manager              *InstanceManager
 	Name                 string
 	PrivateNetworkIDs    []string
 	PublicIPAddress      net.IP
@@ -73,11 +79,14 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 			return i.Ipv6Address != nil
 		}(),
 		InstanceTypeID: *i.InstanceType.Id,
-		ManagerID: func() string {
+		Manager: func() *InstanceManager {
 			if i.Manager != nil {
-				return papi.OptionalString(i.Manager.Id)
+				return &InstanceManager{
+					ID:   papi.OptionalString(i.Manager.Id),
+					Type: papi.OptionalString(i.Manager.Type),
+				}
 			}
-			return ""
+			return nil
 		}(),
 		Name: *i.Name,
 		PrivateNetworkIDs: func() []string {

--- a/v2/instance_test.go
+++ b/v2/instance_test.go
@@ -22,6 +22,7 @@ var (
 	testInstanceIPv6Enabled               = true
 	testInstanceInstanceTypeID            = new(clientTestSuite).randomID()
 	testInstanceManagerID                 = new(clientTestSuite).randomID()
+	testInstanceManagerType               = "instance-pool"
 	testInstanceName                      = "test-instance"
 	testInstancePrivateNetworkID          = new(clientTestSuite).randomID()
 	testInstancePublicIP                  = "1.2.3.4"
@@ -42,7 +43,7 @@ func (ts *clientTestSuite) TestInstance_get() {
 		Id:                 &testInstanceID,
 		InstanceType:       &papi.InstanceType{Id: &testInstanceInstanceTypeID},
 		Ipv6Address:        &testInstanceIPv6Address,
-		Manager:            &papi.Manager{Id: &testInstanceManagerID},
+		Manager:            &papi.Manager{Id: &testInstanceManagerID, Type: &testInstanceManagerType},
 		Name:               &testInstanceName,
 		PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testInstancePrivateNetworkID}},
 		PublicIp:           &testInstancePublicIP,
@@ -63,7 +64,7 @@ func (ts *clientTestSuite) TestInstance_get() {
 		IPv6Address:          net.ParseIP(testInstanceIPv6Address),
 		IPv6Enabled:          testInstanceIPv6Enabled,
 		InstanceTypeID:       testInstanceInstanceTypeID,
-		ManagerID:            testInstanceManagerID,
+		Manager:              &InstanceManager{ID: testInstanceManagerID, Type: testInstanceManagerType},
 		Name:                 testInstanceName,
 		PrivateNetworkIDs:    []string{testInstancePrivateNetworkID},
 		PublicIPAddress:      net.ParseIP(testInstancePublicIP),
@@ -667,7 +668,7 @@ func (ts *clientTestSuite) TestClient_CreateInstance() {
 		Id:                 &testInstanceID,
 		InstanceType:       &papi.InstanceType{Id: &testInstanceInstanceTypeID},
 		Ipv6Address:        &testInstanceIPv6Address,
-		Manager:            &papi.Manager{Id: &testInstanceManagerID},
+		Manager:            &papi.Manager{Id: &testInstanceManagerID, Type: &testInstanceManagerType},
 		Name:               &testInstanceName,
 		PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testInstancePrivateNetworkID}},
 		PublicIp:           &testInstancePublicIP,
@@ -688,7 +689,7 @@ func (ts *clientTestSuite) TestClient_CreateInstance() {
 		IPv6Address:          net.ParseIP(testInstanceIPv6Address),
 		IPv6Enabled:          testInstanceIPv6Enabled,
 		InstanceTypeID:       testInstanceInstanceTypeID,
-		ManagerID:            testInstanceManagerID,
+		Manager:              &InstanceManager{ID: testInstanceManagerID, Type: testInstanceManagerType},
 		Name:                 testInstanceName,
 		PrivateNetworkIDs:    []string{testInstancePrivateNetworkID},
 		PublicIPAddress:      net.ParseIP(testInstancePublicIP),
@@ -712,7 +713,7 @@ func (ts *clientTestSuite) TestClient_CreateInstance() {
 		IPv6Address:          net.ParseIP(testInstanceIPv6Address),
 		IPv6Enabled:          testInstanceIPv6Enabled,
 		InstanceTypeID:       testInstanceInstanceTypeID,
-		ManagerID:            testInstanceManagerID,
+		Manager:              &InstanceManager{ID: testInstanceManagerID, Type: testInstanceManagerType},
 		Name:                 testInstanceName,
 		PrivateNetworkIDs:    []string{testInstancePrivateNetworkID},
 		PublicIPAddress:      net.ParseIP(testInstancePublicIP),
@@ -739,7 +740,7 @@ func (ts *clientTestSuite) TestClient_ListInstances() {
 			Id:                 &testInstanceID,
 			InstanceType:       &papi.InstanceType{Id: &testInstanceInstanceTypeID},
 			Ipv6Address:        &testInstanceIPv6Address,
-			Manager:            &papi.Manager{Id: &testInstanceManagerID},
+			Manager:            &papi.Manager{Id: &testInstanceManagerID, Type: &testInstanceManagerType},
 			Name:               &testInstanceName,
 			PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testInstancePrivateNetworkID}},
 			PublicIp:           &testInstancePublicIP,
@@ -761,7 +762,7 @@ func (ts *clientTestSuite) TestClient_ListInstances() {
 		IPv6Address:          net.ParseIP(testInstanceIPv6Address),
 		IPv6Enabled:          testInstanceIPv6Enabled,
 		InstanceTypeID:       testInstanceInstanceTypeID,
-		ManagerID:            testInstanceManagerID,
+		Manager:              &InstanceManager{ID: testInstanceManagerID, Type: testInstanceManagerType},
 		Name:                 testInstanceName,
 		PrivateNetworkIDs:    []string{testInstancePrivateNetworkID},
 		PublicIPAddress:      net.ParseIP(testInstancePublicIP),
@@ -790,7 +791,7 @@ func (ts *clientTestSuite) TestClient_GetInstance() {
 		Id:                 &testInstanceID,
 		InstanceType:       &papi.InstanceType{Id: &testInstanceInstanceTypeID},
 		Ipv6Address:        &testInstanceIPv6Address,
-		Manager:            &papi.Manager{Id: &testInstanceManagerID},
+		Manager:            &papi.Manager{Id: &testInstanceManagerID, Type: &testInstanceManagerType},
 		Name:               &testInstanceName,
 		PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testInstancePrivateNetworkID}},
 		PublicIp:           &testInstancePublicIP,
@@ -811,7 +812,7 @@ func (ts *clientTestSuite) TestClient_GetInstance() {
 		IPv6Address:          net.ParseIP(testInstanceIPv6Address),
 		IPv6Enabled:          testInstanceIPv6Enabled,
 		InstanceTypeID:       testInstanceInstanceTypeID,
-		ManagerID:            testInstanceManagerID,
+		Manager:              &InstanceManager{ID: testInstanceManagerID, Type: testInstanceManagerType},
 		Name:                 testInstanceName,
 		PrivateNetworkIDs:    []string{testInstancePrivateNetworkID},
 		PublicIPAddress:      net.ParseIP(testInstancePublicIP),


### PR DESCRIPTION
This change replaces the `Instance.ManagerID` field with a more complete
dedicated `InstanceManager` type also containing the manager type.