### PR TITLE
v2: don't return pointers to empty maps/slices

### DIFF
--- a/v2/instance.go
+++ b/v2/instance.go
@@ -45,7 +45,7 @@ type Instance struct {
 func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 	return &Instance{
 		AntiAffinityGroupIDs: func() (v *[]string) {
-			if i.AntiAffinityGroups != nil {
+			if i.AntiAffinityGroups != nil && len(*i.AntiAffinityGroups) > 0 {
 				ids := make([]string, len(*i.AntiAffinityGroups))
 				for i, item := range *i.AntiAffinityGroups {
 					ids[i] = *item.Id
@@ -63,7 +63,7 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 		}(),
 		DiskSize: i.DiskSize,
 		ElasticIPIDs: func() (v *[]string) {
-			if i.ElasticIps != nil {
+			if i.ElasticIps != nil && len(*i.ElasticIps) > 0 {
 				ids := make([]string, len(*i.ElasticIps))
 				for i, item := range *i.ElasticIps {
 					ids[i] = *item.Id
@@ -89,7 +89,7 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 		}(),
 		InstanceTypeID: i.InstanceType.Id,
 		Labels: func() (v *map[string]string) {
-			if i.Labels != nil {
+			if i.Labels != nil && len(i.Labels.AdditionalProperties) > 0 {
 				v = &i.Labels.AdditionalProperties
 			}
 			return
@@ -105,7 +105,7 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 		}(),
 		Name: i.Name,
 		PrivateNetworkIDs: func() (v *[]string) {
-			if i.PrivateNetworks != nil {
+			if i.PrivateNetworks != nil && len(*i.PrivateNetworks) > 0 {
 				ids := make([]string, len(*i.PrivateNetworks))
 				for i, item := range *i.PrivateNetworks {
 					ids[i] = *item.Id
@@ -128,7 +128,7 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 			return
 		}(),
 		SecurityGroupIDs: func() (v *[]string) {
-			if i.SecurityGroups != nil {
+			if i.SecurityGroups != nil && len(*i.SecurityGroups) > 0 {
 				ids := make([]string, len(*i.SecurityGroups))
 				for i, item := range *i.SecurityGroups {
 					ids[i] = *item.Id
@@ -138,7 +138,7 @@ func instanceFromAPI(client *Client, zone string, i *papi.Instance) *Instance {
 			return
 		}(),
 		SnapshotIDs: func() (v *[]string) {
-			if i.Snapshots != nil {
+			if i.Snapshots != nil && len(*i.Snapshots) > 0 {
 				ids := make([]string, len(*i.Snapshots))
 				for i, item := range *i.Snapshots {
 					ids[i] = *item.Id

--- a/v2/instance_pool.go
+++ b/v2/instance_pool.go
@@ -37,7 +37,7 @@ type InstancePool struct {
 func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 	return &InstancePool{
 		AntiAffinityGroupIDs: func() (v *[]string) {
-			if i.AntiAffinityGroups != nil {
+			if i.AntiAffinityGroups != nil && len(*i.AntiAffinityGroups) > 0 {
 				ids := make([]string, len(*i.AntiAffinityGroups))
 				for i, item := range *i.AntiAffinityGroups {
 					ids[i] = *item.Id
@@ -55,7 +55,7 @@ func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 		Description: i.Description,
 		DiskSize:    i.DiskSize,
 		ElasticIPIDs: func() (v *[]string) {
-			if i.ElasticIps != nil {
+			if i.ElasticIps != nil && len(*i.ElasticIps) > 0 {
 				ids := make([]string, len(*i.ElasticIps))
 				for i, item := range *i.ElasticIps {
 					ids[i] = *item.Id
@@ -67,7 +67,7 @@ func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 		ID:          i.Id,
 		IPv6Enabled: i.Ipv6Enabled,
 		InstanceIDs: func() (v *[]string) {
-			if i.Instances != nil {
+			if i.Instances != nil && len(*i.Instances) > 0 {
 				ids := make([]string, len(*i.Instances))
 				for i, item := range *i.Instances {
 					ids[i] = *item.Id
@@ -79,7 +79,7 @@ func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 		InstancePrefix: i.InstancePrefix,
 		InstanceTypeID: i.InstanceType.Id,
 		Labels: func() (v *map[string]string) {
-			if i.Labels != nil {
+			if i.Labels != nil && len(i.Labels.AdditionalProperties) > 0 {
 				v = &i.Labels.AdditionalProperties
 			}
 			return
@@ -92,7 +92,7 @@ func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 		}(),
 		Name: i.Name,
 		PrivateNetworkIDs: func() (v *[]string) {
-			if i.PrivateNetworks != nil {
+			if i.PrivateNetworks != nil && len(*i.PrivateNetworks) > 0 {
 				ids := make([]string, len(*i.PrivateNetworks))
 				for i, item := range *i.PrivateNetworks {
 					ids[i] = *item.Id
@@ -108,7 +108,7 @@ func instancePoolFromAPI(i *papi.InstancePool) *InstancePool {
 			return
 		}(),
 		SecurityGroupIDs: func() (v *[]string) {
-			if i.SecurityGroups != nil {
+			if i.SecurityGroups != nil && len(*i.SecurityGroups) > 0 {
 				ids := make([]string, len(*i.SecurityGroups))
 				for i, item := range *i.SecurityGroups {
 					ids[i] = *item.Id

--- a/v2/network_load_balancer.go
+++ b/v2/network_load_balancer.go
@@ -124,7 +124,7 @@ func nlbFromAPI(client *Client, zone string, nlb *papi.LoadBalancer) *NetworkLoa
 			return
 		}(),
 		Labels: func() (v *map[string]string) {
-			if nlb.Labels != nil {
+			if nlb.Labels != nil && len(nlb.Labels.AdditionalProperties) > 0 {
 				v = &nlb.Labels.AdditionalProperties
 			}
 			return

--- a/v2/sks.go
+++ b/v2/sks.go
@@ -37,7 +37,7 @@ func sksNodepoolFromAPI(client *Client, zone string, np *papi.SksNodepool) *SKSN
 	return &SKSNodepool{
 		AntiAffinityGroupIDs: func() (v *[]string) {
 			ids := make([]string, 0)
-			if np.AntiAffinityGroups != nil {
+			if np.AntiAffinityGroups != nil && len(*np.AntiAffinityGroups) > 0 {
 				for _, aag := range *np.AntiAffinityGroups {
 					aag := aag
 					ids = append(ids, *aag.Id)
@@ -60,7 +60,7 @@ func sksNodepoolFromAPI(client *Client, zone string, np *papi.SksNodepool) *SKSN
 		InstancePrefix: np.InstancePrefix,
 		InstanceTypeID: np.InstanceType.Id,
 		Labels: func() (v *map[string]string) {
-			if np.Labels != nil {
+			if np.Labels != nil && len(np.Labels.AdditionalProperties) > 0 {
 				v = &np.Labels.AdditionalProperties
 			}
 			return
@@ -68,7 +68,7 @@ func sksNodepoolFromAPI(client *Client, zone string, np *papi.SksNodepool) *SKSN
 		Name: np.Name,
 		SecurityGroupIDs: func() (v *[]string) {
 			ids := make([]string, 0)
-			if np.SecurityGroups != nil {
+			if np.SecurityGroups != nil && len(*np.SecurityGroups) > 0 {
 				for _, sg := range *np.SecurityGroups {
 					sg := sg
 					ids = append(ids, *sg.Id)
@@ -144,7 +144,7 @@ func sksClusterFromAPI(client *Client, zone string, c *papi.SksCluster) *SKSClus
 		Endpoint:    c.Endpoint,
 		ID:          c.Id,
 		Labels: func() (v *map[string]string) {
-			if c.Labels != nil {
+			if c.Labels != nil && len(c.Labels.AdditionalProperties) > 0 {
 				v = &c.Labels.AdditionalProperties
 			}
 			return


### PR DESCRIPTION
This change prevents from returning pointers to empty maps or slices
that can be returned by the API.