### PR TITLE
v2: add Client.Find*() methods

### DIFF
--- a/v2/anti_affinity_group.go
+++ b/v2/anti_affinity_group.go
@@ -80,6 +80,22 @@ func (c *Client) GetAntiAffinityGroup(ctx context.Context, zone, id string) (*An
 	return antiAffinityGroupFromAPI(resp.JSON200), nil
 }
 
+// FindAntiAffinityGroup attempts to find an Anti-Affinity Group by name or ID in the specified zone.
+func (c *Client) FindAntiAffinityGroup(ctx context.Context, zone, v string) (*AntiAffinityGroup, error) {
+	res, err := c.ListAntiAffinityGroups(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetAntiAffinityGroup(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
 // DeleteAntiAffinityGroup deletes the specified Anti-Affinity Group in the specified zone.
 func (c *Client) DeleteAntiAffinityGroup(ctx context.Context, zone, id string) error {
 	resp, err := c.DeleteAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)

--- a/v2/anti_affinity_group_test.go
+++ b/v2/anti_affinity_group_test.go
@@ -136,6 +136,41 @@ func (ts *clientTestSuite) TestClient_GetAntiAffinityGroup() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_FindAntiAffinityGroup() {
+	ts.mockAPIRequest("GET", "/anti-affinity-group", struct {
+		AntiAffinityGroups *[]papi.AntiAffinityGroup `json:"anti-affinity-groups,omitempty"`
+	}{
+		AntiAffinityGroups: &[]papi.AntiAffinityGroup{{
+			Description: &testAntiAffinityGroupDescription,
+			Id:          &testAntiAffinityGroupID,
+			Name:        &testAntiAffinityGroupName,
+		}},
+	})
+
+	ts.mockAPIRequest(
+		"GET",
+		fmt.Sprintf("/anti-affinity-group/%s", testAntiAffinityGroupID),
+		papi.AntiAffinityGroup{
+			Description: &testAntiAffinityGroupDescription,
+			Id:          &testAntiAffinityGroupID,
+			Name:        &testAntiAffinityGroupName,
+		})
+
+	expected := &AntiAffinityGroup{
+		Description: testAntiAffinityGroupDescription,
+		ID:          testAntiAffinityGroupID,
+		Name:        testAntiAffinityGroupName,
+	}
+
+	actual, err := ts.client.FindAntiAffinityGroup(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindAntiAffinityGroup(context.Background(), testZone, expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_DeleteAntiAffinityGroup() {
 	var (
 		testOperationID    = ts.randomID()

--- a/v2/api/error.go
+++ b/v2/api/error.go
@@ -6,6 +6,9 @@ var (
 	// ErrNotFound represents an error indicating a non-existent resource.
 	ErrNotFound = errors.New("resource not found")
 
+	// ErrTooManyFound represents an error indicating multiple results found for a single resource.
+	ErrTooManyFound = errors.New("multiple resources found")
+
 	// ErrInvalidRequest represents an error indicating that the caller's request is invalid.
 	ErrInvalidRequest = errors.New("invalid request")
 

--- a/v2/deploy_target.go
+++ b/v2/deploy_target.go
@@ -51,3 +51,19 @@ func (c *Client) GetDeployTarget(ctx context.Context, zone, id string) (*DeployT
 
 	return deployTargetFromAPI(resp.JSON200), nil
 }
+
+// FindDeployTarget attempts to find a Deploy Target by name or ID in the specified zone.
+func (c *Client) FindDeployTarget(ctx context.Context, zone, v string) (*DeployTarget, error) {
+	res, err := c.ListDeployTargets(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetDeployTarget(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}

--- a/v2/deploy_target_test.go
+++ b/v2/deploy_target_test.go
@@ -66,3 +66,47 @@ func (ts *clientTestSuite) TestClient_GetDeployTarget() {
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
+
+func (ts *clientTestSuite) TestClient_FindDeployTarget() {
+	ts.mockAPIRequest("GET", "/deploy-target", struct {
+		DeployTargets *[]papi.DeployTarget `json:"deploy-targets,omitempty"`
+	}{
+		DeployTargets: &[]papi.DeployTarget{{
+			Description: &testDeployTargetDescription,
+			Id:          &testDeployTargetID,
+			Name:        &testDeployTargetName,
+			Type: func() *papi.DeployTargetType {
+				v := papi.DeployTargetType(testDeployTargetType)
+				return &v
+			}(),
+		}},
+	})
+
+	ts.mockAPIRequest(
+		"GET",
+		fmt.Sprintf("/deploy-target/%s", testDeployTargetID),
+		papi.DeployTarget{
+			Description: &testDeployTargetDescription,
+			Id:          &testDeployTargetID,
+			Name:        &testDeployTargetName,
+			Type: func() *papi.DeployTargetType {
+				v := papi.DeployTargetType(testDeployTargetType)
+				return &v
+			}(),
+		})
+
+	expected := &DeployTarget{
+		Description: testDeployTargetDescription,
+		ID:          testDeployTargetID,
+		Name:        testDeployTargetName,
+		Type:        testDeployTargetType,
+	}
+
+	actual, err := ts.client.FindDeployTarget(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindDeployTarget(context.Background(), testZone, expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}

--- a/v2/elastic_ip.go
+++ b/v2/elastic_ip.go
@@ -162,6 +162,22 @@ func (c *Client) GetElasticIP(ctx context.Context, zone, id string) (*ElasticIP,
 	return elasticIPFromAPI(c, zone, resp.JSON200), nil
 }
 
+// FindElasticIP attempts to find an Elastic IP by IP address or ID in the specified zone.
+func (c *Client) FindElasticIP(ctx context.Context, zone, v string) (*ElasticIP, error) {
+	res, err := c.ListElasticIPs(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.IPAddress.String() == v {
+			return c.GetElasticIP(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
 // UpdateElasticIP updates the specified Elastic IP in the specified zone.
 func (c *Client) UpdateElasticIP(ctx context.Context, zone string, elasticIP *ElasticIP) error {
 	resp, err := c.UpdateElasticIpWithResponse(

--- a/v2/elastic_ip_test.go
+++ b/v2/elastic_ip_test.go
@@ -305,6 +305,38 @@ func (ts *clientTestSuite) TestClient_GetElasticIP() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_FindElasticIP() {
+	ts.mockAPIRequest("GET", "/elastic-ip", struct {
+		ElasticIPs *[]papi.ElasticIp `json:"elastic-ips,omitempty"`
+	}{
+		ElasticIPs: &[]papi.ElasticIp{{
+			Id: &testElasticIPID,
+			Ip: &testElasticIPAddress,
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/elastic-ip/%s", testElasticIPID), papi.ElasticIp{
+		Id: &testElasticIPID,
+		Ip: &testElasticIPAddress,
+	})
+
+	expected := &ElasticIP{
+		ID:        testElasticIPID,
+		IPAddress: net.ParseIP(testElasticIPAddress),
+
+		zone: testZone,
+		c:    ts.client,
+	}
+
+	actual, err := ts.client.FindElasticIP(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindElasticIP(context.Background(), testZone, expected.IPAddress.String())
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_UpdateElasticIP() {
 	var (
 		testElasticIPDescriptionUpdated              = testElasticIPDescription + "-updated"

--- a/v2/instance_pool.go
+++ b/v2/instance_pool.go
@@ -354,6 +354,22 @@ func (c *Client) GetInstancePool(ctx context.Context, zone, id string) (*Instanc
 	return instancePool, nil
 }
 
+// FindInstancePool attempts to find an Instance Pool by name or ID in the specified zone.
+func (c *Client) FindInstancePool(ctx context.Context, zone, v string) (*InstancePool, error) {
+	res, err := c.ListInstancePools(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetInstancePool(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
 // UpdateInstancePool updates the specified Instance Pool in the specified zone.
 func (c *Client) UpdateInstancePool(ctx context.Context, zone string, instancePool *InstancePool) error {
 	resp, err := c.UpdateInstancePoolWithResponse(

--- a/v2/instance_pool_test.go
+++ b/v2/instance_pool_test.go
@@ -538,6 +538,70 @@ func (ts *clientTestSuite) TestClient_GetInstancePool() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_FindInstancePool() {
+	ts.mockAPIRequest("GET", "/instance-pool", struct {
+		InstancePools *[]papi.InstancePool `json:"instance-pools,omitempty"`
+	}{
+		InstancePools: &[]papi.InstancePool{{
+			Description:  &testInstancePoolDescription,
+			DiskSize:     &testInstancePoolDiskSize,
+			Id:           &testInstancePoolID,
+			InstanceType: &papi.InstanceType{Id: &testInstancePoolInstanceTypeID},
+			Ipv6Enabled:  &testInstancePoolIPv6Enabled,
+			Manager:      &papi.Manager{Id: &testInstancePoolManagerID},
+			Name:         &testInstancePoolName,
+			Size:         &testInstancePoolSize,
+			SshKey:       &papi.SshKey{Name: &testInstancePoolSSHKey},
+			State:        &testInstancePoolState,
+			Template:     &papi.Template{Id: &testInstancePoolTemplateID},
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/instance-pool/%s", testInstancePoolID), papi.InstancePool{
+		Description:  &testInstancePoolDescription,
+		DiskSize:     &testInstancePoolDiskSize,
+		Id:           &testInstancePoolID,
+		InstanceType: &papi.InstanceType{Id: &testInstancePoolInstanceTypeID},
+		Ipv6Enabled:  &testInstancePoolIPv6Enabled,
+		Manager:      &papi.Manager{Id: &testInstancePoolManagerID},
+		Name:         &testInstancePoolName,
+		Size:         &testInstancePoolSize,
+		SshKey:       &papi.SshKey{Name: &testInstancePoolSSHKey},
+		State:        &testInstancePoolState,
+		Template:     &papi.Template{Id: &testInstancePoolTemplateID},
+	})
+
+	expected := &InstancePool{
+		AntiAffinityGroupIDs: []string{},
+		Description:          testInstancePoolDescription,
+		DiskSize:             testInstancePoolDiskSize,
+		ElasticIPIDs:         []string{},
+		ID:                   testInstancePoolID,
+		IPv6Enabled:          testInstancePoolIPv6Enabled,
+		InstanceIDs:          []string{},
+		InstanceTypeID:       testInstancePoolInstanceTypeID,
+		ManagerID:            testInstancePoolManagerID,
+		Name:                 testInstancePoolName,
+		PrivateNetworkIDs:    []string{},
+		SSHKey:               testInstancePoolSSHKey,
+		SecurityGroupIDs:     []string{},
+		Size:                 testInstancePoolSize,
+		State:                string(testInstancePoolState),
+		TemplateID:           testInstancePoolTemplateID,
+
+		c:    ts.client,
+		zone: testZone,
+	}
+
+	actual, err := ts.client.FindInstancePool(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindInstancePool(context.Background(), testZone, expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_UpdateInstancePool() {
 	var (
 		testInstancePoolAntiAffinityGroupIDUpdated = new(clientTestSuite).randomID()

--- a/v2/network_load_balancer.go
+++ b/v2/network_load_balancer.go
@@ -366,6 +366,22 @@ func (c *Client) GetNetworkLoadBalancer(ctx context.Context, zone, id string) (*
 	return nlbFromAPI(c, zone, resp.JSON200), nil
 }
 
+// FindNetworkLoadBalancer attempts to find a Network Load Balancer by name or ID in the specified zone.
+func (c *Client) FindNetworkLoadBalancer(ctx context.Context, zone, v string) (*NetworkLoadBalancer, error) {
+	res, err := c.ListNetworkLoadBalancers(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetNetworkLoadBalancer(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
 // UpdateNetworkLoadBalancer updates the specified Network Load Balancer instance in the specified zone.
 func (c *Client) UpdateNetworkLoadBalancer(ctx context.Context, zone string, nlb *NetworkLoadBalancer) error {
 	resp, err := c.UpdateLoadBalancerWithResponse(

--- a/v2/security_group.go
+++ b/v2/security_group.go
@@ -255,6 +255,22 @@ func (c *Client) GetSecurityGroup(ctx context.Context, zone, id string) (*Securi
 	return securityGroupFromAPI(c, zone, resp.JSON200), nil
 }
 
+// FindSecurityGroup attempts to find a Security Group by name or ID in the specified zone.
+func (c *Client) FindSecurityGroup(ctx context.Context, zone, v string) (*SecurityGroup, error) {
+	res, err := c.ListSecurityGroups(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetSecurityGroup(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
 // DeleteSecurityGroup deletes the specified Security Group in the specified zone.
 func (c *Client) DeleteSecurityGroup(ctx context.Context, zone, id string) error {
 	resp, err := c.DeleteSecurityGroupWithResponse(apiv2.WithZone(ctx, zone), id)

--- a/v2/security_group_test.go
+++ b/v2/security_group_test.go
@@ -391,6 +391,38 @@ func (ts *clientTestSuite) TestClient_GetSecurityGroup() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_FindSecurityGroup() {
+	ts.mockAPIRequest("GET", "/security-group", struct {
+		SecurityGroups *[]papi.SecurityGroup `json:"security-groups,omitempty"`
+	}{
+		SecurityGroups: &[]papi.SecurityGroup{{
+			Id:   &testSecurityGroupID,
+			Name: &testSecurityGroupName,
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
+		Id:   &testSecurityGroupID,
+		Name: &testSecurityGroupName,
+	})
+
+	expected := &SecurityGroup{
+		ID:   testSecurityGroupID,
+		Name: testSecurityGroupName,
+
+		c:    ts.client,
+		zone: testZone,
+	}
+
+	actual, err := ts.client.FindSecurityGroup(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindSecurityGroup(context.Background(), testZone, expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_DeleteSecurityGroup() {
 	var (
 		testOperationID    = ts.randomID()

--- a/v2/sks.go
+++ b/v2/sks.go
@@ -10,7 +10,7 @@ import (
 	papi "github.com/exoscale/egoscale/v2/internal/public-api"
 )
 
-// SKSNodepool represents a SKS Nodepool.
+// SKSNodepool represents an SKS Nodepool.
 type SKSNodepool struct {
 	AntiAffinityGroupIDs []string `reset:"anti-affinity-groups"`
 	CreatedAt            time.Time
@@ -90,7 +90,7 @@ func (n *SKSNodepool) SecurityGroups(ctx context.Context) ([]*SecurityGroup, err
 	return res.([]*SecurityGroup), err
 }
 
-// SKSCluster represents a SKS cluster.
+// SKSCluster represents an SKS cluster.
 type SKSCluster struct {
 	AddOns       []string
 	CNI          string
@@ -485,7 +485,7 @@ func (c *SKSCluster) ResetNodepoolField(ctx context.Context, np *SKSNodepool, fi
 	return nil
 }
 
-// CreateSKSCluster creates a SKS cluster in the specified zone.
+// CreateSKSCluster creates an SKS cluster in the specified zone.
 func (c *Client) CreateSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) (*SKSCluster, error) {
 	resp, err := c.CreateSksClusterWithResponse(
 		apiv2.WithZone(ctx, zone),
@@ -571,6 +571,22 @@ func (c *Client) GetSKSCluster(ctx context.Context, zone, id string) (*SKSCluste
 	}
 
 	return sksClusterFromAPI(c, zone, resp.JSON200), nil
+}
+
+// FindSKSCluster attempts to find an SKS cluster by name or ID in the specified zone.
+func (c *Client) FindSKSCluster(ctx context.Context, zone, v string) (*SKSCluster, error) {
+	res, err := c.ListSKSClusters(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if r.ID == v || r.Name == v {
+			return c.GetSKSCluster(ctx, zone, r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
 }
 
 // UpdateSKSCluster updates the specified SKS cluster in the specified zone.

--- a/v2/sks_test.go
+++ b/v2/sks_test.go
@@ -849,6 +849,58 @@ func (ts *clientTestSuite) TestClient_GetSKSCluster() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_FindSKSCluster() {
+	ts.mockAPIRequest("GET", "/sks-cluster", struct {
+		SksClusters *[]papi.SksCluster `json:"sks-clusters,omitempty"`
+	}{
+		SksClusters: &[]papi.SksCluster{{
+			Cni:       (*papi.SksClusterCni)(&testSKSClusterCNI),
+			CreatedAt: &testSKSClusterCreatedAt,
+			Endpoint:  &testSKSClusterEndpoint,
+			Id:        &testSKSClusterID,
+			Level:     &testSKSClusterServiceLevel,
+			Name:      &testSKSClusterName,
+			State:     &testSKSClusterState,
+			Version:   &testSKSClusterVersion,
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID), papi.SksCluster{
+		Cni:       (*papi.SksClusterCni)(&testSKSClusterCNI),
+		CreatedAt: &testSKSClusterCreatedAt,
+		Endpoint:  &testSKSClusterEndpoint,
+		Id:        &testSKSClusterID,
+		Level:     &testSKSClusterServiceLevel,
+		Name:      &testSKSClusterName,
+		State:     &testSKSClusterState,
+		Version:   &testSKSClusterVersion,
+	})
+
+	expected := &SKSCluster{
+		AddOns:       []string{},
+		CNI:          testSKSClusterCNI,
+		CreatedAt:    testSKSClusterCreatedAt,
+		Endpoint:     testSKSClusterEndpoint,
+		ID:           testSKSClusterID,
+		Name:         testSKSClusterName,
+		Nodepools:    []*SKSNodepool{},
+		ServiceLevel: string(testSKSClusterServiceLevel),
+		State:        string(testSKSClusterState),
+		Version:      testSKSClusterVersion,
+
+		c:    ts.client,
+		zone: testZone,
+	}
+
+	actual, err := ts.client.FindSKSCluster(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindSKSCluster(context.Background(), testZone, expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_UpdateSKSCluster() {
 	var (
 		testSKSClusterNameUpdated        = testSKSClusterName + "-updated"


### PR DESCRIPTION
This change introduces new `v2.Client.Find*()` convenience methods for
projects using egoscale and allowing users to specify API resource by
name or ID.