### PR TITLE
v2: add support for Private Networks to SKS Nodepools 

### DIFF
--- a/v2/database.go
+++ b/v2/database.go
@@ -152,7 +152,7 @@ type DatabaseService struct {
 	Type                  *string
 	UpdatedAt             *time.Time
 	URI                   *url.URL
-	UserConfig            map[string]interface{}
+	UserConfig            *map[string]interface{}
 	Users                 []*DatabaseServiceUser
 }
 
@@ -210,9 +210,9 @@ func databaseServiceFromAPI(s *papi.DbaasService) *DatabaseService {
 			}
 			return nil
 		}(),
-		UserConfig: func() (v map[string]interface{}) {
+		UserConfig: func() (v *map[string]interface{}) {
 			if s.UserConfig != nil {
-				v = s.UserConfig.AdditionalProperties
+				v = &s.UserConfig.AdditionalProperties
 			}
 			return
 		}(),
@@ -284,13 +284,13 @@ func (c *Client) CreateDatabaseService(
 			Plan:                  *databaseService.Plan,
 			TerminationProtection: databaseService.TerminationProtection,
 			Type:                  papi.DbaasServiceTypeName(*databaseService.Type),
-			UserConfig: func() *papi.CreateDbaasServiceJSONBody_UserConfig {
-				if len(databaseService.UserConfig) > 0 {
-					return &papi.CreateDbaasServiceJSONBody_UserConfig{
-						AdditionalProperties: databaseService.UserConfig,
+			UserConfig: func() (v *papi.CreateDbaasServiceJSONBody_UserConfig) {
+				if databaseService.UserConfig != nil {
+					v = &papi.CreateDbaasServiceJSONBody_UserConfig{
+						AdditionalProperties: *databaseService.UserConfig,
 					}
 				}
-				return nil
+				return
 			}(),
 		})
 	if err != nil {
@@ -351,13 +351,13 @@ func (c *Client) UpdateDatabaseService(ctx context.Context, zone string, databas
 			}(),
 			Plan:                  databaseService.Plan,
 			TerminationProtection: databaseService.TerminationProtection,
-			UserConfig: func() *papi.UpdateDbaasServiceJSONBody_UserConfig {
-				if len(databaseService.UserConfig) > 0 {
-					return &papi.UpdateDbaasServiceJSONBody_UserConfig{
-						AdditionalProperties: databaseService.UserConfig,
+			UserConfig: func() (v *papi.UpdateDbaasServiceJSONBody_UserConfig) {
+				if databaseService.UserConfig != nil {
+					v = &papi.UpdateDbaasServiceJSONBody_UserConfig{
+						AdditionalProperties: *databaseService.UserConfig,
 					}
 				}
-				return nil
+				return
 			}(),
 		})
 	if err != nil {

--- a/v2/database_test.go
+++ b/v2/database_test.go
@@ -270,7 +270,7 @@ func (ts *clientTestSuite) TestClient_CreateDatabaseService() {
 		Type:                  (*string)(&testDatabaseServiceType),
 		UpdatedAt:             &testDatabaseServiceUpdatedAt,
 		URI:                   func() *url.URL { u, _ := url.Parse(testDatabaseServiceURI); return u }(),
-		UserConfig:            map[string]interface{}{"k": "v"},
+		UserConfig:            &map[string]interface{}{"k": "v"},
 		Users: []*DatabaseServiceUser{{
 			Password: &testDatabaseServiceUserPassword,
 			Type:     &testDatabaseServiceUserType,
@@ -287,7 +287,7 @@ func (ts *clientTestSuite) TestClient_CreateDatabaseService() {
 		Plan:                  &testDatabasePlanName,
 		TerminationProtection: &testDatabaseServiceTerminationProtection,
 		Type:                  (*string)(&testDatabaseServiceType),
-		UserConfig:            map[string]interface{}{"k": "v"},
+		UserConfig:            &map[string]interface{}{"k": "v"},
 	})
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
@@ -376,7 +376,7 @@ func (ts *clientTestSuite) TestClient_ListDatabaseServices() {
 		Type:                  (*string)(&testDatabaseServiceType),
 		UpdatedAt:             &testDatabaseServiceUpdatedAt,
 		URI:                   func() *url.URL { u, _ := url.Parse(testDatabaseServiceURI); return u }(),
-		UserConfig:            map[string]interface{}{"k": "v"},
+		UserConfig:            &map[string]interface{}{"k": "v"},
 		Users: []*DatabaseServiceUser{{
 			Password: &testDatabaseServiceUserPassword,
 			Type:     &testDatabaseServiceUserType,
@@ -470,7 +470,7 @@ func (ts *clientTestSuite) TestClient_GetDatabaseService() {
 		Type:                  (*string)(&testDatabaseServiceType),
 		UpdatedAt:             &testDatabaseServiceUpdatedAt,
 		URI:                   func() *url.URL { u, _ := url.Parse(testDatabaseServiceURI); return u }(),
-		UserConfig:            map[string]interface{}{"k": "v"},
+		UserConfig:            &map[string]interface{}{"k": "v"},
 		Users: []*DatabaseServiceUser{{
 			Password: &testDatabaseServiceUserPassword,
 			Type:     &testDatabaseServiceUserType,
@@ -541,7 +541,7 @@ func (ts *clientTestSuite) TestClient_UpdateDatabaseService() {
 		Plan:                  &testDatabasePlanName,
 		TerminationProtection: &testDatabaseServiceTerminationProtection,
 		Type:                  (*string)(&testDatabaseServiceType),
-		UserConfig:            map[string]interface{}{"k": "v"},
+		UserConfig:            &map[string]interface{}{"k": "v"},
 	}))
 	ts.Require().True(updated)
 }

--- a/v2/internal/public-api/public-api.gen.go
+++ b/v2/internal/public-api/public-api.gen.go
@@ -1588,6 +1588,9 @@ type SksNodepool struct {
 	// Nodepool name
 	Name *string `json:"name,omitempty"`
 
+	// Nodepool Private Networks
+	PrivateNetworks *[]PrivateNetwork `json:"private-networks,omitempty"`
+
 	// Nodepool Security Groups
 	SecurityGroups *[]SecurityGroup `json:"security-groups,omitempty"`
 
@@ -2308,6 +2311,9 @@ type CreateSksNodepoolJSONBody struct {
 	// Nodepool name
 	Name string `json:"name"`
 
+	// Nodepool Private Networks
+	PrivateNetworks *[]PrivateNetwork `json:"private-networks,omitempty"`
+
 	// Nodepool Security Groups
 	SecurityGroups *[]SecurityGroup `json:"security-groups,omitempty"`
 
@@ -2339,6 +2345,9 @@ type UpdateSksNodepoolJSONBody struct {
 
 	// Nodepool name
 	Name *string `json:"name,omitempty"`
+
+	// Nodepool Private Networks
+	PrivateNetworks *[]PrivateNetwork `json:"private-networks,omitempty"`
 
 	// Nodepool Security Groups
 	SecurityGroups *[]SecurityGroup `json:"security-groups,omitempty"`

--- a/v2/internal/public-api/sks_nodepool.go
+++ b/v2/internal/public-api/sks_nodepool.go
@@ -21,6 +21,7 @@ func (n *SksNodepool) UnmarshalJSON(data []byte) error {
 		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
 		Labels             *Labels              `json:"labels,omitempty"`
 		Name               *string              `json:"name,omitempty"`
+		PrivateNetworks    *[]PrivateNetwork    `json:"private-networks,omitempty"`
 		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
 		Size               *int64               `json:"size,omitempty"`
 		State              *SksNodepoolState    `json:"state,omitempty"`
@@ -50,6 +51,7 @@ func (n *SksNodepool) UnmarshalJSON(data []byte) error {
 	n.InstanceType = raw.InstanceType
 	n.Labels = raw.Labels
 	n.Name = raw.Name
+	n.PrivateNetworks = raw.PrivateNetworks
 	n.SecurityGroups = raw.SecurityGroups
 	n.Size = raw.Size
 	n.State = raw.State
@@ -74,6 +76,7 @@ func (n *SksNodepool) MarshalJSON() ([]byte, error) {
 		InstanceType       *InstanceType        `json:"instance-type,omitempty"`
 		Labels             *Labels              `json:"labels,omitempty"`
 		Name               *string              `json:"name,omitempty"`
+		PrivateNetworks    *[]PrivateNetwork    `json:"private-networks,omitempty"`
 		SecurityGroups     *[]SecurityGroup     `json:"security-groups,omitempty"`
 		Size               *int64               `json:"size,omitempty"`
 		State              *SksNodepoolState    `json:"state,omitempty"`
@@ -96,6 +99,7 @@ func (n *SksNodepool) MarshalJSON() ([]byte, error) {
 	raw.InstanceType = n.InstanceType
 	raw.Labels = n.Labels
 	raw.Name = n.Name
+	raw.PrivateNetworks = n.PrivateNetworks
 	raw.SecurityGroups = n.SecurityGroups
 	raw.Size = n.Size
 	raw.State = n.State

--- a/v2/internal/public-api/sks_nodepool_test.go
+++ b/v2/internal/public-api/sks_nodepool_test.go
@@ -22,6 +22,7 @@ func TestSksNodepool_UnmarshalJSON(t *testing.T) {
 		testInstanceTypeID            = testRandomID(t)
 		testLabels                    = map[string]string{"k1": "v1", "k2": "v2"}
 		testName                      = "test-nodepool"
+		testPrivateNetworkID          = testRandomID(t)
 		testSecurityGroupID           = testRandomID(t)
 		testSize                int64 = 3
 		testState                     = SksNodepoolStateRunning
@@ -40,6 +41,7 @@ func TestSksNodepool_UnmarshalJSON(t *testing.T) {
 			InstanceType:       &InstanceType{Id: &testInstanceTypeID},
 			Labels:             &Labels{AdditionalProperties: testLabels},
 			Name:               &testName,
+			PrivateNetworks:    &[]PrivateNetwork{{Id: &testPrivateNetworkID}},
 			SecurityGroups:     &[]SecurityGroup{{Id: &testSecurityGroupID}},
 			Size:               &testSize,
 			State:              &testState,
@@ -61,6 +63,7 @@ func TestSksNodepool_UnmarshalJSON(t *testing.T) {
   "instance-type": {"id": "` + testInstanceTypeID + `"},
   "labels": {"k1": "` + testLabels["k1"] + `", "k2": "` + testLabels["k2"] + `"},
   "name": "` + testName + `",
+  "private-networks": [{"id":"` + testPrivateNetworkID + `"}],
   "security-groups": [{"id":"` + testSecurityGroupID + `"}],
   "size": ` + fmt.Sprint(testSize) + `,
   "state": "` + string(testState) + `",
@@ -86,6 +89,7 @@ func TestSksNodepool_MarshalJSON(t *testing.T) {
 		testInstanceTypeID            = testRandomID(t)
 		testLabels                    = map[string]string{"k1": "v1", "k2": "v2"}
 		testName                      = "test-nodepool"
+		testPrivateNetworkID          = testRandomID(t)
 		testSecurityGroupID           = testRandomID(t)
 		testSize                int64 = 3
 		testState                     = SksNodepoolStateRunning
@@ -104,6 +108,7 @@ func TestSksNodepool_MarshalJSON(t *testing.T) {
 			InstanceType:       &InstanceType{Id: &testInstanceTypeID},
 			Labels:             &Labels{AdditionalProperties: testLabels},
 			Name:               &testName,
+			PrivateNetworks:    &[]PrivateNetwork{{Id: &testPrivateNetworkID}},
 			SecurityGroups:     &[]SecurityGroup{{Id: &testSecurityGroupID}},
 			Size:               &testSize,
 			State:              &testState,
@@ -123,6 +128,7 @@ func TestSksNodepool_MarshalJSON(t *testing.T) {
 			`"instance-type":{"id":"` + testInstanceTypeID + `"},` +
 			`"labels":{"k1":"` + testLabels["k1"] + `","k2":"` + testLabels["k2"] + `"},` +
 			`"name":"` + testName + `",` +
+			`"private-networks":[{"id":"` + testPrivateNetworkID + `"}],` +
 			`"security-groups":[{"id":"` + testSecurityGroupID + `"}],` +
 			`"size":` + fmt.Sprint(testSize) + `,` +
 			`"state":"` + string(testState) + `",` +


### PR DESCRIPTION
This change adds a new `PrivateNetworkIDs` field to the `SKSNodepool`
resource struct.