### PR TITLE
v2: add Client.FindInstanceType() method

### DIFF
--- a/v2/instance_type_test.go
+++ b/v2/instance_type_test.go
@@ -72,3 +72,47 @@ func (ts *clientTestSuite) TestClient_GetInstanceType() {
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
+
+func (ts *clientTestSuite) TestClient_FindInstanceType() {
+	ts.mockAPIRequest("GET", "/instance-type", struct {
+		InstanceTypes *[]papi.InstanceType `json:"instance-types,omitempty"`
+	}{
+		InstanceTypes: &[]papi.InstanceType{{
+			Authorized: &testInstanceTypeAuthorized,
+			Cpus:       &testInstanceTypeCPUs,
+			Family:     &testInstanceTypeFamily,
+			Gpus:       &testInstanceTypeGPUs,
+			Id:         &testInstanceTypeID,
+			Memory:     &testInstanceTypeMemory,
+			Size:       &testInstanceTypeSize,
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/instance-type/%s", testInstanceTypeID), papi.InstanceType{
+		Authorized: &testInstanceTypeAuthorized,
+		Cpus:       &testInstanceTypeCPUs,
+		Family:     &testInstanceTypeFamily,
+		Gpus:       &testInstanceTypeGPUs,
+		Id:         &testInstanceTypeID,
+		Memory:     &testInstanceTypeMemory,
+		Size:       &testInstanceTypeSize,
+	})
+
+	expected := &InstanceType{
+		Authorized: testInstanceTypeAuthorized,
+		CPUs:       testInstanceTypeCPUs,
+		Family:     string(testInstanceTypeFamily),
+		GPUs:       testInstanceTypeGPUs,
+		ID:         testInstanceTypeID,
+		Memory:     testInstanceTypeMemory,
+		Size:       string(testInstanceTypeSize),
+	}
+
+	actual, err := ts.client.FindInstanceType(context.Background(), testZone, expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindInstanceType(context.Background(), testZone, expected.Family+"."+expected.Size)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}


### PR DESCRIPTION
This change adds a new `v2.Client.FindInstanceType()` method.