### PR TITLE
v2: fix optional fields management

### DIFF
--- a/v2/anti_affinity_group.go
+++ b/v2/anti_affinity_group.go
@@ -35,8 +35,13 @@ func (c *Client) CreateAntiAffinityGroup(
 	resp, err := c.CreateAntiAffinityGroupWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreateAntiAffinityGroupJSONRequestBody{
-			Description: &antiAffinityGroup.Description,
-			Name:        antiAffinityGroup.Name,
+			Description: func() *string {
+				if antiAffinityGroup.Description != "" {
+					return &antiAffinityGroup.Description
+				}
+				return nil
+			}(),
+			Name: antiAffinityGroup.Name,
 		})
 	if err != nil {
 		return nil, err

--- a/v2/elastic_ip.go
+++ b/v2/elastic_ip.go
@@ -97,7 +97,12 @@ func (c *Client) CreateElasticIP(ctx context.Context, zone string, elasticIP *El
 	resp, err := c.CreateElasticIpWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreateElasticIpJSONRequestBody{
-			Description: &elasticIP.Description,
+			Description: func() *string {
+				if elasticIP.Description != "" {
+					return &elasticIP.Description
+				}
+				return nil
+			}(),
 			Healthcheck: func() *papi.ElasticIpHealthcheck {
 				if hc := elasticIP.Healthcheck; hc != nil {
 					var (
@@ -114,8 +119,18 @@ func (c *Client) CreateElasticIP(ctx context.Context, zone string, elasticIP *El
 						StrikesOk:     &hc.StrikesOK,
 						Timeout:       &timeout,
 						TlsSkipVerify: &hc.TLSSkipVerify,
-						TlsSni:        &hc.TLSSNI,
-						Uri:           &hc.URI,
+						TlsSni: func() *string {
+							if hc.TLSSNI != "" {
+								return &hc.TLSSNI
+							}
+							return nil
+						}(),
+						Uri: func() *string {
+							if hc.URI != "" {
+								return &hc.URI
+							}
+							return nil
+						}(),
 					}
 				}
 				return nil
@@ -208,8 +223,18 @@ func (c *Client) UpdateElasticIP(ctx context.Context, zone string, elasticIP *El
 						StrikesOk:     &hc.StrikesOK,
 						Timeout:       &timeout,
 						TlsSkipVerify: &hc.TLSSkipVerify,
-						TlsSni:        &hc.TLSSNI,
-						Uri:           &hc.URI,
+						TlsSni: func() *string {
+							if hc.TLSSNI != "" {
+								return &hc.TLSSNI
+							}
+							return nil
+						}(),
+						Uri: func() *string {
+							if hc.URI != "" {
+								return &hc.URI
+							}
+							return nil
+						}(),
 					}
 				}
 				return nil

--- a/v2/elastic_ip_test.go
+++ b/v2/elastic_ip_test.go
@@ -340,14 +340,12 @@ func (ts *clientTestSuite) TestClient_FindElasticIP() {
 func (ts *clientTestSuite) TestClient_UpdateElasticIP() {
 	var (
 		testElasticIPDescriptionUpdated              = testElasticIPDescription + "-updated"
-		testElasticIPHealthcheckModeUpdated          = papi.ElasticIpHealthcheckModeHttp
+		testElasticIPHealthcheckModeUpdated          = papi.ElasticIpHealthcheckModeTcp
 		testElasticIPHealthcheckPortUpdated          = testElasticIPHealthcheckPort + 1
 		testElasticIPHealthcheckIntervalUpdated      = testElasticIPHealthcheckInterval + 1
 		testElasticIPHealthcheckTimeoutUpdated       = testElasticIPHealthcheckTimeout + 1
 		testElasticIPHealthcheckStrikesFailUpdated   = testElasticIPHealthcheckStrikesFail + 1
 		testElasticIPHealthcheckStrikesOKUpdated     = testElasticIPHealthcheckStrikesOK + 1
-		testElasticIPHealthcheckURIUpdated           = ""
-		testElasticIPHealthcheckTLSSNIUpdated        = ""
 		testElasticIPHealthcheckTLSSkipVerifyUpdated = false
 		testOperationID                              = ts.randomID()
 		testOperationState                           = papi.OperationStateSuccess
@@ -370,9 +368,7 @@ func (ts *clientTestSuite) TestClient_UpdateElasticIP() {
 					StrikesFail:   &testElasticIPHealthcheckStrikesFailUpdated,
 					StrikesOk:     &testElasticIPHealthcheckStrikesOKUpdated,
 					Timeout:       &testElasticIPHealthcheckTimeoutUpdated,
-					TlsSni:        &testElasticIPHealthcheckTLSSNIUpdated,
 					TlsSkipVerify: &testElasticIPHealthcheckTLSSkipVerifyUpdated,
-					Uri:           &testElasticIPHealthcheckURIUpdated,
 				},
 			}
 			ts.Require().Equal(expected, actual)
@@ -404,9 +400,7 @@ func (ts *clientTestSuite) TestClient_UpdateElasticIP() {
 			StrikesFail:   testElasticIPHealthcheckStrikesFailUpdated,
 			StrikesOK:     testElasticIPHealthcheckStrikesOKUpdated,
 			Timeout:       time.Duration(testElasticIPHealthcheckTimeoutUpdated) * time.Second,
-			TLSSNI:        testElasticIPHealthcheckTLSSNIUpdated,
 			TLSSkipVerify: testElasticIPHealthcheckTLSSkipVerifyUpdated,
-			URI:           testElasticIPHealthcheckURIUpdated,
 		},
 		ID:        testElasticIPID,
 		IPAddress: net.ParseIP(testElasticIPAddress),

--- a/v2/instance_pool.go
+++ b/v2/instance_pool.go
@@ -253,8 +253,13 @@ func (c *Client) CreateInstancePool(ctx context.Context, zone string, instancePo
 				}
 				return nil
 			}(),
-			Description: &instancePool.Description,
-			DiskSize:    instancePool.DiskSize,
+			Description: func() *string {
+				if instancePool.Description != "" {
+					return &instancePool.Description
+				}
+				return nil
+			}(),
+			DiskSize: instancePool.DiskSize,
 			ElasticIps: func() *[]papi.ElasticIp {
 				if l := len(instancePool.ElasticIPIDs); l > 0 {
 					list := make([]papi.ElasticIp, l)
@@ -266,10 +271,15 @@ func (c *Client) CreateInstancePool(ctx context.Context, zone string, instancePo
 				}
 				return nil
 			}(),
-			InstancePrefix: &instancePool.InstancePrefix,
-			InstanceType:   papi.InstanceType{Id: &instancePool.InstanceTypeID},
-			Ipv6Enabled:    &instancePool.IPv6Enabled,
-			Name:           instancePool.Name,
+			InstancePrefix: func() *string {
+				if instancePool.InstancePrefix != "" {
+					return &instancePool.InstancePrefix
+				}
+				return nil
+			}(),
+			InstanceType: papi.InstanceType{Id: &instancePool.InstanceTypeID},
+			Ipv6Enabled:  &instancePool.IPv6Enabled,
+			Name:         instancePool.Name,
 			PrivateNetworks: func() *[]papi.PrivateNetwork {
 				if l := len(instancePool.PrivateNetworkIDs); l > 0 {
 					list := make([]papi.PrivateNetwork, l)

--- a/v2/network_load_balancer.go
+++ b/v2/network_load_balancer.go
@@ -158,7 +158,12 @@ func (nlb *NetworkLoadBalancer) AddService(
 		apiv2.WithZone(ctx, nlb.zone),
 		nlb.ID,
 		papi.AddServiceToLoadBalancerJSONRequestBody{
-			Description: &svc.Description,
+			Description: func() *string {
+				if svc.Description != "" {
+					return &svc.Description
+				}
+				return nil
+			}(),
 			Healthcheck: papi.LoadBalancerServiceHealthcheck{
 				Interval: &healthcheckInterval,
 				Mode:     papi.LoadBalancerServiceHealthcheckMode(svc.Healthcheck.Mode),
@@ -357,9 +362,19 @@ func (c *Client) CreateNetworkLoadBalancer(
 	resp, err := c.CreateLoadBalancerWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreateLoadBalancerJSONRequestBody{
-			Description: &nlb.Description,
-			Labels:      &papi.Labels{AdditionalProperties: nlb.Labels},
-			Name:        nlb.Name,
+			Description: func() *string {
+				if nlb.Description != "" {
+					return &nlb.Description
+				}
+				return nil
+			}(),
+			Labels: func() *papi.Labels {
+				if len(nlb.Labels) > 0 {
+					return &papi.Labels{AdditionalProperties: nlb.Labels}
+				}
+				return nil
+			}(),
+			Name: nlb.Name,
 		})
 	if err != nil {
 		return nil, err

--- a/v2/private_network.go
+++ b/v2/private_network.go
@@ -42,7 +42,12 @@ func (c *Client) CreatePrivateNetwork(
 	resp, err := c.CreatePrivateNetworkWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.CreatePrivateNetworkJSONRequestBody{
-			Description: &privateNetwork.Description,
+			Description: func() *string {
+				if privateNetwork.Description != "" {
+					return &privateNetwork.Description
+				}
+				return nil
+			}(),
 			EndIp: func() (ip *string) {
 				if privateNetwork.EndIP != nil {
 					v := privateNetwork.EndIP.String()
@@ -147,7 +152,12 @@ func (c *Client) UpdatePrivateNetwork(ctx context.Context, zone string, privateN
 		apiv2.WithZone(ctx, zone),
 		privateNetwork.ID,
 		papi.UpdatePrivateNetworkJSONRequestBody{
-			Description: &privateNetwork.Description,
+			Description: func() *string {
+				if privateNetwork.Description != "" {
+					return &privateNetwork.Description
+				}
+				return nil
+			}(),
 			EndIp: func() (ip *string) {
 				if privateNetwork.EndIP != nil {
 					v := privateNetwork.EndIP.String()

--- a/v2/security_group.go
+++ b/v2/security_group.go
@@ -144,8 +144,18 @@ func (s *SecurityGroup) AddRule(ctx context.Context, rule *SecurityGroupRule) (*
 		apiv2.WithZone(ctx, s.zone),
 		s.ID,
 		papi.AddRuleToSecurityGroupJSONRequestBody{
-			Description:   &rule.Description,
-			EndPort:       &endPort,
+			Description: func() *string {
+				if rule.Description != "" {
+					return &rule.Description
+				}
+				return nil
+			}(),
+			EndPort: func() *int64 {
+				if endPort > 0 {
+					return &endPort
+				}
+				return nil
+			}(),
 			FlowDirection: papi.AddRuleToSecurityGroupJSONBodyFlowDirection(rule.FlowDirection),
 			Icmp:          icmp,
 			Network: func() (v *string) {
@@ -162,7 +172,12 @@ func (s *SecurityGroup) AddRule(ctx context.Context, rule *SecurityGroupRule) (*
 				}
 				return
 			}(),
-			StartPort: &startPort,
+			StartPort: func() *int64 {
+				if startPort > 0 {
+					return &startPort
+				}
+				return nil
+			}(),
 		})
 	if err != nil {
 		return nil, err
@@ -222,8 +237,13 @@ func (c *Client) CreateSecurityGroup(
 	securityGroup *SecurityGroup,
 ) (*SecurityGroup, error) {
 	resp, err := c.CreateSecurityGroupWithResponse(ctx, papi.CreateSecurityGroupJSONRequestBody{
-		Description: &securityGroup.Description,
-		Name:        securityGroup.Name,
+		Description: func() *string {
+			if securityGroup.Description != "" {
+				return &securityGroup.Description
+			}
+			return nil
+		}(),
+		Name: securityGroup.Name,
 	})
 	if err != nil {
 		return nil, err

--- a/v2/sks.go
+++ b/v2/sks.go
@@ -249,10 +249,15 @@ func (c *SKSCluster) AddNodepool(ctx context.Context, np *SKSNodepool) (*SKSNode
 				}
 				return nil
 			}(),
-			DiskSize:       np.DiskSize,
-			InstancePrefix: &np.InstancePrefix,
-			InstanceType:   papi.InstanceType{Id: &np.InstanceTypeID},
-			Name:           np.Name,
+			DiskSize: np.DiskSize,
+			InstancePrefix: func() *string {
+				if np.InstancePrefix != "" {
+					return &np.InstancePrefix
+				}
+				return nil
+			}(),
+			InstanceType: papi.InstanceType{Id: &np.InstanceTypeID},
+			Name:         np.Name,
 			SecurityGroups: func() *[]papi.SecurityGroup {
 				if l := len(np.SecurityGroupIDs); l > 0 {
 					list := make([]papi.SecurityGroup, l)
@@ -515,10 +520,15 @@ func (c *Client) CreateSKSCluster(ctx context.Context, zone string, cluster *SKS
 				}
 				return nil
 			}(),
-			Description: &cluster.Description,
-			Level:       papi.CreateSksClusterJSONBodyLevel(cluster.ServiceLevel),
-			Name:        cluster.Name,
-			Version:     cluster.Version,
+			Description: func() *string {
+				if cluster.Description != "" {
+					return &cluster.Description
+				}
+				return nil
+			}(),
+			Level:   papi.CreateSksClusterJSONBodyLevel(cluster.ServiceLevel),
+			Name:    cluster.Name,
+			Version: cluster.Version,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change fixes how the v2 package sets optional API resource fields,
only including those if they actually hold a non-empty value.