### PR TITLE
v2: fix RegisterSSHKey() method

### DIFF
--- a/v2/ssh_key.go
+++ b/v2/ssh_key.go
@@ -22,7 +22,7 @@ func sshKeyFromAPI(k *papi.SshKey) *SSHKey {
 
 // RegisterSSHKey registers a new SSH key in the specified zone.
 func (c *Client) RegisterSSHKey(ctx context.Context, zone, name, publicKey string) (*SSHKey, error) {
-	resp, err := c.RegisterSshKeyWithResponse(
+	_, err := c.RegisterSshKeyWithResponse(
 		apiv2.WithZone(ctx, zone),
 		papi.RegisterSshKeyJSONRequestBody{
 			Name:      name,
@@ -32,15 +32,7 @@ func (c *Client) RegisterSSHKey(ctx context.Context, zone, name, publicKey strin
 		return nil, err
 	}
 
-	res, err := papi.NewPoller().
-		WithTimeout(c.timeout).
-		WithInterval(c.pollInterval).
-		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return nil, err
-	}
-
-	return c.GetSSHKey(ctx, zone, *res.(*papi.Reference).Id)
+	return c.GetSSHKey(ctx, zone, name)
 }
 
 // ListSSHKeys returns the list of existing SSH keys in the specified zone.

--- a/v2/ssh_key_test.go
+++ b/v2/ssh_key_test.go
@@ -44,12 +44,6 @@ func (ts *clientTestSuite) TestClient_RegisterSSHKey() {
 			return resp, nil
 		})
 
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSSHKeyName},
-	})
-
 	ts.mockAPIRequest("GET", fmt.Sprintf("/ssh-key/%s", testSSHKeyName), papi.SshKey{
 		Fingerprint: &testSSHKeyFingerprint,
 		Name:        &testSSHKeyName,


### PR DESCRIPTION
This change fixes a bug in the `client.RegisterSSHKey()` method causing
it to return a polling-related error, where there is actually no need
for polling for this operation.