### PR TITLE
v2: add new Client.RegisterTemplate() method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,5 @@ jobs:
         version: v1.40
     - name: Tests
       run: |
-        go test -race -v ./...
+        git submodule update --init --recursive go.mk
+        PATH=$(go env GOPATH)/bin:$PATH make test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "go.mk"]
 	path = go.mk
-	url = git@github.com:exoscale/go.mk.git
+	url = https://github.com/exoscale/go.mk.git

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,7 @@ include go.mk/public.mk
 PACKAGE := github.com/exoscale/egoscale
 
 PROJECT_URL := https://$(PACKAGE)
+
+GO_TEST_EXTRA_ARGS := -mod=readonly -v
+
+GOLANGCI_EXTRA_ARGS := --modules-download-mode=readonly


### PR DESCRIPTION
This change adds a new `Client.RegisterTemplate()` method.