### PR TITLE
v2: add new InstanceType type

### DIFF
--- a/v2/instance_type.go
+++ b/v2/instance_type.go
@@ -1,0 +1,59 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// InstanceType represents a Compute instance type.
+type InstanceType struct {
+	Authorized bool
+	CPUs       int64
+	Family     string
+	GPUs       int64
+	ID         string
+	Memory     int64
+	Size       string
+}
+
+func instanceTypeFromAPI(t *papi.InstanceType) *InstanceType {
+	return &InstanceType{
+		Authorized: *t.Authorized,
+		CPUs:       *t.Cpus,
+		Family:     *t.Family,
+		GPUs:       papi.OptionalInt64(t.Gpus),
+		ID:         *t.Id,
+		Memory:     *t.Memory,
+		Size:       *t.Size,
+	}
+}
+
+// ListInstanceTypes returns the list of existing Instance types in the specified zone.
+func (c *Client) ListInstanceTypes(ctx context.Context, zone string) ([]*InstanceType, error) {
+	list := make([]*InstanceType, 0)
+
+	resp, err := c.ListInstanceTypesWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.InstanceTypes != nil {
+		for i := range *resp.JSON200.InstanceTypes {
+			list = append(list, instanceTypeFromAPI(&(*resp.JSON200.InstanceTypes)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetInstanceType returns the Instance type corresponding to the specified ID in the specified zone.
+func (c *Client) GetInstanceType(ctx context.Context, zone, id string) (*InstanceType, error) {
+	resp, err := c.GetInstanceTypeWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return instanceTypeFromAPI(resp.JSON200), nil
+}

--- a/v2/instance_type_test.go
+++ b/v2/instance_type_test.go
@@ -1,0 +1,74 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+var (
+	testInstanceTypeAuthorized       = true
+	testInstanceTypeCPUs       int64 = 16
+	testInstanceTypeGPUs       int64 = 2
+	testInstanceTypeFamily           = "gpu2"
+	testInstanceTypeID               = new(clientTestSuite).randomID()
+	testInstanceTypeMemory     int64 = 96636764160
+	testInstanceTypeSize             = "medium"
+)
+
+func (ts *clientTestSuite) TestClient_ListInstanceTypes() {
+	ts.mockAPIRequest("GET", "/instance-type", struct {
+		InstanceTypes *[]papi.InstanceType `json:"instance-types,omitempty"`
+	}{
+		InstanceTypes: &[]papi.InstanceType{{
+			Authorized: &testInstanceTypeAuthorized,
+			Cpus:       &testInstanceTypeCPUs,
+			Family:     &testInstanceTypeFamily,
+			Gpus:       &testInstanceTypeGPUs,
+			Id:         &testInstanceTypeID,
+			Memory:     &testInstanceTypeMemory,
+			Size:       &testInstanceTypeSize,
+		}},
+	})
+
+	expected := []*InstanceType{{
+		Authorized: testInstanceTypeAuthorized,
+		CPUs:       testInstanceTypeCPUs,
+		Family:     testInstanceTypeFamily,
+		GPUs:       testInstanceTypeGPUs,
+		ID:         testInstanceTypeID,
+		Memory:     testInstanceTypeMemory,
+		Size:       testInstanceTypeSize,
+	}}
+
+	actual, err := ts.client.ListInstanceTypes(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetInstanceType() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/instance-type/%s", testInstanceTypeID), papi.InstanceType{
+		Authorized: &testInstanceTypeAuthorized,
+		Cpus:       &testInstanceTypeCPUs,
+		Family:     &testInstanceTypeFamily,
+		Gpus:       &testInstanceTypeGPUs,
+		Id:         &testInstanceTypeID,
+		Memory:     &testInstanceTypeMemory,
+		Size:       &testInstanceTypeSize,
+	})
+
+	expected := &InstanceType{
+		Authorized: testInstanceTypeAuthorized,
+		CPUs:       testInstanceTypeCPUs,
+		Family:     testInstanceTypeFamily,
+		GPUs:       testInstanceTypeGPUs,
+		ID:         testInstanceTypeID,
+		Memory:     testInstanceTypeMemory,
+		Size:       testInstanceTypeSize,
+	}
+
+	actual, err := ts.client.GetInstanceType(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}


### PR DESCRIPTION
This change adds support for Compute instance types via the new type
`InstanceType`.