### PR TITLE
v2: add support for SSH keys management

### DIFF
--- a/v2/ssh_key.go
+++ b/v2/ssh_key.go
@@ -1,0 +1,90 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// SSHKey represents an SSH key.
+type SSHKey struct {
+	Fingerprint *string
+	Name        *string
+}
+
+func sshKeyFromAPI(k *papi.SshKey) *SSHKey {
+	return &SSHKey{
+		Fingerprint: k.Fingerprint,
+		Name:        k.Name,
+	}
+}
+
+// RegisterSSHKey registers a new SSH key in the specified zone.
+func (c *Client) RegisterSSHKey(ctx context.Context, zone, name, publicKey string) (*SSHKey, error) {
+	resp, err := c.RegisterSshKeyWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.RegisterSshKeyJSONRequestBody{
+			Name:      name,
+			PublicKey: publicKey,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetSSHKey(ctx, zone, *res.(*papi.Reference).Id)
+}
+
+// ListSSHKeys returns the list of existing SSH keys in the specified zone.
+func (c *Client) ListSSHKeys(ctx context.Context, zone string) ([]*SSHKey, error) {
+	list := make([]*SSHKey, 0)
+
+	resp, err := c.ListSshKeysWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SshKeys != nil {
+		for i := range *resp.JSON200.SshKeys {
+			list = append(list, sshKeyFromAPI(&(*resp.JSON200.SshKeys)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetSSHKey returns the SSH key corresponding to the specified name in the specified zone.
+func (c *Client) GetSSHKey(ctx context.Context, zone, name string) (*SSHKey, error) {
+	resp, err := c.GetSshKeyWithResponse(apiv2.WithZone(ctx, zone), name)
+	if err != nil {
+		return nil, err
+	}
+
+	return sshKeyFromAPI(resp.JSON200), nil
+}
+
+// DeleteSSHKey deletes the specified SSH key in the specified zone.
+func (c *Client) DeleteSSHKey(ctx context.Context, zone, id string) error {
+	resp, err := c.DeleteSshKeyWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/ssh_key_test.go
+++ b/v2/ssh_key_test.go
@@ -1,0 +1,142 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+	"github.com/jarcoal/httpmock"
+)
+
+var (
+	testSSHKeyFingerprint = new(clientTestSuite).randomString(10)
+	testSSHKeyName        = new(clientTestSuite).randomString(10)
+	testSSHKeyPublicKey   = new(clientTestSuite).randomString(10)
+)
+
+func (ts *clientTestSuite) TestClient_RegisterSSHKey() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+	)
+
+	httpmock.RegisterResponder("POST", "/ssh-key",
+		func(req *http.Request) (*http.Response, error) {
+			var actual papi.RegisterSshKeyJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.RegisterSshKeyJSONRequestBody{
+				Name:      testSSHKeyName,
+				PublicKey: testSSHKeyPublicKey,
+			}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSSHKeyName},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSSHKeyName},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/ssh-key/%s", testSSHKeyName), papi.SshKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	})
+
+	expected := &SSHKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	}
+
+	actual, err := ts.client.RegisterSSHKey(context.Background(), testZone, testSSHKeyName, testSSHKeyPublicKey)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListSSHKeys() {
+	httpmock.RegisterResponder("GET", "/ssh-key", func(req *http.Request) (*http.Response, error) {
+		resp, err := httpmock.NewJsonResponse(http.StatusOK,
+			struct {
+				SSHKeys *[]papi.SshKey `json:"ssh-keys,omitempty"`
+			}{
+				SSHKeys: &[]papi.SshKey{{
+					Fingerprint: &testSSHKeyFingerprint,
+					Name:        &testSSHKeyName,
+				}},
+			})
+		if err != nil {
+			ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+		}
+		return resp, nil
+	})
+
+	expected := []*SSHKey{{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	}}
+
+	actual, err := ts.client.ListSSHKeys(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetSSHKey() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/ssh-key/%s", testSSHKeyName), papi.SshKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	})
+
+	expected := &SSHKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	}
+
+	actual, err := ts.client.GetSSHKey(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_DeleteSSHKey() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/ssh-key/%s", testSSHKeyName),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSSHKeyName},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSSHKeyName},
+	})
+
+	ts.Require().NoError(ts.client.DeleteSSHKey(context.Background(), testZone, testSSHKeyName))
+	ts.Require().True(deleted)
+}


### PR DESCRIPTION
This change introduces support for SSH keys resources
management via the Exoscale V2 API.