### PR TITLE
Change AuthorizeSecurityGroupIngress.Icmp(Code|Type) type

### DIFF
--- a/security_groups.go
+++ b/security_groups.go
@@ -124,8 +124,8 @@ type AuthorizeSecurityGroupIngress struct {
 	CIDRList              []CIDR              `json:"cidrlist,omitempty" doc:"the cidr list associated"`
 	Description           string              `json:"description,omitempty" doc:"the description of the ingress/egress rule"`
 	EndPort               uint16              `json:"endport,omitempty" doc:"end port for this ingress/egress rule"`
-	IcmpCode              uint8               `json:"icmpcode,omitempty" doc:"error code for this icmp message"`
-	IcmpType              uint8               `json:"icmptype,omitempty" doc:"type of the icmp message being sent"`
+	IcmpCode              int                 `json:"icmpcode,omitempty" doc:"error code for this icmp message"`
+	IcmpType              int                 `json:"icmptype,omitempty" doc:"type of the icmp message being sent"`
 	Protocol              string              `json:"protocol,omitempty" doc:"TCP is default. UDP, ICMP, ICMPv6, AH, ESP, GRE, IPIP are the other supported protocols"`
 	SecurityGroupID       *UUID               `json:"securitygroupid,omitempty" doc:"The ID of the security group. Mutually exclusive with securitygroupname parameter"`
 	SecurityGroupName     string              `json:"securitygroupname,omitempty" doc:"The name of the security group. Mutually exclusive with securitygroupid parameter"`


### PR DESCRIPTION
Follow-up to 55d713e35cccb11e4c60e81e7de065466730700f, this change
modifies the type used for `AuthorizeSecurityGroupIngress.Icmp(Code|Type)`
to `int` to support -1 value.