### PR TITLE
v2: API overhaul + quotas support

### DIFF
--- a/v2/anti_affinity_group.go
+++ b/v2/anti_affinity_group.go
@@ -22,11 +22,7 @@ func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
 	}
 }
 
-func (a AntiAffinityGroup) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
-	return client.GetAntiAffinityGroup(ctx, zone, id)
-}
-
-// CreateAntiAffinityGroup creates an Anti-Affinity Group in the specified zone.
+// CreateAntiAffinityGroup creates an Anti-Affinity Group.
 func (c *Client) CreateAntiAffinityGroup(
 	ctx context.Context,
 	zone string,
@@ -57,7 +53,55 @@ func (c *Client) CreateAntiAffinityGroup(
 	return c.GetAntiAffinityGroup(ctx, zone, *res.(*papi.Reference).Id)
 }
 
-// ListAntiAffinityGroups returns the list of existing Anti-Affinity Groups in the specified zone.
+// DeleteAntiAffinityGroup deletes an Anti-Affinity Group.
+func (c *Client) DeleteAntiAffinityGroup(
+	ctx context.Context,
+	zone string,
+	antiAffinityGroup *AntiAffinityGroup,
+) error {
+	resp, err := c.DeleteAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), *antiAffinityGroup.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindAntiAffinityGroup attempts to find an Anti-Affinity Group by name or ID.
+func (c *Client) FindAntiAffinityGroup(ctx context.Context, zone, x string) (*AntiAffinityGroup, error) {
+	res, err := c.ListAntiAffinityGroups(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if *r.ID == x || *r.Name == x {
+			return c.GetAntiAffinityGroup(ctx, zone, *r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
+// GetAntiAffinityGroup returns the Anti-Affinity Group corresponding to the specified ID.
+func (c *Client) GetAntiAffinityGroup(ctx context.Context, zone, id string) (*AntiAffinityGroup, error) {
+	resp, err := c.GetAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return antiAffinityGroupFromAPI(resp.JSON200), nil
+}
+
+// ListAntiAffinityGroups returns the list of existing Anti-Affinity Groups.
 func (c *Client) ListAntiAffinityGroups(ctx context.Context, zone string) ([]*AntiAffinityGroup, error) {
 	list := make([]*AntiAffinityGroup, 0)
 
@@ -73,48 +117,4 @@ func (c *Client) ListAntiAffinityGroups(ctx context.Context, zone string) ([]*An
 	}
 
 	return list, nil
-}
-
-// GetAntiAffinityGroup returns the Anti-Affinity Group corresponding to the specified ID in the specified zone.
-func (c *Client) GetAntiAffinityGroup(ctx context.Context, zone, id string) (*AntiAffinityGroup, error) {
-	resp, err := c.GetAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return nil, err
-	}
-
-	return antiAffinityGroupFromAPI(resp.JSON200), nil
-}
-
-// FindAntiAffinityGroup attempts to find an Anti-Affinity Group by name or ID in the specified zone.
-func (c *Client) FindAntiAffinityGroup(ctx context.Context, zone, v string) (*AntiAffinityGroup, error) {
-	res, err := c.ListAntiAffinityGroups(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, r := range res {
-		if *r.ID == v || *r.Name == v {
-			return c.GetAntiAffinityGroup(ctx, zone, *r.ID)
-		}
-	}
-
-	return nil, apiv2.ErrNotFound
-}
-
-// DeleteAntiAffinityGroup deletes the specified Anti-Affinity Group in the specified zone.
-func (c *Client) DeleteAntiAffinityGroup(ctx context.Context, zone, id string) error {
-	resp, err := c.DeleteAntiAffinityGroupWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.timeout).
-		WithInterval(c.pollInterval).
-		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -248,10 +248,11 @@ func TestNewClient(t *testing.T) {
 	client, err := NewClient(
 		testAPIKey,
 		testAPISecret,
+		ClientOptCond(func() bool { return true }, ClientOptWithTrace()),
 		ClientOptWithAPIEndpoint(testAPIEndpoint),
 		ClientOptWithHTTPClient(testHTTPClient),
-		ClientOptWithTimeout(testTimeout),
 		ClientOptWithPollInterval(testPollInterval),
+		ClientOptWithTimeout(testTimeout),
 	)
 
 	require.NoError(t, err)
@@ -261,6 +262,7 @@ func TestNewClient(t *testing.T) {
 	require.Equal(t, testHTTPClient, client.httpClient)
 	require.Equal(t, testTimeout, client.timeout)
 	require.Equal(t, testPollInterval, client.pollInterval)
+	require.True(t, client.trace)
 	require.IsType(t, &api.ErrorHandlerMiddleware{}, client.httpClient.Transport)
 }
 

--- a/v2/database.go
+++ b/v2/database.go
@@ -228,6 +228,16 @@ func databaseServiceFromAPI(s *papi.DbaasService) *DatabaseService {
 	}
 }
 
+// GetDatabaseServiceType returns the Database Service type corresponding to the specified name.
+func (c *Client) GetDatabaseServiceType(ctx context.Context, zone, name string) (*DatabaseServiceType, error) {
+	resp, err := c.GetDbaasServiceTypeWithResponse(apiv2.WithZone(ctx, zone), name)
+	if err != nil {
+		return nil, err
+	}
+
+	return databaseServiceTypeFromAPI(resp.JSON200), nil
+}
+
 // ListDatabaseServiceTypes returns the list of existing Database Service types.
 func (c *Client) ListDatabaseServiceTypes(ctx context.Context, zone string) ([]*DatabaseServiceType, error) {
 	list := make([]*DatabaseServiceType, 0)
@@ -244,16 +254,6 @@ func (c *Client) ListDatabaseServiceTypes(ctx context.Context, zone string) ([]*
 	}
 
 	return list, nil
-}
-
-// GetDatabaseServiceType returns the Database Service type corresponding to the specified name.
-func (c *Client) GetDatabaseServiceType(ctx context.Context, zone, name string) (*DatabaseServiceType, error) {
-	resp, err := c.GetDbaasServiceTypeWithResponse(apiv2.WithZone(ctx, zone), name)
-	if err != nil {
-		return nil, err
-	}
-
-	return databaseServiceTypeFromAPI(resp.JSON200), nil
 }
 
 // CreateDatabaseService creates a Database Service.
@@ -300,6 +300,26 @@ func (c *Client) CreateDatabaseService(
 	return c.GetDatabaseService(ctx, zone, *databaseService.Name)
 }
 
+// DeleteDatabaseService deletes a Database Service.
+func (c *Client) DeleteDatabaseService(ctx context.Context, zone string, databaseService *DatabaseService) error {
+	_, err := c.TerminateDbaasServiceWithResponse(apiv2.WithZone(ctx, zone), *databaseService.Name)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetDatabaseService returns the Database Service corresponding to the specified name.
+func (c *Client) GetDatabaseService(ctx context.Context, zone, name string) (*DatabaseService, error) {
+	resp, err := c.GetDbaasServiceWithResponse(apiv2.WithZone(ctx, zone), name)
+	if err != nil {
+		return nil, err
+	}
+
+	return databaseServiceFromAPI(resp.JSON200), nil
+}
+
 // ListDatabaseServices returns the list of Database Services.
 func (c *Client) ListDatabaseServices(ctx context.Context, zone string) ([]*DatabaseService, error) {
 	list := make([]*DatabaseService, 0)
@@ -318,17 +338,7 @@ func (c *Client) ListDatabaseServices(ctx context.Context, zone string) ([]*Data
 	return list, nil
 }
 
-// GetDatabaseService returns the Database Service corresponding to the specified name.
-func (c *Client) GetDatabaseService(ctx context.Context, zone, name string) (*DatabaseService, error) {
-	resp, err := c.GetDbaasServiceWithResponse(apiv2.WithZone(ctx, zone), name)
-	if err != nil {
-		return nil, err
-	}
-
-	return databaseServiceFromAPI(resp.JSON200), nil
-}
-
-// UpdateDatabaseService updates the specified Database Service.
+// UpdateDatabaseService updates a Database Service.
 func (c *Client) UpdateDatabaseService(ctx context.Context, zone string, databaseService *DatabaseService) error {
 	_, err := c.UpdateDbaasServiceWithResponse(
 		apiv2.WithZone(ctx, zone),
@@ -360,16 +370,6 @@ func (c *Client) UpdateDatabaseService(ctx context.Context, zone string, databas
 				return
 			}(),
 		})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteDatabaseService deletes the specified Database Service.
-func (c *Client) DeleteDatabaseService(ctx context.Context, zone, name string) error {
-	_, err := c.TerminateDbaasServiceWithResponse(apiv2.WithZone(ctx, zone), name)
 	if err != nil {
 		return err
 	}

--- a/v2/database_test.go
+++ b/v2/database_test.go
@@ -48,108 +48,6 @@ var (
 	testDatabaseServiceUserUsername                = new(clientTestSuite).randomString(10)
 )
 
-func (ts *clientTestSuite) TestClient_GetDatabaseServiceType() {
-	ts.mockAPIRequest("GET",
-		fmt.Sprintf("/dbaas-service-type/%s", testDatabaseServiceTypeName),
-		papi.DbaasServiceType{
-			DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
-			Description:    &testDatabaseServiceTypeDescription,
-			LatestVersion:  &testDatabaseServiceTypeLatestVersion,
-			Name:           &testDatabaseServiceTypeName,
-			Plans: &[]papi.DbaasPlan{{
-				BackupConfig: &papi.DbaasBackupConfig{
-					Interval:     &testDatabasePlanBackupConfigInterval,
-					MaxCount:     &testDatabasePlanBackupConfigMaxCount,
-					RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
-				},
-				DiskSpace:    &testDatabasePlanDiskSpace,
-				Name:         &testDatabasePlanName,
-				NodeCount:    &testDatabasePlanNodeCount,
-				NodeCpuCount: &testDatabasePlanNodeCPUCount,
-				NodeMemory:   &testDatabasePlanNodeMemory,
-			}},
-			UserConfigSchema: &papi.DbaasServiceType_UserConfigSchema{
-				AdditionalProperties: map[string]interface{}{"k": "v"},
-			},
-		})
-
-	expected := &DatabaseServiceType{
-		DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
-		Description:    &testDatabaseServiceTypeDescription,
-		LatestVersion:  &testDatabaseServiceTypeLatestVersion,
-		Name:           (*string)(&testDatabaseServiceTypeName),
-		Plans: []*DatabasePlan{{
-			BackupConfig: &DatabaseBackupConfig{
-				Interval:     &testDatabasePlanBackupConfigInterval,
-				MaxCount:     &testDatabasePlanBackupConfigMaxCount,
-				RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
-			},
-			DiskSpace:  &testDatabasePlanDiskSpace,
-			Name:       &testDatabasePlanName,
-			Nodes:      &testDatabasePlanNodeCount,
-			NodeCPUs:   &testDatabasePlanNodeCPUCount,
-			NodeMemory: &testDatabasePlanNodeMemory,
-		}},
-		UserConfigSchema: map[string]interface{}{"k": "v"},
-	}
-
-	actual, err := ts.client.GetDatabaseServiceType(context.Background(), testZone, *expected.Name)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_ListDatabaseServiceTypes() {
-	ts.mockAPIRequest("GET", "/dbaas-service-type", struct {
-		DatabaseServiceTypes *[]papi.DbaasServiceType `json:"dbaas-service-types,omitempty"`
-	}{
-		DatabaseServiceTypes: &[]papi.DbaasServiceType{{
-			DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
-			Description:    &testDatabaseServiceTypeDescription,
-			LatestVersion:  &testDatabaseServiceTypeLatestVersion,
-			Name:           &testDatabaseServiceTypeName,
-			Plans: &[]papi.DbaasPlan{{
-				BackupConfig: &papi.DbaasBackupConfig{
-					Interval:     &testDatabasePlanBackupConfigInterval,
-					MaxCount:     &testDatabasePlanBackupConfigMaxCount,
-					RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
-				},
-				DiskSpace:    &testDatabasePlanDiskSpace,
-				Name:         &testDatabasePlanName,
-				NodeCount:    &testDatabasePlanNodeCount,
-				NodeCpuCount: &testDatabasePlanNodeCPUCount,
-				NodeMemory:   &testDatabasePlanNodeMemory,
-			}},
-			UserConfigSchema: &papi.DbaasServiceType_UserConfigSchema{
-				AdditionalProperties: map[string]interface{}{"k": "v"},
-			},
-		}},
-	})
-
-	expected := []*DatabaseServiceType{{
-		DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
-		Description:    &testDatabaseServiceTypeDescription,
-		LatestVersion:  &testDatabaseServiceTypeLatestVersion,
-		Name:           (*string)(&testDatabaseServiceTypeName),
-		Plans: []*DatabasePlan{{
-			BackupConfig: &DatabaseBackupConfig{
-				Interval:     &testDatabasePlanBackupConfigInterval,
-				MaxCount:     &testDatabasePlanBackupConfigMaxCount,
-				RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
-			},
-			DiskSpace:  &testDatabasePlanDiskSpace,
-			Name:       &testDatabasePlanName,
-			Nodes:      &testDatabasePlanNodeCount,
-			NodeCPUs:   &testDatabasePlanNodeCPUCount,
-			NodeMemory: &testDatabasePlanNodeMemory,
-		}},
-		UserConfigSchema: map[string]interface{}{"k": "v"},
-	}}
-
-	actual, err := ts.client.ListDatabaseServiceTypes(context.Background(), testZone)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
 func (ts *clientTestSuite) TestClient_CreateDatabaseService() {
 	var (
 		testID             = ts.randomID()
@@ -293,100 +191,41 @@ func (ts *clientTestSuite) TestClient_CreateDatabaseService() {
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *clientTestSuite) TestClient_ListDatabaseServices() {
-	ts.mockAPIRequest("GET", "/dbaas-service", struct {
-		DatabaseServices *[]papi.DbaasService `json:"dbaas-services,omitempty"`
-	}{
-		DatabaseServices: &[]papi.DbaasService{{
-			Acl: &[]papi.DbaasServiceAcl{},
-			Backups: &[]papi.DbaasServiceBackup{{
-				BackupName: testDatabaseServiceBackupName,
-				BackupTime: testDatabaseServiceBackupTime,
-				DataSize:   testDatabaseServiceBackupDataSize,
-			}},
-			Components: &[]papi.DbaasServiceComponents{{
-				Component: "pg",
-				Host:      "host",
-				Port:      12345,
-				Route:     papi.DbaasServiceComponentsRouteDynamic,
-				Usage:     papi.DbaasServiceComponentsUsagePrimary,
-			}},
-			ConnectionInfo:  &papi.DbaasService_ConnectionInfo{AdditionalProperties: map[string]interface{}{"k": "v"}},
-			ConnectionPools: &[]papi.DbaasServiceConnectionPools{},
-			CreatedAt:       &testDatabaseServiceCreatedAt,
-			Description:     &testDatabaseServiceDescription,
-			DiskSize:        &testDatabaseServiceDiskSize,
-			Features:        &papi.DbaasService_Features{AdditionalProperties: map[string]interface{}{"k": "v"}},
-			Integrations:    &[]papi.DbaasServiceIntegration{},
-			Maintenance: &papi.DbaasServiceMaintenance{
-				Dow:     testDatabaseServiceMaintenanceDOW,
-				Time:    testDatabaseServiceMaintenanceTime,
-				Updates: []papi.DbaasServiceUpdate{},
-			},
-			Metadata:     &papi.DbaasService_Metadata{AdditionalProperties: map[string]interface{}{"k": "v"}},
-			Name:         papi.DbaasServiceName(testDatabaseServiceName),
-			NodeCount:    &testDatabaseServiceNodeCount,
-			NodeCpuCount: &testDatabaseServiceNodeCPUCount,
-			NodeMemory:   &testDatabaseServiceNodeMemory,
-			NodeStates: &[]papi.DbaasNodeState{{
-				Name:            ts.randomString(10),
-				ProgressUpdates: &[]papi.DbaasNodeStateProgressUpdate{},
-				Role:            &testDatabaseServiceNodeStateRole,
-				State:           testDatabaseServiceNodeStateState,
-			}},
-			Notifications:         &[]papi.DbaasServiceNotification{},
-			Plan:                  testDatabasePlanName,
-			State:                 &testDatabaseServiceState,
-			TerminationProtection: &testDatabaseServiceTerminationProtection,
-			Type:                  testDatabaseServiceType,
-			UpdatedAt:             &testDatabaseServiceUpdatedAt,
-			Uri:                   &testDatabaseServiceURI,
-			UriParams:             &papi.DbaasService_UriParams{AdditionalProperties: map[string]interface{}{"k": "v"}},
-			UserConfig:            &papi.DbaasService_UserConfig{AdditionalProperties: map[string]interface{}{"k": "v"}},
-			Users: &[]papi.DbaasServiceUser{{
-				Password: &testDatabaseServiceUserPassword,
-				Type:     testDatabaseServiceUserType,
-				Username: testDatabaseServiceUserUsername,
-			}},
-		}},
+func (ts *clientTestSuite) TestClient_DeleteDatabaseService() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/dbaas-service/%s", testDatabaseServiceName),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testDatabaseServiceName},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testDatabaseServiceName},
 	})
 
-	expected := []*DatabaseService{{
-		Backups: []*DatabaseServiceBackup{{
-			Name: &testDatabaseServiceBackupName,
-			Size: &testDatabaseServiceBackupDataSize,
-			Date: &testDatabaseServiceBackupTime,
-		}},
-		ConnectionInfo: map[string]interface{}{"k": "v"},
-		CreatedAt:      &testDatabaseServiceCreatedAt,
-		DiskSize:       &testDatabaseServiceDiskSize,
-		Features:       map[string]interface{}{"k": "v"},
-		Maintenance: &DatabaseServiceMaintenance{
-			DOW:  string(testDatabaseServiceMaintenanceDOW),
-			Time: testDatabaseServiceMaintenanceTime,
-		},
-		Metadata:              map[string]interface{}{"k": "v"},
-		Name:                  &testDatabaseServiceName,
-		Nodes:                 &testDatabaseServiceNodeCount,
-		NodeCPUs:              &testDatabaseServiceNodeCPUCount,
-		NodeMemory:            &testDatabaseServiceNodeMemory,
-		Plan:                  &testDatabasePlanName,
-		State:                 (*string)(&testDatabaseServiceState),
-		TerminationProtection: &testDatabaseServiceTerminationProtection,
-		Type:                  (*string)(&testDatabaseServiceType),
-		UpdatedAt:             &testDatabaseServiceUpdatedAt,
-		URI:                   func() *url.URL { u, _ := url.Parse(testDatabaseServiceURI); return u }(),
-		UserConfig:            &map[string]interface{}{"k": "v"},
-		Users: []*DatabaseServiceUser{{
-			Password: &testDatabaseServiceUserPassword,
-			Type:     &testDatabaseServiceUserType,
-			UserName: &testDatabaseServiceUserUsername,
-		}},
-	}}
-
-	actual, err := ts.client.ListDatabaseServices(context.Background(), testZone)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
+	ts.Require().NoError(ts.client.DeleteDatabaseService(
+		context.Background(),
+		testZone,
+		&DatabaseService{Name: &testDatabaseServiceName}),
+	)
+	ts.Require().True(deleted)
 }
 
 func (ts *clientTestSuite) TestClient_GetDatabaseService() {
@@ -483,6 +322,204 @@ func (ts *clientTestSuite) TestClient_GetDatabaseService() {
 	ts.Require().Equal(expected, actual)
 }
 
+func (ts *clientTestSuite) TestClient_GetDatabaseServiceType() {
+	ts.mockAPIRequest("GET",
+		fmt.Sprintf("/dbaas-service-type/%s", testDatabaseServiceTypeName),
+		papi.DbaasServiceType{
+			DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
+			Description:    &testDatabaseServiceTypeDescription,
+			LatestVersion:  &testDatabaseServiceTypeLatestVersion,
+			Name:           &testDatabaseServiceTypeName,
+			Plans: &[]papi.DbaasPlan{{
+				BackupConfig: &papi.DbaasBackupConfig{
+					Interval:     &testDatabasePlanBackupConfigInterval,
+					MaxCount:     &testDatabasePlanBackupConfigMaxCount,
+					RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
+				},
+				DiskSpace:    &testDatabasePlanDiskSpace,
+				Name:         &testDatabasePlanName,
+				NodeCount:    &testDatabasePlanNodeCount,
+				NodeCpuCount: &testDatabasePlanNodeCPUCount,
+				NodeMemory:   &testDatabasePlanNodeMemory,
+			}},
+			UserConfigSchema: &papi.DbaasServiceType_UserConfigSchema{
+				AdditionalProperties: map[string]interface{}{"k": "v"},
+			},
+		})
+
+	expected := &DatabaseServiceType{
+		DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
+		Description:    &testDatabaseServiceTypeDescription,
+		LatestVersion:  &testDatabaseServiceTypeLatestVersion,
+		Name:           (*string)(&testDatabaseServiceTypeName),
+		Plans: []*DatabasePlan{{
+			BackupConfig: &DatabaseBackupConfig{
+				Interval:     &testDatabasePlanBackupConfigInterval,
+				MaxCount:     &testDatabasePlanBackupConfigMaxCount,
+				RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
+			},
+			DiskSpace:  &testDatabasePlanDiskSpace,
+			Name:       &testDatabasePlanName,
+			Nodes:      &testDatabasePlanNodeCount,
+			NodeCPUs:   &testDatabasePlanNodeCPUCount,
+			NodeMemory: &testDatabasePlanNodeMemory,
+		}},
+		UserConfigSchema: map[string]interface{}{"k": "v"},
+	}
+
+	actual, err := ts.client.GetDatabaseServiceType(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListDatabaseServiceTypes() {
+	ts.mockAPIRequest("GET", "/dbaas-service-type", struct {
+		DatabaseServiceTypes *[]papi.DbaasServiceType `json:"dbaas-service-types,omitempty"`
+	}{
+		DatabaseServiceTypes: &[]papi.DbaasServiceType{{
+			DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
+			Description:    &testDatabaseServiceTypeDescription,
+			LatestVersion:  &testDatabaseServiceTypeLatestVersion,
+			Name:           &testDatabaseServiceTypeName,
+			Plans: &[]papi.DbaasPlan{{
+				BackupConfig: &papi.DbaasBackupConfig{
+					Interval:     &testDatabasePlanBackupConfigInterval,
+					MaxCount:     &testDatabasePlanBackupConfigMaxCount,
+					RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
+				},
+				DiskSpace:    &testDatabasePlanDiskSpace,
+				Name:         &testDatabasePlanName,
+				NodeCount:    &testDatabasePlanNodeCount,
+				NodeCpuCount: &testDatabasePlanNodeCPUCount,
+				NodeMemory:   &testDatabasePlanNodeMemory,
+			}},
+			UserConfigSchema: &papi.DbaasServiceType_UserConfigSchema{
+				AdditionalProperties: map[string]interface{}{"k": "v"},
+			},
+		}},
+	})
+
+	expected := []*DatabaseServiceType{{
+		DefaultVersion: &testDatabaseServiceTypeDefaultVersion,
+		Description:    &testDatabaseServiceTypeDescription,
+		LatestVersion:  &testDatabaseServiceTypeLatestVersion,
+		Name:           (*string)(&testDatabaseServiceTypeName),
+		Plans: []*DatabasePlan{{
+			BackupConfig: &DatabaseBackupConfig{
+				Interval:     &testDatabasePlanBackupConfigInterval,
+				MaxCount:     &testDatabasePlanBackupConfigMaxCount,
+				RecoveryMode: &testDatabasePlanBackupConfigRecoveryMode,
+			},
+			DiskSpace:  &testDatabasePlanDiskSpace,
+			Name:       &testDatabasePlanName,
+			Nodes:      &testDatabasePlanNodeCount,
+			NodeCPUs:   &testDatabasePlanNodeCPUCount,
+			NodeMemory: &testDatabasePlanNodeMemory,
+		}},
+		UserConfigSchema: map[string]interface{}{"k": "v"},
+	}}
+
+	actual, err := ts.client.ListDatabaseServiceTypes(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListDatabaseServices() {
+	ts.mockAPIRequest("GET", "/dbaas-service", struct {
+		DatabaseServices *[]papi.DbaasService `json:"dbaas-services,omitempty"`
+	}{
+		DatabaseServices: &[]papi.DbaasService{{
+			Acl: &[]papi.DbaasServiceAcl{},
+			Backups: &[]papi.DbaasServiceBackup{{
+				BackupName: testDatabaseServiceBackupName,
+				BackupTime: testDatabaseServiceBackupTime,
+				DataSize:   testDatabaseServiceBackupDataSize,
+			}},
+			Components: &[]papi.DbaasServiceComponents{{
+				Component: "pg",
+				Host:      "host",
+				Port:      12345,
+				Route:     papi.DbaasServiceComponentsRouteDynamic,
+				Usage:     papi.DbaasServiceComponentsUsagePrimary,
+			}},
+			ConnectionInfo:  &papi.DbaasService_ConnectionInfo{AdditionalProperties: map[string]interface{}{"k": "v"}},
+			ConnectionPools: &[]papi.DbaasServiceConnectionPools{},
+			CreatedAt:       &testDatabaseServiceCreatedAt,
+			Description:     &testDatabaseServiceDescription,
+			DiskSize:        &testDatabaseServiceDiskSize,
+			Features:        &papi.DbaasService_Features{AdditionalProperties: map[string]interface{}{"k": "v"}},
+			Integrations:    &[]papi.DbaasServiceIntegration{},
+			Maintenance: &papi.DbaasServiceMaintenance{
+				Dow:     testDatabaseServiceMaintenanceDOW,
+				Time:    testDatabaseServiceMaintenanceTime,
+				Updates: []papi.DbaasServiceUpdate{},
+			},
+			Metadata:     &papi.DbaasService_Metadata{AdditionalProperties: map[string]interface{}{"k": "v"}},
+			Name:         papi.DbaasServiceName(testDatabaseServiceName),
+			NodeCount:    &testDatabaseServiceNodeCount,
+			NodeCpuCount: &testDatabaseServiceNodeCPUCount,
+			NodeMemory:   &testDatabaseServiceNodeMemory,
+			NodeStates: &[]papi.DbaasNodeState{{
+				Name:            ts.randomString(10),
+				ProgressUpdates: &[]papi.DbaasNodeStateProgressUpdate{},
+				Role:            &testDatabaseServiceNodeStateRole,
+				State:           testDatabaseServiceNodeStateState,
+			}},
+			Notifications:         &[]papi.DbaasServiceNotification{},
+			Plan:                  testDatabasePlanName,
+			State:                 &testDatabaseServiceState,
+			TerminationProtection: &testDatabaseServiceTerminationProtection,
+			Type:                  testDatabaseServiceType,
+			UpdatedAt:             &testDatabaseServiceUpdatedAt,
+			Uri:                   &testDatabaseServiceURI,
+			UriParams:             &papi.DbaasService_UriParams{AdditionalProperties: map[string]interface{}{"k": "v"}},
+			UserConfig:            &papi.DbaasService_UserConfig{AdditionalProperties: map[string]interface{}{"k": "v"}},
+			Users: &[]papi.DbaasServiceUser{{
+				Password: &testDatabaseServiceUserPassword,
+				Type:     testDatabaseServiceUserType,
+				Username: testDatabaseServiceUserUsername,
+			}},
+		}},
+	})
+
+	expected := []*DatabaseService{{
+		Backups: []*DatabaseServiceBackup{{
+			Name: &testDatabaseServiceBackupName,
+			Size: &testDatabaseServiceBackupDataSize,
+			Date: &testDatabaseServiceBackupTime,
+		}},
+		ConnectionInfo: map[string]interface{}{"k": "v"},
+		CreatedAt:      &testDatabaseServiceCreatedAt,
+		DiskSize:       &testDatabaseServiceDiskSize,
+		Features:       map[string]interface{}{"k": "v"},
+		Maintenance: &DatabaseServiceMaintenance{
+			DOW:  string(testDatabaseServiceMaintenanceDOW),
+			Time: testDatabaseServiceMaintenanceTime,
+		},
+		Metadata:              map[string]interface{}{"k": "v"},
+		Name:                  &testDatabaseServiceName,
+		Nodes:                 &testDatabaseServiceNodeCount,
+		NodeCPUs:              &testDatabaseServiceNodeCPUCount,
+		NodeMemory:            &testDatabaseServiceNodeMemory,
+		Plan:                  &testDatabasePlanName,
+		State:                 (*string)(&testDatabaseServiceState),
+		TerminationProtection: &testDatabaseServiceTerminationProtection,
+		Type:                  (*string)(&testDatabaseServiceType),
+		UpdatedAt:             &testDatabaseServiceUpdatedAt,
+		URI:                   func() *url.URL { u, _ := url.Parse(testDatabaseServiceURI); return u }(),
+		UserConfig:            &map[string]interface{}{"k": "v"},
+		Users: []*DatabaseServiceUser{{
+			Password: &testDatabaseServiceUserPassword,
+			Type:     &testDatabaseServiceUserType,
+			UserName: &testDatabaseServiceUserUsername,
+		}},
+	}}
+
+	actual, err := ts.client.ListDatabaseServices(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_UpdateDatabaseService() {
 	var (
 		testID             = ts.randomID()
@@ -544,37 +581,4 @@ func (ts *clientTestSuite) TestClient_UpdateDatabaseService() {
 		UserConfig:            &map[string]interface{}{"k": "v"},
 	}))
 	ts.Require().True(updated)
-}
-
-func (ts *clientTestSuite) TestClient_DeleteDatabaseService() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		deleted            = false
-	)
-
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/dbaas-service/%s", testDatabaseServiceName),
-		func(req *http.Request) (*http.Response, error) {
-			deleted = true
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testDatabaseServiceName},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testDatabaseServiceName},
-	})
-
-	ts.Require().NoError(ts.client.DeleteDatabaseService(context.Background(), testZone, testDatabaseServiceName))
-	ts.Require().True(deleted)
 }

--- a/v2/deploy_target_test.go
+++ b/v2/deploy_target_test.go
@@ -14,59 +14,6 @@ var (
 	testDeployTargetType        = "dedicated"
 )
 
-func (ts *clientTestSuite) TestClient_ListDeployTargets() {
-	ts.mockAPIRequest("GET", "/deploy-target", struct {
-		DeployTargets *[]papi.DeployTarget `json:"deploy-targets,omitempty"`
-	}{
-		DeployTargets: &[]papi.DeployTarget{{
-			Description: &testDeployTargetDescription,
-			Id:          &testDeployTargetID,
-			Name:        &testDeployTargetName,
-			Type: func() *papi.DeployTargetType {
-				v := papi.DeployTargetType(testDeployTargetType)
-				return &v
-			}(),
-		}},
-	})
-
-	expected := []*DeployTarget{{
-		Description: &testDeployTargetDescription,
-		ID:          &testDeployTargetID,
-		Name:        &testDeployTargetName,
-		Type:        &testDeployTargetType,
-	}}
-
-	actual, err := ts.client.ListDeployTargets(context.Background(), testZone)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_GetDeployTarget() {
-	ts.mockAPIRequest(
-		"GET",
-		fmt.Sprintf("/deploy-target/%s", testDeployTargetID),
-		papi.DeployTarget{
-			Description: &testDeployTargetDescription,
-			Id:          &testDeployTargetID,
-			Name:        &testDeployTargetName,
-			Type: func() *papi.DeployTargetType {
-				v := papi.DeployTargetType(testDeployTargetType)
-				return &v
-			}(),
-		})
-
-	expected := &DeployTarget{
-		Description: &testDeployTargetDescription,
-		ID:          &testDeployTargetID,
-		Name:        &testDeployTargetName,
-		Type:        &testDeployTargetType,
-	}
-
-	actual, err := ts.client.GetDeployTarget(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
 func (ts *clientTestSuite) TestClient_FindDeployTarget() {
 	ts.mockAPIRequest("GET", "/deploy-target", struct {
 		DeployTargets *[]papi.DeployTarget `json:"deploy-targets,omitempty"`
@@ -107,6 +54,59 @@ func (ts *clientTestSuite) TestClient_FindDeployTarget() {
 	ts.Require().Equal(expected, actual)
 
 	actual, err = ts.client.FindDeployTarget(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetDeployTarget() {
+	ts.mockAPIRequest(
+		"GET",
+		fmt.Sprintf("/deploy-target/%s", testDeployTargetID),
+		papi.DeployTarget{
+			Description: &testDeployTargetDescription,
+			Id:          &testDeployTargetID,
+			Name:        &testDeployTargetName,
+			Type: func() *papi.DeployTargetType {
+				v := papi.DeployTargetType(testDeployTargetType)
+				return &v
+			}(),
+		})
+
+	expected := &DeployTarget{
+		Description: &testDeployTargetDescription,
+		ID:          &testDeployTargetID,
+		Name:        &testDeployTargetName,
+		Type:        &testDeployTargetType,
+	}
+
+	actual, err := ts.client.GetDeployTarget(context.Background(), testZone, *expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListDeployTargets() {
+	ts.mockAPIRequest("GET", "/deploy-target", struct {
+		DeployTargets *[]papi.DeployTarget `json:"deploy-targets,omitempty"`
+	}{
+		DeployTargets: &[]papi.DeployTarget{{
+			Description: &testDeployTargetDescription,
+			Id:          &testDeployTargetID,
+			Name:        &testDeployTargetName,
+			Type: func() *papi.DeployTargetType {
+				v := papi.DeployTargetType(testDeployTargetType)
+				return &v
+			}(),
+		}},
+	})
+
+	expected := []*DeployTarget{{
+		Description: &testDeployTargetDescription,
+		ID:          &testDeployTargetID,
+		Name:        &testDeployTargetName,
+		Type:        &testDeployTargetType,
+	}}
+
+	actual, err := ts.client.ListDeployTargets(context.Background(), testZone)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }

--- a/v2/instance_type.go
+++ b/v2/instance_type.go
@@ -44,7 +44,7 @@ func instanceTypeFromAPI(t *papi.InstanceType) *InstanceType {
 	}
 }
 
-// ListInstanceTypes returns the list of existing Instance types in the specified zone.
+// ListInstanceTypes returns the list of existing Instance types.
 func (c *Client) ListInstanceTypes(ctx context.Context, zone string) ([]*InstanceType, error) {
 	list := make([]*InstanceType, 0)
 
@@ -62,7 +62,7 @@ func (c *Client) ListInstanceTypes(ctx context.Context, zone string) ([]*Instanc
 	return list, nil
 }
 
-// GetInstanceType returns the Instance type corresponding to the specified ID in the specified zone.
+// GetInstanceType returns the Instance type corresponding to the specified ID.
 func (c *Client) GetInstanceType(ctx context.Context, zone, id string) (*InstanceType, error) {
 	resp, err := c.GetInstanceTypeWithResponse(apiv2.WithZone(ctx, zone), id)
 	if err != nil {
@@ -72,13 +72,13 @@ func (c *Client) GetInstanceType(ctx context.Context, zone, id string) (*Instanc
 	return instanceTypeFromAPI(resp.JSON200), nil
 }
 
-// FindInstanceType attempts to find an Instance type by family+size or ID in the specified zone.
+// FindInstanceType attempts to find an Instance type by family+size or ID.
 // To search by family+size, the expected format for v is "[FAMILY.]SIZE" (e.g. "large", "gpu.medium"),
 // with family defaulting to "standard" if not specified.
-func (c *Client) FindInstanceType(ctx context.Context, zone, v string) (*InstanceType, error) {
+func (c *Client) FindInstanceType(ctx context.Context, zone, x string) (*InstanceType, error) {
 	var typeFamily, typeSize string
 
-	parts := strings.SplitN(v, ".", 2)
+	parts := strings.SplitN(x, ".", 2)
 	if l := len(parts); l > 0 {
 		if l == 1 {
 			typeFamily, typeSize = "standard", strings.ToLower(parts[0])
@@ -93,7 +93,7 @@ func (c *Client) FindInstanceType(ctx context.Context, zone, v string) (*Instanc
 	}
 
 	for _, r := range res {
-		if *r.ID == v || (*r.Family == typeFamily && *r.Size == typeSize) {
+		if *r.ID == x || (*r.Family == typeFamily && *r.Size == typeSize) {
 			return c.GetInstanceType(ctx, zone, *r.ID)
 		}
 	}

--- a/v2/private_network.go
+++ b/v2/private_network.go
@@ -23,12 +23,9 @@ type PrivateNetwork struct {
 	Netmask     *net.IP
 	StartIP     *net.IP
 	Leases      []*PrivateNetworkLease
-
-	c    *Client
-	zone string
 }
 
-func privateNetworkFromAPI(client *Client, zone string, p *papi.PrivateNetwork) *PrivateNetwork {
+func privateNetworkFromAPI(p *papi.PrivateNetwork) *PrivateNetwork {
 	return &PrivateNetwork{
 		Description: p.Description,
 		EndIP: func() (v *net.IP) {
@@ -66,41 +63,10 @@ func privateNetworkFromAPI(client *Client, zone string, p *papi.PrivateNetwork) 
 			}
 			return
 		}(),
-
-		c:    client,
-		zone: zone,
 	}
 }
 
-func (p PrivateNetwork) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
-	return client.GetPrivateNetwork(ctx, zone, id)
-}
-
-// UpdateInstanceIPAddress updates the IP address of a Compute instance attached to the managed Private Network.
-func (p *PrivateNetwork) UpdateInstanceIPAddress(ctx context.Context, instance *Instance, ip net.IP) error {
-	resp, err := p.c.UpdatePrivateNetworkInstanceIpWithResponse(
-		apiv2.WithZone(ctx, p.zone),
-		*p.ID,
-		papi.UpdatePrivateNetworkInstanceIpJSONRequestBody{
-			Instance: papi.Instance{Id: instance.ID},
-			Ip: func() *string {
-				s := ip.String()
-				return &s
-			}(),
-		})
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(p.c.timeout).
-		WithInterval(p.c.pollInterval).
-		Poll(ctx, p.c.OperationPoller(p.zone, *resp.JSON200.Id))
-
-	return err
-}
-
-// CreatePrivateNetwork creates a Private Network in the specified zone.
+// CreatePrivateNetwork creates a Private Network.
 func (c *Client) CreatePrivateNetwork(
 	ctx context.Context,
 	zone string,
@@ -152,37 +118,27 @@ func (c *Client) CreatePrivateNetwork(
 	return c.GetPrivateNetwork(ctx, zone, *res.(*papi.Reference).Id)
 }
 
-// ListPrivateNetworks returns the list of existing Private Networks in the specified zone.
-func (c *Client) ListPrivateNetworks(ctx context.Context, zone string) ([]*PrivateNetwork, error) {
-	list := make([]*PrivateNetwork, 0)
-
-	resp, err := c.ListPrivateNetworksWithResponse(apiv2.WithZone(ctx, zone))
+// DeletePrivateNetwork deletes a Private Network.
+func (c *Client) DeletePrivateNetwork(ctx context.Context, zone string, privateNetwork *PrivateNetwork) error {
+	resp, err := c.DeletePrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), *privateNetwork.ID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if resp.JSON200.PrivateNetworks != nil {
-		for i := range *resp.JSON200.PrivateNetworks {
-			list = append(list, privateNetworkFromAPI(c, zone, &(*resp.JSON200.PrivateNetworks)[i]))
-		}
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
 	}
 
-	return list, nil
+	return nil
 }
 
-// GetPrivateNetwork returns the Private Network corresponding to the specified ID in the specified zone.
-func (c *Client) GetPrivateNetwork(ctx context.Context, zone, id string) (*PrivateNetwork, error) {
-	resp, err := c.GetPrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return nil, err
-	}
-
-	return privateNetworkFromAPI(c, zone, resp.JSON200), nil
-}
-
-// FindPrivateNetwork attempts to find a Private Network by name or ID in the specified zone.
+// FindPrivateNetwork attempts to find a Private Network by name or ID.
 // In case the identifier is a name and multiple resources match, an ErrTooManyFound error is returned.
-func (c *Client) FindPrivateNetwork(ctx context.Context, zone, v string) (*PrivateNetwork, error) {
+func (c *Client) FindPrivateNetwork(ctx context.Context, zone, x string) (*PrivateNetwork, error) {
 	res, err := c.ListPrivateNetworks(ctx, zone)
 	if err != nil {
 		return nil, err
@@ -190,14 +146,14 @@ func (c *Client) FindPrivateNetwork(ctx context.Context, zone, v string) (*Priva
 
 	var found *PrivateNetwork
 	for _, r := range res {
-		if *r.ID == v {
+		if *r.ID == x {
 			return c.GetPrivateNetwork(ctx, zone, *r.ID)
 		}
 
 		// Historically, the Exoscale API allowed users to create multiple Private Networks sharing a common name.
 		// This function being expected to return one resource at most, in case the specified identifier is a name
 		// we have to check that there aren't more that one matching result before returning it.
-		if *r.Name == v {
+		if *r.Name == x {
 			if found != nil {
 				return nil, apiv2.ErrTooManyFound
 			}
@@ -212,7 +168,35 @@ func (c *Client) FindPrivateNetwork(ctx context.Context, zone, v string) (*Priva
 	return nil, apiv2.ErrNotFound
 }
 
-// UpdatePrivateNetwork updates the specified Private Network in the specified zone.
+// GetPrivateNetwork returns the Private Network corresponding to the specified ID.
+func (c *Client) GetPrivateNetwork(ctx context.Context, zone, id string) (*PrivateNetwork, error) {
+	resp, err := c.GetPrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return privateNetworkFromAPI(resp.JSON200), nil
+}
+
+// ListPrivateNetworks returns the list of existing Private Networks.
+func (c *Client) ListPrivateNetworks(ctx context.Context, zone string) ([]*PrivateNetwork, error) {
+	list := make([]*PrivateNetwork, 0)
+
+	resp, err := c.ListPrivateNetworksWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.PrivateNetworks != nil {
+		for i := range *resp.JSON200.PrivateNetworks {
+			list = append(list, privateNetworkFromAPI(&(*resp.JSON200.PrivateNetworks)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// UpdatePrivateNetwork updates a Private Network.
 func (c *Client) UpdatePrivateNetwork(ctx context.Context, zone string, privateNetwork *PrivateNetwork) error {
 	if err := validateOperationParams(privateNetwork, "update"); err != nil {
 		return err
@@ -261,9 +245,25 @@ func (c *Client) UpdatePrivateNetwork(ctx context.Context, zone string, privateN
 	return nil
 }
 
-// DeletePrivateNetwork deletes the specified Private Network in the specified zone.
-func (c *Client) DeletePrivateNetwork(ctx context.Context, zone, id string) error {
-	resp, err := c.DeletePrivateNetworkWithResponse(apiv2.WithZone(ctx, zone), id)
+// UpdatePrivateNetworkInstanceIPAddress updates the IP address of a Compute instance attached to a managed
+// Private Network.
+func (c *Client) UpdatePrivateNetworkInstanceIPAddress(
+	ctx context.Context,
+	zone string,
+	instance *Instance,
+	privateNetwork *PrivateNetwork,
+	ip net.IP,
+) error {
+	resp, err := c.UpdatePrivateNetworkInstanceIpWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*privateNetwork.ID,
+		papi.UpdatePrivateNetworkInstanceIpJSONRequestBody{
+			Instance: papi.Instance{Id: instance.ID},
+			Ip: func() *string {
+				s := ip.String()
+				return &s
+			}(),
+		})
 	if err != nil {
 		return err
 	}
@@ -272,9 +272,6 @@ func (c *Client) DeletePrivateNetwork(ctx context.Context, zone, id string) erro
 		WithTimeout(c.timeout).
 		WithInterval(c.pollInterval).
 		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }

--- a/v2/private_network_test.go
+++ b/v2/private_network_test.go
@@ -27,83 +27,6 @@ var (
 	testPrivateNetworkLeaseIPAddressP = net.ParseIP(testPrivateNetworkLeaseIPAddress)
 )
 
-func (ts *clientTestSuite) TestPrivateNetwork_get() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID), papi.PrivateNetwork{
-		Id:   &testPrivateNetworkID,
-		Name: &testPrivateNetworkName,
-	})
-
-	expected := &PrivateNetwork{
-		ID:   &testPrivateNetworkID,
-		Name: &testPrivateNetworkName,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := new(PrivateNetwork).get(context.Background(), ts.client, testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestPrivateNetwork_UpdateInstanceIPAddress() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		updated            = false
-	)
-
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("/private-network/%s:update-ip", testPrivateNetworkID),
-		func(req *http.Request) (*http.Response, error) {
-			updated = true
-
-			var actual papi.UpdatePrivateNetworkInstanceIpJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.UpdatePrivateNetworkInstanceIpJSONRequestBody{
-				Instance: papi.Instance{Id: &testPrivateNetworkLeaseInstanceID},
-				Ip:       &testPrivateNetworkLeaseIPAddress,
-			}
-
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testPrivateNetworkID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testPrivateNetworkID},
-	})
-
-	privateNetwork := &PrivateNetwork{
-		ID: &testPrivateNetworkID,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	instance := &Instance{
-		ID: &testPrivateNetworkLeaseInstanceID,
-	}
-
-	ts.Require().NoError(privateNetwork.UpdateInstanceIPAddress(
-		context.Background(),
-		instance,
-		testPrivateNetworkLeaseIPAddressP),
-	)
-	ts.Require().True(updated)
-}
-
 func (ts *clientTestSuite) TestClient_CreatePrivateNetwork() {
 	var (
 		testOperationID    = ts.randomID()
@@ -158,9 +81,6 @@ func (ts *clientTestSuite) TestClient_CreatePrivateNetwork() {
 		Name:        &testPrivateNetworkName,
 		Netmask:     &testPrivateNetworkNetmaskP,
 		StartIP:     &testPrivateNetworkStartIPP,
-
-		c:    ts.client,
-		zone: testZone,
 	}
 
 	actual, err := ts.client.CreatePrivateNetwork(context.Background(), testZone, &PrivateNetwork{
@@ -171,6 +91,117 @@ func (ts *clientTestSuite) TestClient_CreatePrivateNetwork() {
 		Netmask:     &testPrivateNetworkNetmaskP,
 		StartIP:     &testPrivateNetworkStartIPP,
 	})
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_DeletePrivateNetwork() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/private-network/%s", testPrivateNetworkID),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testPrivateNetworkID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testPrivateNetworkID},
+	})
+
+	ts.Require().NoError(ts.client.DeletePrivateNetwork(
+		context.Background(),
+		testZone,
+		&PrivateNetwork{ID: &testPrivateNetworkID},
+	))
+	ts.Require().True(deleted)
+}
+
+func (ts *clientTestSuite) TestClient_FindPrivateNetwork() {
+	ts.mockAPIRequest("GET", "/private-network", struct {
+		PrivateNetworks *[]papi.PrivateNetwork `json:"private-networks,omitempty"`
+	}{
+		PrivateNetworks: &[]papi.PrivateNetwork{
+			{
+				Id:   &testPrivateNetworkID,
+				Name: &testPrivateNetworkName,
+			},
+			{
+				Id:   func() *string { id := ts.randomID(); return &id }(),
+				Name: func() *string { name := "dup"; return &name }(),
+			},
+			{
+				Id:   func() *string { id := ts.randomID(); return &id }(),
+				Name: func() *string { name := "dup"; return &name }(),
+			},
+		},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID), papi.PrivateNetwork{
+		Id:   &testPrivateNetworkID,
+		Name: &testPrivateNetworkName,
+	})
+
+	expected := &PrivateNetwork{
+		ID:   &testPrivateNetworkID,
+		Name: &testPrivateNetworkName,
+	}
+
+	actual, err := ts.client.FindPrivateNetwork(context.Background(), testZone, *expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindPrivateNetwork(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	_, err = ts.client.FindPrivateNetwork(context.Background(), testZone, "dup")
+	ts.Require().EqualError(err, apiv2.ErrTooManyFound.Error())
+}
+
+func (ts *clientTestSuite) TestClient_GetPrivateNetwork() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID), papi.PrivateNetwork{
+		Description: &testPrivateNetworkDescription,
+		EndIp:       &testPrivateNetworkEndIP,
+		Id:          &testPrivateNetworkID,
+		Name:        &testPrivateNetworkName,
+		Netmask:     &testPrivateNetworkNetmask,
+		StartIp:     &testPrivateNetworkStartIP,
+		Leases: &[]papi.PrivateNetworkLease{{
+			InstanceId: &testPrivateNetworkLeaseInstanceID,
+			Ip:         &testPrivateNetworkLeaseIPAddress,
+		}},
+	})
+
+	expected := &PrivateNetwork{
+		Description: &testPrivateNetworkDescription,
+		EndIP:       &testPrivateNetworkEndIPP,
+		ID:          &testPrivateNetworkID,
+		Leases: []*PrivateNetworkLease{{
+			InstanceID: &testPrivateNetworkLeaseInstanceID,
+			IPAddress:  &testPrivateNetworkLeaseIPAddressP,
+		}},
+		Name:    &testPrivateNetworkName,
+		Netmask: &testPrivateNetworkNetmaskP,
+		StartIP: &testPrivateNetworkStartIPP,
+	}
+
+	actual, err := ts.client.GetPrivateNetwork(context.Background(), testZone, *expected.ID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
@@ -204,94 +235,11 @@ func (ts *clientTestSuite) TestClient_ListPrivateNetworks() {
 		Name:    &testPrivateNetworkName,
 		Netmask: &testPrivateNetworkNetmaskP,
 		StartIP: &testPrivateNetworkStartIPP,
-
-		c:    ts.client,
-		zone: testZone,
 	}}
 
 	actual, err := ts.client.ListPrivateNetworks(context.Background(), testZone)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_GetPrivateNetwork() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID), papi.PrivateNetwork{
-		Description: &testPrivateNetworkDescription,
-		EndIp:       &testPrivateNetworkEndIP,
-		Id:          &testPrivateNetworkID,
-		Name:        &testPrivateNetworkName,
-		Netmask:     &testPrivateNetworkNetmask,
-		StartIp:     &testPrivateNetworkStartIP,
-		Leases: &[]papi.PrivateNetworkLease{{
-			InstanceId: &testPrivateNetworkLeaseInstanceID,
-			Ip:         &testPrivateNetworkLeaseIPAddress,
-		}},
-	})
-
-	expected := &PrivateNetwork{
-		Description: &testPrivateNetworkDescription,
-		EndIP:       &testPrivateNetworkEndIPP,
-		ID:          &testPrivateNetworkID,
-		Leases: []*PrivateNetworkLease{{
-			InstanceID: &testPrivateNetworkLeaseInstanceID,
-			IPAddress:  &testPrivateNetworkLeaseIPAddressP,
-		}},
-		Name:    &testPrivateNetworkName,
-		Netmask: &testPrivateNetworkNetmaskP,
-		StartIP: &testPrivateNetworkStartIPP,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := ts.client.GetPrivateNetwork(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_FindPrivateNetwork() {
-	ts.mockAPIRequest("GET", "/private-network", struct {
-		PrivateNetworks *[]papi.PrivateNetwork `json:"private-networks,omitempty"`
-	}{
-		PrivateNetworks: &[]papi.PrivateNetwork{
-			{
-				Id:   &testPrivateNetworkID,
-				Name: &testPrivateNetworkName,
-			},
-			{
-				Id:   func() *string { id := ts.randomID(); return &id }(),
-				Name: func() *string { name := "dup"; return &name }(),
-			},
-			{
-				Id:   func() *string { id := ts.randomID(); return &id }(),
-				Name: func() *string { name := "dup"; return &name }(),
-			},
-		},
-	})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID), papi.PrivateNetwork{
-		Id:   &testPrivateNetworkID,
-		Name: &testPrivateNetworkName,
-	})
-
-	expected := &PrivateNetwork{
-		ID:   &testPrivateNetworkID,
-		Name: &testPrivateNetworkName,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := ts.client.FindPrivateNetwork(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-
-	actual, err = ts.client.FindPrivateNetwork(context.Background(), testZone, *expected.Name)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-
-	_, err = ts.client.FindPrivateNetwork(context.Background(), testZone, "dup")
-	ts.Require().EqualError(err, apiv2.ErrTooManyFound.Error())
 }
 
 func (ts *clientTestSuite) TestClient_UpdatePrivateNetwork() {
@@ -354,16 +302,26 @@ func (ts *clientTestSuite) TestClient_UpdatePrivateNetwork() {
 	ts.Require().True(updated)
 }
 
-func (ts *clientTestSuite) TestClient_DeletePrivateNetwork() {
+func (ts *clientTestSuite) TestClient_UpdatePrivateNetworkInstanceIPAddress() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = papi.OperationStateSuccess
-		deleted            = false
+		updated            = false
 	)
 
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/private-network/%s", testPrivateNetworkID),
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("/private-network/%s:update-ip", testPrivateNetworkID),
 		func(req *http.Request) (*http.Response, error) {
-			deleted = true
+			updated = true
+
+			var actual papi.UpdatePrivateNetworkInstanceIpJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.UpdatePrivateNetworkInstanceIpJSONRequestBody{
+				Instance: papi.Instance{Id: &testPrivateNetworkLeaseInstanceID},
+				Ip:       &testPrivateNetworkLeaseIPAddress,
+			}
+
+			ts.Require().Equal(expected, actual)
 
 			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
 				Id:        &testOperationID,
@@ -383,6 +341,12 @@ func (ts *clientTestSuite) TestClient_DeletePrivateNetwork() {
 		Reference: &papi.Reference{Id: &testPrivateNetworkID},
 	})
 
-	ts.Require().NoError(ts.client.DeletePrivateNetwork(context.Background(), testZone, testPrivateNetworkID))
-	ts.Require().True(deleted)
+	ts.Require().NoError(ts.client.UpdatePrivateNetworkInstanceIPAddress(
+		context.Background(),
+		testZone,
+		&Instance{ID: &testPrivateNetworkLeaseInstanceID},
+		&PrivateNetwork{ID: &testPrivateNetworkID},
+		testPrivateNetworkLeaseIPAddressP),
+	)
+	ts.Require().True(updated)
 }

--- a/v2/quota.go
+++ b/v2/quota.go
@@ -1,0 +1,60 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+// Quota represents an Exoscale organization quota.
+type Quota struct {
+	Resource *string
+	Usage    *int64
+	Limit    *int64
+}
+
+// ToAPIMock returns the low-level representation of the resource. This is intended for testing purposes.
+func (q Quota) ToAPIMock() interface{} {
+	return papi.Quota{
+		Limit:    q.Limit,
+		Resource: q.Resource,
+		Usage:    q.Usage,
+	}
+}
+
+func quotaFromAPI(q *papi.Quota) *Quota {
+	return &Quota{
+		Resource: q.Resource,
+		Usage:    q.Usage,
+		Limit:    q.Limit,
+	}
+}
+
+// ListQuotas returns the list of Exoscale organization quotas.
+func (c *Client) ListQuotas(ctx context.Context, zone string) ([]*Quota, error) {
+	list := make([]*Quota, 0)
+
+	resp, err := c.ListQuotasWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Quotas != nil {
+		for i := range *resp.JSON200.Quotas {
+			list = append(list, quotaFromAPI(&(*resp.JSON200.Quotas)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// GetQuota returns the current Exoscale organization quota for the specified resource.
+func (c *Client) GetQuota(ctx context.Context, zone, resource string) (*Quota, error) {
+	resp, err := c.GetQuotaWithResponse(apiv2.WithZone(ctx, zone), resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return quotaFromAPI(resp.JSON200), nil
+}

--- a/v2/quota_test.go
+++ b/v2/quota_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	papi "github.com/exoscale/egoscale/v2/internal/public-api"
+)
+
+var (
+	testQuotaResource       = "instance"
+	testQuotaLimit    int64 = 2
+	testQuotaUsage    int64 = 1
+)
+
+func (ts *clientTestSuite) TestClient_ListQuotas() {
+	ts.mockAPIRequest("GET", "/quota", struct {
+		Quotas *[]papi.Quota `json:"quotas,omitempty"`
+	}{
+		Quotas: &[]papi.Quota{{
+			Limit:    &testQuotaLimit,
+			Resource: &testQuotaResource,
+			Usage:    &testQuotaUsage,
+		}},
+	})
+
+	expected := []*Quota{{
+		Resource: &testQuotaResource,
+		Usage:    &testQuotaUsage,
+		Limit:    &testQuotaLimit,
+	}}
+
+	actual, err := ts.client.ListQuotas(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetQuota() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/quota/%s", testQuotaResource), papi.Quota{
+		Limit:    &testQuotaLimit,
+		Resource: &testQuotaResource,
+		Usage:    &testQuotaUsage,
+	})
+
+	expected := &Quota{
+		Resource: &testQuotaResource,
+		Usage:    &testQuotaUsage,
+		Limit:    &testQuotaLimit,
+	}
+
+	actual, err := ts.client.GetQuota(context.Background(), testZone, *expected.Resource)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}

--- a/v2/security_group_test.go
+++ b/v2/security_group_test.go
@@ -22,62 +22,68 @@ var (
 	testSecurityGroupRuleICMPType        int64  = 8
 	testSecurityGroupRuleID                     = new(clientTestSuite).randomID()
 	testSecurityGroupRuleNetwork                = "1.2.3.0/24"
+	_, testSecurityGroupRuleNetworkP, _         = net.ParseCIDR(testSecurityGroupRuleNetwork)
 	testSecurityGroupRuleProtocol               = papi.SecurityGroupRuleProtocolIcmp
 	testSecurityGroupRuleSecurityGroupID        = new(clientTestSuite).randomID()
 	testSecurityGroupRuleStartPort       uint16 = 8081
 )
 
-func (ts *clientTestSuite) TestSecurityGroup_get() {
+func (ts *clientTestSuite) TestClient_CreateSecurityGroup() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+	)
+
+	httpmock.RegisterResponder("POST", "/security-group",
+		func(req *http.Request) (*http.Response, error) {
+			var actual papi.CreateSecurityGroupJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.CreateSecurityGroupJSONRequestBody{
+				Description: &testSecurityGroupDescription,
+				Name:        testSecurityGroupName,
+			}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testPrivateNetworkID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSecurityGroupID},
+	})
+
 	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
 		Description: &testSecurityGroupDescription,
 		Id:          &testSecurityGroupID,
 		Name:        &testSecurityGroupName,
-		Rules: &[]papi.SecurityGroupRule{{
-			Description:   &testSecurityGroupRuleDescription,
-			EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort); return &v }(),
-			FlowDirection: &testSecurityGroupRuleFlowDirection,
-			Icmp: &struct {
-				Code *int64 `json:"code,omitempty"`
-				Type *int64 `json:"type,omitempty"`
-			}{
-				Code: &testSecurityGroupRuleICMPCode,
-				Type: &testSecurityGroupRuleICMPType,
-			},
-			Id:            &testSecurityGroupRuleID,
-			Network:       &testSecurityGroupRuleNetwork,
-			Protocol:      &testSecurityGroupRuleProtocol,
-			SecurityGroup: &papi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
-			StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
-		}},
 	})
 
 	expected := &SecurityGroup{
 		Description: &testSecurityGroupDescription,
 		ID:          &testSecurityGroupID,
 		Name:        &testSecurityGroupName,
-		Rules: []*SecurityGroupRule{{
-			Description:     &testSecurityGroupRuleDescription,
-			EndPort:         &testSecurityGroupRuleEndPort,
-			FlowDirection:   (*string)(&testSecurityGroupRuleFlowDirection),
-			ICMPCode:        &testSecurityGroupRuleICMPCode,
-			ICMPType:        &testSecurityGroupRuleICMPType,
-			ID:              &testSecurityGroupRuleID,
-			Network:         func() *net.IPNet { _, v, _ := net.ParseCIDR(testSecurityGroupRuleNetwork); return v }(),
-			Protocol:        (*string)(&testSecurityGroupRuleProtocol),
-			SecurityGroupID: &testSecurityGroupRuleSecurityGroupID,
-			StartPort:       &testSecurityGroupRuleStartPort,
-		}},
-
-		c:    ts.client,
-		zone: testZone,
 	}
 
-	actual, err := new(SecurityGroup).get(context.Background(), ts.client, testZone, *expected.ID)
+	actual, err := ts.client.CreateSecurityGroup(context.Background(), testZone, &SecurityGroup{
+		Description: &testSecurityGroupDescription,
+		Name:        &testSecurityGroupName,
+	})
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *clientTestSuite) TestSecurityGroup_AddRule() {
+func (ts *clientTestSuite) TestClient_CreateSecurityGroupRule() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = papi.OperationStateSuccess
@@ -151,8 +157,6 @@ func (ts *clientTestSuite) TestSecurityGroup_AddRule() {
 		Description: &testSecurityGroupDescription,
 		ID:          &testSecurityGroupID,
 		Name:        &testSecurityGroupName,
-
-		c: ts.client,
 	}
 
 	expected := SecurityGroupRule{
@@ -168,20 +172,60 @@ func (ts *clientTestSuite) TestSecurityGroup_AddRule() {
 		StartPort:       &testSecurityGroupRuleStartPort,
 	}
 
-	actual, err := securityGroup.AddRule(context.Background(), &expected)
+	actual, err := ts.client.CreateSecurityGroupRule(context.Background(), testZone, securityGroup, &expected)
 	ts.Require().NoError(err)
 	ts.Require().Equal(&expected, actual)
 }
 
-func (ts *clientTestSuite) TestSecurityGroup_DeleteRule() {
+func (ts *clientTestSuite) TestClient_DeleteSecurityGroup() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/security-group/%s", testSecurityGroupID),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSecurityGroupID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSecurityGroupID},
+	})
+
+	ts.Require().NoError(ts.client.DeleteSecurityGroup(
+		context.Background(),
+		testZone,
+		&SecurityGroup{ID: &testSecurityGroupID},
+	))
+	ts.Require().True(deleted)
+}
+
+func (ts *clientTestSuite) TestClient_DeleteSecurityGroupRule() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
 	)
 
 	httpmock.RegisterResponder("DELETE",
 		fmt.Sprintf("=~^/security-group/%s/rules/.*", testSecurityGroupID),
 		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
 			ts.Require().Equal(
 				fmt.Sprintf("/security-group/%s/rules/%s", testSecurityGroupID, testSecurityGroupRuleID),
 				req.URL.String())
@@ -215,72 +259,94 @@ func (ts *clientTestSuite) TestSecurityGroup_DeleteRule() {
 			ICMPCode:        &testSecurityGroupRuleICMPCode,
 			ICMPType:        &testSecurityGroupRuleICMPType,
 			ID:              &testSecurityGroupRuleID,
-			Network:         func() *net.IPNet { _, v, _ := net.ParseCIDR(testSecurityGroupRuleNetwork); return v }(),
+			Network:         testSecurityGroupRuleNetworkP,
 			Protocol:        (*string)(&testSecurityGroupRuleProtocol),
 			SecurityGroupID: &testSecurityGroupRuleSecurityGroupID,
 			StartPort:       &testSecurityGroupRuleStartPort,
 		}},
-
-		c: ts.client,
 	}
 
-	ts.Require().NoError(securityGroup.DeleteRule(context.Background(), securityGroup.Rules[0]))
+	ts.Require().NoError(ts.client.DeleteSecurityGroupRule(
+		context.Background(),
+		testZone,
+		securityGroup,
+		securityGroup.Rules[0],
+	))
+	ts.Require().True(deleted)
 }
 
-func (ts *clientTestSuite) TestClient_CreateSecurityGroup() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-	)
-
-	httpmock.RegisterResponder("POST", "/security-group",
-		func(req *http.Request) (*http.Response, error) {
-			var actual papi.CreateSecurityGroupJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.CreateSecurityGroupJSONRequestBody{
-				Description: &testSecurityGroupDescription,
-				Name:        testSecurityGroupName,
-			}
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testPrivateNetworkID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSecurityGroupID},
+func (ts *clientTestSuite) TestClient_FindSecurityGroup() {
+	ts.mockAPIRequest("GET", "/security-group", struct {
+		SecurityGroups *[]papi.SecurityGroup `json:"security-groups,omitempty"`
+	}{
+		SecurityGroups: &[]papi.SecurityGroup{{
+			Id:   &testSecurityGroupID,
+			Name: &testSecurityGroupName,
+		}},
 	})
 
+	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
+		Id:   &testSecurityGroupID,
+		Name: &testSecurityGroupName,
+	})
+
+	expected := &SecurityGroup{
+		ID:   &testSecurityGroupID,
+		Name: &testSecurityGroupName,
+	}
+
+	actual, err := ts.client.FindSecurityGroup(context.Background(), testZone, *expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindSecurityGroup(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetSecurityGroup() {
 	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
 		Description: &testSecurityGroupDescription,
 		Id:          &testSecurityGroupID,
 		Name:        &testSecurityGroupName,
+		Rules: &[]papi.SecurityGroupRule{{
+			Description:   &testSecurityGroupRuleDescription,
+			EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort); return &v }(),
+			FlowDirection: &testSecurityGroupRuleFlowDirection,
+			Icmp: &struct {
+				Code *int64 `json:"code,omitempty"`
+				Type *int64 `json:"type,omitempty"`
+			}{
+				Code: &testSecurityGroupRuleICMPCode,
+				Type: &testSecurityGroupRuleICMPType,
+			},
+			Id:            &testSecurityGroupRuleID,
+			Network:       &testSecurityGroupRuleNetwork,
+			Protocol:      &testSecurityGroupRuleProtocol,
+			SecurityGroup: &papi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
+			StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
+		}},
 	})
 
 	expected := &SecurityGroup{
 		Description: &testSecurityGroupDescription,
 		ID:          &testSecurityGroupID,
 		Name:        &testSecurityGroupName,
-
-		c:    ts.client,
-		zone: testZone,
+		Rules: []*SecurityGroupRule{{
+			Description:     &testSecurityGroupRuleDescription,
+			EndPort:         &testSecurityGroupRuleEndPort,
+			FlowDirection:   (*string)(&testSecurityGroupRuleFlowDirection),
+			ICMPCode:        &testSecurityGroupRuleICMPCode,
+			ICMPType:        &testSecurityGroupRuleICMPType,
+			ID:              &testSecurityGroupRuleID,
+			Network:         testSecurityGroupRuleNetworkP,
+			Protocol:        (*string)(&testSecurityGroupRuleProtocol),
+			SecurityGroupID: &testSecurityGroupRuleSecurityGroupID,
+			StartPort:       &testSecurityGroupRuleStartPort,
+		}},
 	}
 
-	actual, err := ts.client.CreateSecurityGroup(context.Background(), testZone, &SecurityGroup{
-		Description: &testSecurityGroupDescription,
-		Name:        &testSecurityGroupName,
-	})
+	actual, err := ts.client.GetSecurityGroup(context.Background(), testZone, *expected.ID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
@@ -325,133 +391,15 @@ func (ts *clientTestSuite) TestClient_ListSecurityGroups() {
 				ICMPCode:        &testSecurityGroupRuleICMPCode,
 				ICMPType:        &testSecurityGroupRuleICMPType,
 				ID:              &testSecurityGroupRuleID,
-				Network:         func() *net.IPNet { _, v, _ := net.ParseCIDR(testSecurityGroupRuleNetwork); return v }(),
+				Network:         testSecurityGroupRuleNetworkP,
 				Protocol:        (*string)(&testSecurityGroupRuleProtocol),
 				SecurityGroupID: &testSecurityGroupRuleSecurityGroupID,
 				StartPort:       &testSecurityGroupRuleStartPort,
 			}},
-
-			c:    ts.client,
-			zone: testZone,
 		},
 	}
 
 	actual, err := ts.client.ListSecurityGroups(context.Background(), testZone)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_GetSecurityGroup() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
-		Description: &testSecurityGroupDescription,
-		Id:          &testSecurityGroupID,
-		Name:        &testSecurityGroupName,
-		Rules: &[]papi.SecurityGroupRule{{
-			Description:   &testSecurityGroupRuleDescription,
-			EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort); return &v }(),
-			FlowDirection: &testSecurityGroupRuleFlowDirection,
-			Icmp: &struct {
-				Code *int64 `json:"code,omitempty"`
-				Type *int64 `json:"type,omitempty"`
-			}{
-				Code: &testSecurityGroupRuleICMPCode,
-				Type: &testSecurityGroupRuleICMPType,
-			},
-			Id:            &testSecurityGroupRuleID,
-			Network:       &testSecurityGroupRuleNetwork,
-			Protocol:      &testSecurityGroupRuleProtocol,
-			SecurityGroup: &papi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
-			StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
-		}},
-	})
-
-	expected := &SecurityGroup{
-		Description: &testSecurityGroupDescription,
-		ID:          &testSecurityGroupID,
-		Name:        &testSecurityGroupName,
-		Rules: []*SecurityGroupRule{{
-			Description:     &testSecurityGroupRuleDescription,
-			EndPort:         &testSecurityGroupRuleEndPort,
-			FlowDirection:   (*string)(&testSecurityGroupRuleFlowDirection),
-			ICMPCode:        &testSecurityGroupRuleICMPCode,
-			ICMPType:        &testSecurityGroupRuleICMPType,
-			ID:              &testSecurityGroupRuleID,
-			Network:         func() *net.IPNet { _, v, _ := net.ParseCIDR(testSecurityGroupRuleNetwork); return v }(),
-			Protocol:        (*string)(&testSecurityGroupRuleProtocol),
-			SecurityGroupID: &testSecurityGroupRuleSecurityGroupID,
-			StartPort:       &testSecurityGroupRuleStartPort,
-		}},
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := ts.client.GetSecurityGroup(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_FindSecurityGroup() {
-	ts.mockAPIRequest("GET", "/security-group", struct {
-		SecurityGroups *[]papi.SecurityGroup `json:"security-groups,omitempty"`
-	}{
-		SecurityGroups: &[]papi.SecurityGroup{{
-			Id:   &testSecurityGroupID,
-			Name: &testSecurityGroupName,
-		}},
-	})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID), papi.SecurityGroup{
-		Id:   &testSecurityGroupID,
-		Name: &testSecurityGroupName,
-	})
-
-	expected := &SecurityGroup{
-		ID:   &testSecurityGroupID,
-		Name: &testSecurityGroupName,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := ts.client.FindSecurityGroup(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-
-	actual, err = ts.client.FindSecurityGroup(context.Background(), testZone, *expected.Name)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_DeleteSecurityGroup() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		deleted            = false
-	)
-
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/security-group/%s", testSecurityGroupID),
-		func(req *http.Request) (*http.Response, error) {
-			deleted = true
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSecurityGroupID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSecurityGroupID},
-	})
-
-	ts.Require().NoError(ts.client.DeleteSecurityGroup(context.Background(), testZone, testSecurityGroupID))
-	ts.Require().True(deleted)
 }

--- a/v2/sks.go
+++ b/v2/sks.go
@@ -30,12 +30,9 @@ type SKSNodepool struct {
 	State                *string
 	TemplateID           *string
 	Version              *string
-
-	c    *Client
-	zone string
 }
 
-func sksNodepoolFromAPI(client *Client, zone string, n *papi.SksNodepool) *SKSNodepool {
+func sksNodepoolFromAPI(n *papi.SksNodepool) *SKSNodepool {
 	return &SKSNodepool{
 		AddOns: func() (v *[]string) {
 			if n.Addons != nil {
@@ -104,37 +101,7 @@ func sksNodepoolFromAPI(client *Client, zone string, n *papi.SksNodepool) *SKSNo
 		State:      (*string)(n.State),
 		TemplateID: n.Template.Id,
 		Version:    n.Version,
-
-		c:    client,
-		zone: zone,
 	}
-}
-
-// AntiAffinityGroups returns the list of Anti-Affinity Groups applied to the members of the cluster Nodepool.
-func (n *SKSNodepool) AntiAffinityGroups(ctx context.Context) ([]*AntiAffinityGroup, error) {
-	if n.AntiAffinityGroupIDs != nil {
-		res, err := n.c.fetchFromIDs(ctx, n.zone, *n.AntiAffinityGroupIDs, new(AntiAffinityGroup))
-		return res.([]*AntiAffinityGroup), err
-	}
-	return nil, nil
-}
-
-// PrivateNetworks returns the list of Private Networks attached to the members of the cluster Nodepool.
-func (n *SKSNodepool) PrivateNetworks(ctx context.Context) ([]*PrivateNetwork, error) {
-	if n.PrivateNetworkIDs != nil {
-		res, err := n.c.fetchFromIDs(ctx, n.zone, *n.PrivateNetworkIDs, new(PrivateNetwork))
-		return res.([]*PrivateNetwork), err
-	}
-	return nil, nil
-}
-
-// SecurityGroups returns the list of Security Groups attached to the members of the cluster Nodepool.
-func (n *SKSNodepool) SecurityGroups(ctx context.Context) ([]*SecurityGroup, error) {
-	if n.SecurityGroupIDs != nil {
-		res, err := n.c.fetchFromIDs(ctx, n.zone, *n.SecurityGroupIDs, new(SecurityGroup))
-		return res.([]*SecurityGroup), err
-	}
-	return nil, nil
 }
 
 // SKSCluster represents an SKS cluster.
@@ -152,12 +119,9 @@ type SKSCluster struct {
 	ServiceLevel *string `req-for:"create"`
 	State        *string
 	Version      *string `req-for:"create"`
-
-	c    *Client
-	zone string
 }
 
-func sksClusterFromAPI(client *Client, zone string, c *papi.SksCluster) *SKSCluster {
+func sksClusterFromAPI(c *papi.SksCluster) *SKSCluster {
 	return &SKSCluster{
 		AddOns: func() (v *[]string) {
 			if c.Addons != nil {
@@ -187,7 +151,7 @@ func sksClusterFromAPI(client *Client, zone string, c *papi.SksCluster) *SKSClus
 			if c.Nodepools != nil {
 				for _, n := range *c.Nodepools {
 					n := n
-					nodepools = append(nodepools, sksNodepoolFromAPI(client, zone, &n))
+					nodepools = append(nodepools, sksNodepoolFromAPI(&n))
 				}
 			}
 			return nodepools
@@ -195,92 +159,179 @@ func sksClusterFromAPI(client *Client, zone string, c *papi.SksCluster) *SKSClus
 		ServiceLevel: (*string)(c.Level),
 		State:        (*string)(c.State),
 		Version:      c.Version,
-
-		c:    client,
-		zone: zone,
 	}
 }
 
-// RotateCCMCredentials rotates the Exoscale IAM credentials managed by the SKS control plane for the
-// Kubernetes Exoscale Cloud Controller Manager.
-func (c *SKSCluster) RotateCCMCredentials(ctx context.Context) error {
-	resp, err := c.c.RotateSksCcmCredentialsWithResponse(apiv2.WithZone(ctx, c.zone), *c.ID)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// AuthorityCert returns the SKS cluster base64-encoded certificate content for the specified authority.
-func (c *SKSCluster) AuthorityCert(ctx context.Context, authority string) (string, error) {
-	if authority == "" {
-		return "", errors.New("authority not specified")
-	}
-
-	resp, err := c.c.GetSksClusterAuthorityCertWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
-		papi.GetSksClusterAuthorityCertParamsAuthority(authority),
-	)
-	if err != nil {
-		return "", err
-	}
-
-	return papi.OptionalString(resp.JSON200.Cacert), nil
-}
-
-// RequestKubeconfig returns a base64-encoded kubeconfig content for the specified user name,
-// optionally associated to specified groups for a duration d (default API-set TTL applies if not specified).
-// Fore more information: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-func (c *SKSCluster) RequestKubeconfig(
-	ctx context.Context,
-	user string,
-	groups []string,
-	d time.Duration,
-) (string, error) {
-	if user == "" {
-		return "", errors.New("user not specified")
-	}
-
-	resp, err := c.c.GenerateSksClusterKubeconfigWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
-		papi.GenerateSksClusterKubeconfigJSONRequestBody{
-			User:   &user,
-			Groups: &groups,
-			Ttl: func() *int64 {
-				ttl := int64(d.Seconds())
-				if ttl > 0 {
-					return &ttl
+// ToAPIMock returns the low-level representation of the resource. This is intended for testing purposes.
+func (c SKSCluster) ToAPIMock() interface{} {
+	return papi.SksCluster{
+		Addons: func() *[]papi.SksClusterAddons {
+			if c.AddOns != nil {
+				list := make([]papi.SksClusterAddons, len(*c.AddOns))
+				for i, a := range *c.AddOns {
+					a := a
+					list[i] = papi.SksClusterAddons(a)
 				}
-				return nil
+				return &list
+			}
+			return nil
+		}(),
+		AutoUpgrade: c.AutoUpgrade,
+		Cni:         (*papi.SksClusterCni)(c.CNI),
+		CreatedAt:   c.CreatedAt,
+		Description: c.Description,
+		Endpoint:    c.Endpoint,
+		Id:          c.ID,
+		Labels: func() *papi.Labels {
+			if c.Labels != nil {
+				return &papi.Labels{AdditionalProperties: *c.Labels}
+			}
+			return nil
+		}(),
+		Level: (*papi.SksClusterLevel)(c.ServiceLevel),
+		Name:  c.Name,
+		Nodepools: func() *[]papi.SksNodepool {
+			list := make([]papi.SksNodepool, len(c.Nodepools))
+			for j, n := range c.Nodepools {
+				list[j] = papi.SksNodepool{
+					Addons: func() *[]papi.SksNodepoolAddons {
+						if n.AddOns != nil {
+							list := make([]papi.SksNodepoolAddons, len(*n.AddOns))
+							for i, a := range *n.AddOns {
+								a := a
+								list[i] = papi.SksNodepoolAddons(a)
+							}
+							return &list
+						}
+						return nil
+					}(),
+					AntiAffinityGroups: func() *[]papi.AntiAffinityGroup {
+						if n.AntiAffinityGroupIDs != nil {
+							list := make([]papi.AntiAffinityGroup, len(*n.AntiAffinityGroupIDs))
+							for i, id := range *n.AntiAffinityGroupIDs {
+								id := id
+								list[i] = papi.AntiAffinityGroup{Id: &id}
+							}
+							return &list
+						}
+						return nil
+					}(),
+					CreatedAt: n.CreatedAt,
+					DeployTarget: func() *papi.DeployTarget {
+						if n.DeployTargetID != nil {
+							return &papi.DeployTarget{Id: n.DeployTargetID}
+						}
+						return nil
+					}(),
+					Description:    n.Description,
+					DiskSize:       n.DiskSize,
+					Id:             n.ID,
+					InstancePool:   &papi.InstancePool{Id: n.InstancePoolID},
+					InstancePrefix: n.InstancePrefix,
+					InstanceType:   &papi.InstanceType{Id: n.InstanceTypeID},
+					Labels: func() *papi.Labels {
+						if n.Labels != nil {
+							return &papi.Labels{AdditionalProperties: *n.Labels}
+						}
+						return nil
+					}(),
+					Name: n.Name,
+					PrivateNetworks: func() *[]papi.PrivateNetwork {
+						if n.PrivateNetworkIDs != nil {
+							list := make([]papi.PrivateNetwork, len(*n.PrivateNetworkIDs))
+							for i, id := range *n.PrivateNetworkIDs {
+								id := id
+								list[i] = papi.PrivateNetwork{Id: &id}
+							}
+							return &list
+						}
+						return nil
+					}(),
+					SecurityGroups: func() *[]papi.SecurityGroup {
+						if n.SecurityGroupIDs != nil {
+							list := make([]papi.SecurityGroup, len(*n.SecurityGroupIDs))
+							for i, id := range *n.SecurityGroupIDs {
+								id := id
+								list[i] = papi.SecurityGroup{Id: &id}
+							}
+							return &list
+						}
+						return nil
+					}(),
+					Size:     n.Size,
+					State:    (*papi.SksNodepoolState)(n.State),
+					Template: &papi.Template{Id: n.TemplateID},
+					Version:  n.Version,
+				}
+			}
+			return &list
+		}(),
+		State:   (*papi.SksClusterState)(c.State),
+		Version: c.Version,
+	}
+}
+
+// CreateSKSCluster creates an SKS cluster.
+func (c *Client) CreateSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) (*SKSCluster, error) {
+	if err := validateOperationParams(cluster, "create"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.CreateSksClusterWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.CreateSksClusterJSONRequestBody{
+			Addons: func() (v *[]papi.CreateSksClusterJSONBodyAddons) {
+				if cluster.AddOns != nil {
+					addOns := make([]papi.CreateSksClusterJSONBodyAddons, len(*cluster.AddOns))
+					for i, a := range *cluster.AddOns {
+						addOns[i] = papi.CreateSksClusterJSONBodyAddons(a)
+					}
+					v = &addOns
+				}
+				return
 			}(),
+			AutoUpgrade: cluster.AutoUpgrade,
+			Cni:         (*papi.CreateSksClusterJSONBodyCni)(cluster.CNI),
+			Description: cluster.Description,
+			Labels: func() (v *papi.Labels) {
+				if cluster.Labels != nil {
+					v = &papi.Labels{AdditionalProperties: *cluster.Labels}
+				}
+				return
+			}(),
+			Level:   papi.CreateSksClusterJSONBodyLevel(*cluster.ServiceLevel),
+			Name:    *cluster.Name,
+			Version: *cluster.Version,
 		})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return papi.OptionalString(resp.JSON200.Kubeconfig), nil
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetSKSCluster(ctx, zone, *res.(*papi.Reference).Id)
 }
 
-// AddNodepool adds a Nodepool to the SKS cluster.
-func (c *SKSCluster) AddNodepool(ctx context.Context, nodepool *SKSNodepool) (*SKSNodepool, error) {
+// CreateSKSNodepool create an SKS Nodepool.
+func (c *Client) CreateSKSNodepool(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	nodepool *SKSNodepool,
+) (*SKSNodepool, error) {
 	if err := validateOperationParams(nodepool, "create"); err != nil {
 		return nil, err
 	}
 
-	resp, err := c.c.CreateSksNodepoolWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
+	resp, err := c.CreateSksNodepoolWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
 		papi.CreateSksNodepoolJSONRequestBody{
 			Addons: func() (v *[]papi.CreateSksNodepoolJSONBodyAddons) {
 				if nodepool.AddOns != nil {
@@ -349,30 +400,318 @@ func (c *SKSCluster) AddNodepool(ctx context.Context, nodepool *SKSNodepool) (*S
 	}
 
 	res, err := papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
 	if err != nil {
 		return nil, err
 	}
 
-	nodepoolRes, err := c.c.GetSksNodepoolWithResponse(ctx, *c.ID, *res.(*papi.Reference).Id)
+	nodepoolRes, err := c.GetSksNodepoolWithResponse(ctx, *cluster.ID, *res.(*papi.Reference).Id)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Nodepool: %s", err)
 	}
 
-	return sksNodepoolFromAPI(c.c, c.zone, nodepoolRes.JSON200), nil
+	return sksNodepoolFromAPI(nodepoolRes.JSON200), nil
 }
 
-// UpdateNodepool updates the specified SKS cluster Nodepool.
-func (c *SKSCluster) UpdateNodepool(ctx context.Context, nodepool *SKSNodepool) error {
+// DeleteSKSCluster deletes an SKS cluster.
+func (c *Client) DeleteSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) error {
+	resp, err := c.DeleteSksClusterWithResponse(apiv2.WithZone(ctx, zone), *cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteSKSNodepool deletes an SKS Nodepool.
+func (c *Client) DeleteSKSNodepool(ctx context.Context, zone string, cluster *SKSCluster, nodepool *SKSNodepool) error {
+	if err := validateOperationParams(nodepool, "delete"); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteSksNodepoolWithResponse(apiv2.WithZone(ctx, zone), *cluster.ID, *nodepool.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// EvictSKSNodepoolMembers evicts the specified members (identified by their Compute instance ID) from the
+// SKS cluster Nodepool.
+func (c *Client) EvictSKSNodepoolMembers(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	nodepool *SKSNodepool,
+	members []string,
+) error {
+	if err := validateOperationParams(nodepool, "evict"); err != nil {
+		return err
+	}
+
+	resp, err := c.EvictSksNodepoolMembersWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+		*nodepool.ID,
+		papi.EvictSksNodepoolMembersJSONRequestBody{Instances: &members},
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindSKSCluster attempts to find an SKS cluster by name or ID.
+func (c *Client) FindSKSCluster(ctx context.Context, zone, x string) (*SKSCluster, error) {
+	res, err := c.ListSKSClusters(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range res {
+		if *r.ID == x || *r.Name == x {
+			return c.GetSKSCluster(ctx, zone, *r.ID)
+		}
+	}
+
+	return nil, apiv2.ErrNotFound
+}
+
+// GetSKSCluster returns the SKS cluster corresponding to the specified ID.
+func (c *Client) GetSKSCluster(ctx context.Context, zone, id string) (*SKSCluster, error) {
+	resp, err := c.GetSksClusterWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return sksClusterFromAPI(resp.JSON200), nil
+}
+
+// GetSKSClusterAuthorityCert returns the SKS cluster base64-encoded certificate content for the specified authority.
+func (c *Client) GetSKSClusterAuthorityCert(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	authority string,
+) (string, error) {
+	if authority == "" {
+		return "", errors.New("authority not specified")
+	}
+
+	resp, err := c.GetSksClusterAuthorityCertWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+		papi.GetSksClusterAuthorityCertParamsAuthority(authority),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return papi.OptionalString(resp.JSON200.Cacert), nil
+}
+
+// GetSKSClusterKubeconfig returns a base64-encoded kubeconfig content for the specified user name, optionally
+// associated to specified groups for a duration d (default API-set TTL applies if not specified).
+// Fore more information: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+func (c *Client) GetSKSClusterKubeconfig(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	user string,
+	groups []string,
+	d time.Duration,
+) (string, error) {
+	if user == "" {
+		return "", errors.New("user not specified")
+	}
+
+	resp, err := c.GenerateSksClusterKubeconfigWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+		papi.GenerateSksClusterKubeconfigJSONRequestBody{
+			User:   &user,
+			Groups: &groups,
+			Ttl: func() *int64 {
+				ttl := int64(d.Seconds())
+				if ttl > 0 {
+					return &ttl
+				}
+				return nil
+			}(),
+		})
+	if err != nil {
+		return "", err
+	}
+
+	return papi.OptionalString(resp.JSON200.Kubeconfig), nil
+}
+
+// ListSKSClusters returns the list of existing SKS clusters.
+func (c *Client) ListSKSClusters(ctx context.Context, zone string) ([]*SKSCluster, error) {
+	list := make([]*SKSCluster, 0)
+
+	resp, err := c.ListSksClustersWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SksClusters != nil {
+		for i := range *resp.JSON200.SksClusters {
+			list = append(list, sksClusterFromAPI(&(*resp.JSON200.SksClusters)[i]))
+		}
+	}
+
+	return list, nil
+}
+
+// ListSKSClusterVersions returns the list of Kubernetes versions supported during SKS cluster creation.
+func (c *Client) ListSKSClusterVersions(ctx context.Context) ([]string, error) {
+	list := make([]string, 0)
+
+	resp, err := c.ListSksClusterVersionsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.SksClusterVersions != nil {
+		for i := range *resp.JSON200.SksClusterVersions {
+			version := &(*resp.JSON200.SksClusterVersions)[i]
+			list = append(list, *version)
+		}
+	}
+
+	return list, nil
+}
+
+// RotateSKSClusterCCMCredentials rotates the Exoscale IAM credentials managed by the SKS control plane for the
+// Kubernetes Exoscale Cloud Controller Manager.
+func (c *Client) RotateSKSClusterCCMCredentials(ctx context.Context, zone string, cluster *SKSCluster) error {
+	resp, err := c.RotateSksCcmCredentialsWithResponse(apiv2.WithZone(ctx, zone), *cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ScaleSKSNodepool scales the SKS cluster Nodepool to the specified number of Kubernetes Nodes.
+func (c *Client) ScaleSKSNodepool(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	nodepool *SKSNodepool,
+	size int64,
+) error {
+	if err := validateOperationParams(nodepool, "scale"); err != nil {
+		return err
+	}
+
+	resp, err := c.ScaleSksNodepoolWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+		*nodepool.ID,
+		papi.ScaleSksNodepoolJSONRequestBody{Size: size},
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateSKSCluster updates an SKS cluster.
+func (c *Client) UpdateSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) error {
+	if err := validateOperationParams(cluster, "update"); err != nil {
+		return err
+	}
+
+	resp, err := c.UpdateSksClusterWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+		papi.UpdateSksClusterJSONRequestBody{
+			AutoUpgrade: cluster.AutoUpgrade,
+			Description: cluster.Description,
+			Labels: func() (v *papi.Labels) {
+				if cluster.Labels != nil {
+					v = &papi.Labels{AdditionalProperties: *cluster.Labels}
+				}
+				return
+			}(),
+			Name: cluster.Name,
+		})
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateSKSNodepool updates an SKS Nodepool.
+func (c *Client) UpdateSKSNodepool(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+	nodepool *SKSNodepool,
+) error {
 	if err := validateOperationParams(nodepool, "update"); err != nil {
 		return err
 	}
 
-	resp, err := c.c.UpdateSksNodepoolWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
+	resp, err := c.UpdateSksNodepoolWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
 		*nodepool.ID,
 		papi.UpdateSksNodepoolJSONRequestBody{
 			AntiAffinityGroups: func() (v *[]papi.AntiAffinityGroup) {
@@ -436,232 +775,6 @@ func (c *SKSCluster) UpdateNodepool(ctx context.Context, nodepool *SKSNodepool) 
 	}
 
 	_, err = papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ScaleNodepool scales the SKS cluster Nodepool to the specified number of Kubernetes Nodes.
-func (c *SKSCluster) ScaleNodepool(ctx context.Context, nodepool *SKSNodepool, nodes int64) error {
-	if err := validateOperationParams(nodepool, "scale"); err != nil {
-		return err
-	}
-
-	resp, err := c.c.ScaleSksNodepoolWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
-		*nodepool.ID,
-		papi.ScaleSksNodepoolJSONRequestBody{Size: nodes},
-	)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// EvictNodepoolMembers evicts the specified members (identified by their Compute instance ID) from the
-// SKS cluster Nodepool.
-func (c *SKSCluster) EvictNodepoolMembers(ctx context.Context, nodepool *SKSNodepool, members []string) error {
-	if err := validateOperationParams(nodepool, "evict"); err != nil {
-		return err
-	}
-
-	resp, err := c.c.EvictSksNodepoolMembersWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
-		*nodepool.ID,
-		papi.EvictSksNodepoolMembersJSONRequestBody{Instances: &members},
-	)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteNodepool deletes the specified Nodepool from the SKS cluster.
-func (c *SKSCluster) DeleteNodepool(ctx context.Context, nodepool *SKSNodepool) error {
-	if err := validateOperationParams(nodepool, "delete"); err != nil {
-		return err
-	}
-
-	resp, err := c.c.DeleteSksNodepoolWithResponse(
-		apiv2.WithZone(ctx, c.zone),
-		*c.ID,
-		*nodepool.ID,
-	)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.c.timeout).
-		WithInterval(c.c.pollInterval).
-		Poll(ctx, c.c.OperationPoller(c.zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// CreateSKSCluster creates an SKS cluster in the specified zone.
-func (c *Client) CreateSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) (*SKSCluster, error) {
-	if err := validateOperationParams(cluster, "create"); err != nil {
-		return nil, err
-	}
-
-	resp, err := c.CreateSksClusterWithResponse(
-		apiv2.WithZone(ctx, zone),
-		papi.CreateSksClusterJSONRequestBody{
-			Addons: func() (v *[]papi.CreateSksClusterJSONBodyAddons) {
-				if cluster.AddOns != nil {
-					addOns := make([]papi.CreateSksClusterJSONBodyAddons, len(*cluster.AddOns))
-					for i, a := range *cluster.AddOns {
-						addOns[i] = papi.CreateSksClusterJSONBodyAddons(a)
-					}
-					v = &addOns
-				}
-				return
-			}(),
-			AutoUpgrade: cluster.AutoUpgrade,
-			Cni:         (*papi.CreateSksClusterJSONBodyCni)(cluster.CNI),
-			Description: cluster.Description,
-			Labels: func() (v *papi.Labels) {
-				if cluster.Labels != nil {
-					v = &papi.Labels{AdditionalProperties: *cluster.Labels}
-				}
-				return
-			}(),
-			Level:   papi.CreateSksClusterJSONBodyLevel(*cluster.ServiceLevel),
-			Name:    *cluster.Name,
-			Version: *cluster.Version,
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := papi.NewPoller().
-		WithTimeout(c.timeout).
-		WithInterval(c.pollInterval).
-		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return nil, err
-	}
-
-	return c.GetSKSCluster(ctx, zone, *res.(*papi.Reference).Id)
-}
-
-// ListSKSClusters returns the list of existing SKS clusters in the specified zone.
-func (c *Client) ListSKSClusters(ctx context.Context, zone string) ([]*SKSCluster, error) {
-	list := make([]*SKSCluster, 0)
-
-	resp, err := c.ListSksClustersWithResponse(apiv2.WithZone(ctx, zone))
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200.SksClusters != nil {
-		for i := range *resp.JSON200.SksClusters {
-			list = append(list, sksClusterFromAPI(c, zone, &(*resp.JSON200.SksClusters)[i]))
-		}
-	}
-
-	return list, nil
-}
-
-// ListSKSClusterVersions returns the list of Kubernetes versions supported during SKS cluster creation.
-func (c *Client) ListSKSClusterVersions(ctx context.Context) ([]string, error) {
-	list := make([]string, 0)
-
-	resp, err := c.ListSksClusterVersionsWithResponse(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200.SksClusterVersions != nil {
-		for i := range *resp.JSON200.SksClusterVersions {
-			version := &(*resp.JSON200.SksClusterVersions)[i]
-			list = append(list, *version)
-		}
-	}
-
-	return list, nil
-}
-
-// GetSKSCluster returns the SKS cluster corresponding to the specified ID in the specified zone.
-func (c *Client) GetSKSCluster(ctx context.Context, zone, id string) (*SKSCluster, error) {
-	resp, err := c.GetSksClusterWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return nil, err
-	}
-
-	return sksClusterFromAPI(c, zone, resp.JSON200), nil
-}
-
-// FindSKSCluster attempts to find an SKS cluster by name or ID in the specified zone.
-func (c *Client) FindSKSCluster(ctx context.Context, zone, v string) (*SKSCluster, error) {
-	res, err := c.ListSKSClusters(ctx, zone)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, r := range res {
-		if *r.ID == v || *r.Name == v {
-			return c.GetSKSCluster(ctx, zone, *r.ID)
-		}
-	}
-
-	return nil, apiv2.ErrNotFound
-}
-
-// UpdateSKSCluster updates the specified SKS cluster in the specified zone.
-func (c *Client) UpdateSKSCluster(ctx context.Context, zone string, cluster *SKSCluster) error {
-	if err := validateOperationParams(cluster, "update"); err != nil {
-		return err
-	}
-
-	resp, err := c.UpdateSksClusterWithResponse(
-		apiv2.WithZone(ctx, zone),
-		*cluster.ID,
-		papi.UpdateSksClusterJSONRequestBody{
-			AutoUpgrade: cluster.AutoUpgrade,
-			Description: cluster.Description,
-			Labels: func() (v *papi.Labels) {
-				if cluster.Labels != nil {
-					v = &papi.Labels{AdditionalProperties: *cluster.Labels}
-				}
-				return
-			}(),
-			Name: cluster.Name,
-		})
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
 		WithTimeout(c.timeout).
 		WithInterval(c.pollInterval).
 		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
@@ -672,31 +785,12 @@ func (c *Client) UpdateSKSCluster(ctx context.Context, zone string, cluster *SKS
 	return nil
 }
 
-// UpgradeSKSCluster upgrades the SKS cluster corresponding to the specified ID in the specified zone to the
-// requested Kubernetes version.
-func (c *Client) UpgradeSKSCluster(ctx context.Context, zone, id, version string) error {
+// UpgradeSKSCluster upgrades an SKS cluster to the requested Kubernetes version.
+func (c *Client) UpgradeSKSCluster(ctx context.Context, zone string, cluster *SKSCluster, version string) error {
 	resp, err := c.UpgradeSksClusterWithResponse(
 		apiv2.WithZone(ctx, zone),
-		id,
+		*cluster.ID,
 		papi.UpgradeSksClusterJSONRequestBody{Version: version})
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.timeout).
-		WithInterval(c.pollInterval).
-		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// DeleteSKSCluster deletes the specified SKS cluster in the specified zone.
-func (c *Client) DeleteSKSCluster(ctx context.Context, zone, id string) error {
-	resp, err := c.DeleteSksClusterWithResponse(apiv2.WithZone(ctx, zone), id)
 	if err != nil {
 		return err
 	}

--- a/v2/sks_test.go
+++ b/v2/sks_test.go
@@ -45,523 +45,6 @@ var (
 	testSKSNodepoolVersion                   = "1.18.6"
 )
 
-func (ts *clientTestSuite) TestSKSNodepool_AntiAffinityGroups() {
-	ts.mockAPIRequest(
-		"GET",
-		fmt.Sprintf("/anti-affinity-group/%s", testAntiAffinityGroupID),
-		papi.AntiAffinityGroup{
-			Id:   &testAntiAffinityGroupID,
-			Name: &testAntiAffinityGroupName,
-		},
-	)
-
-	expected := []*AntiAffinityGroup{{
-		ID:   &testAntiAffinityGroupID,
-		Name: &testAntiAffinityGroupName,
-	}}
-
-	sksNodepool := &SKSNodepool{
-		AntiAffinityGroupIDs: &[]string{testAntiAffinityGroupID},
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := sksNodepool.AntiAffinityGroups(context.Background())
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestSKSNodepool_PrivateNetworks() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/private-network/%s", testPrivateNetworkID),
-		papi.PrivateNetwork{
-			Id:   &testPrivateNetworkID,
-			Name: &testPrivateNetworkName,
-		})
-
-	expected := []*PrivateNetwork{
-		{
-			ID:   &testPrivateNetworkID,
-			Name: &testPrivateNetworkName,
-
-			c:    ts.client,
-			zone: testZone,
-		},
-	}
-
-	sksNodepool := &SKSNodepool{
-		PrivateNetworkIDs: &[]string{testPrivateNetworkID},
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := sksNodepool.PrivateNetworks(context.Background())
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestSKSNodepool_SecurityGroups() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/security-group/%s", testSecurityGroupID),
-		papi.SecurityGroup{
-			Id:   &testSecurityGroupID,
-			Name: &testSecurityGroupName,
-		})
-
-	expected := []*SecurityGroup{
-		{
-			ID:   &testSecurityGroupID,
-			Name: &testSecurityGroupName,
-
-			c:    ts.client,
-			zone: testZone,
-		},
-	}
-
-	sksNodepool := &SKSNodepool{
-		SecurityGroupIDs: &[]string{testSecurityGroupID},
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := sksNodepool.SecurityGroups(context.Background())
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_RotateCCMCredentials() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		rotated            = false
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/rotate-ccm-credentials", *cluster.ID),
-		func(req *http.Request) (*http.Response, error) {
-			rotated = true
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSClusterID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	ts.Require().NoError(cluster.RotateCCMCredentials(context.Background()))
-	ts.Require().True(rotated)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_AuthorityCert() {
-	var (
-		testAuthority   = "aggregation"
-		testCertificate = base64.StdEncoding.EncodeToString([]byte("test"))
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	ts.mockAPIRequest("GET",
-		fmt.Sprintf("/sks-cluster/%s/authority/%s/cert", *cluster.ID, testAuthority),
-		struct {
-			Cacert string `json:"cacert,omitempty"`
-		}{
-			Cacert: testCertificate,
-		})
-
-	actual, err := cluster.AuthorityCert(context.Background(), testAuthority)
-	ts.Require().NoError(err)
-	ts.Require().Equal(testCertificate, actual)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_RequestKubeconfig() {
-	var (
-		testRequestUser   = "test-user"
-		testRequestGroups = []string{"system:masters"}
-		testKubeconfig    = base64.StdEncoding.EncodeToString([]byte("test"))
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	ts.mockAPIRequest("POST", fmt.Sprintf("/sks-cluster-kubeconfig/%s", *cluster.ID), struct {
-		Kubeconfig string `json:"kubeconfig,omitempty"`
-	}{
-		Kubeconfig: testKubeconfig,
-	})
-
-	actual, err := cluster.RequestKubeconfig(context.Background(), testRequestUser, testRequestGroups, time.Hour)
-	ts.Require().NoError(err)
-	ts.Require().Equal(testKubeconfig, actual)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_AddNodepool() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-	)
-
-	httpmock.RegisterResponder("POST", fmt.Sprintf("/sks-cluster/%s/nodepool", testSKSClusterID),
-		func(req *http.Request) (*http.Response, error) {
-			var actual papi.CreateSksNodepoolJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.CreateSksNodepoolJSONRequestBody{
-				Addons: &[]papi.CreateSksNodepoolJSONBodyAddons{
-					papi.CreateSksNodepoolJSONBodyAddons(testSKSNodepoolAddons[0]),
-				},
-				AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
-				DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetID},
-				Description:        &testSKSNodepoolDescription,
-				DiskSize:           testSKSNodepoolDiskSize,
-				InstancePrefix:     &testSKSNodepoolInstancePrefix,
-				InstanceType:       papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
-				Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
-				Name:               testSKSNodepoolName,
-				PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
-				SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
-				Size:               testSKSNodepoolSize,
-			}
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSNodepoolID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
-		testSKSClusterID, testSKSNodepoolID),
-		papi.SksNodepool{
-			Addons:             &testSKSNodepoolAddons,
-			AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
-			CreatedAt:          &testSKSNodepoolCreatedAt,
-			DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetID},
-			Description:        &testSKSNodepoolDescription,
-			DiskSize:           &testSKSNodepoolDiskSize,
-			Id:                 &testSKSNodepoolID,
-			InstancePool:       &papi.InstancePool{Id: &testSKSNodepoolInstancePoolID},
-			InstancePrefix:     &testSKSNodepoolInstancePrefix,
-			InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
-			Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
-			Name:               &testSKSNodepoolName,
-			PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
-			SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
-			Size:               &testSKSNodepoolSize,
-			State:              &testSKSNodepoolState,
-			Template:           &papi.Template{Id: &testSKSNodepoolTemplateID},
-			Version:            &testSKSNodepoolVersion,
-		})
-
-	cluster := &SKSCluster{
-		ID: &testSKSClusterID,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	expected := &SKSNodepool{
-		AddOns:               &[]string{string(testSKSNodepoolAddons[0])},
-		AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupID},
-		CreatedAt:            &testSKSNodepoolCreatedAt,
-		DeployTargetID:       &testSKSNodepoolDeployTargetID,
-		Description:          &testSKSNodepoolDescription,
-		DiskSize:             &testSKSNodepoolDiskSize,
-		ID:                   &testSKSNodepoolID,
-		InstancePoolID:       &testSKSNodepoolInstancePoolID,
-		InstancePrefix:       &testSKSNodepoolInstancePrefix,
-		InstanceTypeID:       &testSKSNodepoolInstanceTypeID,
-		Labels:               &testSKSNodepoolLabels,
-		Name:                 &testSKSNodepoolName,
-		PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkID},
-		SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupID},
-		Size:                 &testSKSNodepoolSize,
-		State:                (*string)(&testSKSNodepoolState),
-		TemplateID:           &testSKSNodepoolTemplateID,
-		Version:              &testSKSNodepoolVersion,
-
-		c:    ts.client,
-		zone: testZone,
-	}
-
-	actual, err := cluster.AddNodepool(context.Background(), expected)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_UpdateNodepool() {
-	var (
-		testOperationID                           = ts.randomID()
-		testSKSNodepoolAntiAffinityGroupIDUpdated = ts.randomID()
-		testSKSNodepoolDeployTargetIDUpdated      = ts.randomID()
-		testSKSNodepoolDescriptionUpdated         = testSKSNodepoolDescription + "-updated"
-		testSKSNodepoolDiskSizeUpdated            = testSKSNodepoolDiskSize + 1
-		testSKSNodepoolInstancePrefixUpdated      = testSKSNodepoolInstancePrefix + "-updated"
-		testSKSNodepoolInstanceTypeIDUpdated      = testSKSNodepoolInstanceTypeID + "-updated"
-		testSKSNodepoolLabelsUpdated              = map[string]string{"k3": "v3"}
-		testSKSNodepoolNameUpdated                = testSKSNodepoolName + "-updated"
-		testSKSNodepoolPrivateNetworkIDUpdated    = ts.randomID()
-		testSKSNodepoolSecurityGroupIDUpdated     = ts.randomID()
-		testOperationState                        = papi.OperationStateSuccess
-		updated                                   = false
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-
-		Nodepools: []*SKSNodepool{
-			{
-				DeployTargetID: &testSKSNodepoolDeployTargetID,
-				Description:    &testSKSNodepoolDescription,
-				DiskSize:       &testSKSNodepoolDiskSize,
-				ID:             &testSKSNodepoolID,
-				InstancePrefix: &testSKSNodepoolInstancePrefix,
-				InstanceTypeID: &testSKSNodepoolInstanceTypeID,
-				Labels:         &testSKSNodepoolLabels,
-				Name:           &testSKSNodepoolName,
-			},
-		},
-	}
-
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
-		*cluster.ID,
-		*cluster.Nodepools[0].ID),
-		func(req *http.Request) (*http.Response, error) {
-			updated = true
-
-			var actual papi.UpdateSksNodepoolJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.UpdateSksNodepoolJSONRequestBody{
-				AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupIDUpdated}},
-				DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetIDUpdated},
-				Description:        &testSKSNodepoolDescriptionUpdated,
-				DiskSize:           &testSKSNodepoolDiskSizeUpdated,
-				InstancePrefix:     &testSKSNodepoolInstancePrefixUpdated,
-				InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeIDUpdated},
-				Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabelsUpdated},
-				Name:               &testSKSNodepoolNameUpdated,
-				PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkIDUpdated}},
-				SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupIDUpdated}},
-			}
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSNodepoolID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	nodepoolUpdated := SKSNodepool{
-		AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupIDUpdated},
-		DeployTargetID:       &testSKSNodepoolDeployTargetIDUpdated,
-		Description:          &testSKSNodepoolDescriptionUpdated,
-		DiskSize:             &testSKSNodepoolDiskSizeUpdated,
-		ID:                   cluster.Nodepools[0].ID,
-		InstancePrefix:       &testSKSNodepoolInstancePrefixUpdated,
-		InstanceTypeID:       &testSKSNodepoolInstanceTypeIDUpdated,
-		Labels:               &testSKSNodepoolLabelsUpdated,
-		Name:                 &testSKSNodepoolNameUpdated,
-		PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkIDUpdated},
-		SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupIDUpdated},
-	}
-	ts.Require().NoError(cluster.UpdateNodepool(context.Background(), &nodepoolUpdated))
-	ts.Require().True(updated)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_ScaleNodepool() {
-	var (
-		testOperationID          = ts.randomID()
-		testOperationState       = papi.OperationStateSuccess
-		testScaleSize      int64 = 3
-		scaled                   = false
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-
-		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
-	}
-
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s:scale",
-		*cluster.ID,
-		*cluster.Nodepools[0].ID),
-		func(req *http.Request) (*http.Response, error) {
-			scaled = true
-
-			var actual papi.ScaleSksNodepoolJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.ScaleSksNodepoolJSONRequestBody{Size: testScaleSize}
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSNodepoolID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	ts.Require().NoError(cluster.ScaleNodepool(context.Background(), cluster.Nodepools[0], testScaleSize))
-	ts.Require().True(scaled)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_EvictNodepoolMembers() {
-	var (
-		testOperationID     = ts.randomID()
-		testOperationState  = papi.OperationStateSuccess
-		testEvictedMemberID = ts.randomID()
-		evicted             = false
-	)
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-
-		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
-	}
-
-	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s:evict",
-		*cluster.ID,
-		*cluster.Nodepools[0].ID),
-		func(req *http.Request) (*http.Response, error) {
-			evicted = true
-
-			var actual papi.EvictSksNodepoolMembersJSONRequestBody
-			ts.unmarshalJSONRequestBody(req, &actual)
-
-			expected := papi.EvictSksNodepoolMembersJSONRequestBody{Instances: &[]string{testEvictedMemberID}}
-			ts.Require().Equal(expected, actual)
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSNodepoolID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	ts.Require().NoError(cluster.EvictNodepoolMembers(
-		context.Background(),
-		cluster.Nodepools[0],
-		[]string{testEvictedMemberID}))
-	ts.Require().True(evicted)
-}
-
-func (ts *clientTestSuite) TestSKSCluster_DeleteNodepool() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-	)
-
-	httpmock.RegisterResponder("DELETE",
-		fmt.Sprintf("=~^/sks-cluster/%s/nodepool/.*", testSKSClusterID),
-		func(req *http.Request) (*http.Response, error) {
-			ts.Require().Equal(fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
-				testSKSClusterID, testSKSNodepoolID), req.URL.String())
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSClusterID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSNodepoolID},
-	})
-
-	cluster := &SKSCluster{
-		ID:   &testSKSClusterID,
-		c:    ts.client,
-		zone: testZone,
-
-		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
-	}
-
-	ts.Require().NoError(cluster.DeleteNodepool(context.Background(), cluster.Nodepools[0]))
-}
-
 func (ts *clientTestSuite) TestClient_CreateSKSCluster() {
 	var (
 		testOperationID    = ts.randomID()
@@ -634,9 +117,6 @@ func (ts *clientTestSuite) TestClient_CreateSKSCluster() {
 		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
 		State:        (*string)(&testSKSClusterState),
 		Version:      &testSKSClusterVersion,
-
-		c:    ts.client,
-		zone: testZone,
 	}
 
 	actual, err := ts.client.CreateSKSCluster(context.Background(), testZone, &SKSCluster{
@@ -651,6 +131,406 @@ func (ts *clientTestSuite) TestClient_CreateSKSCluster() {
 	})
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestCLient_CreateSKSNodepool() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+	)
+
+	httpmock.RegisterResponder("POST", fmt.Sprintf("/sks-cluster/%s/nodepool", testSKSClusterID),
+		func(req *http.Request) (*http.Response, error) {
+			var actual papi.CreateSksNodepoolJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.CreateSksNodepoolJSONRequestBody{
+				Addons: &[]papi.CreateSksNodepoolJSONBodyAddons{
+					papi.CreateSksNodepoolJSONBodyAddons(testSKSNodepoolAddons[0]),
+				},
+				AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
+				DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetID},
+				Description:        &testSKSNodepoolDescription,
+				DiskSize:           testSKSNodepoolDiskSize,
+				InstancePrefix:     &testSKSNodepoolInstancePrefix,
+				InstanceType:       papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
+				Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
+				Name:               testSKSNodepoolName,
+				PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
+				SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
+				Size:               testSKSNodepoolSize,
+			}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSNodepoolID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
+		testSKSClusterID, testSKSNodepoolID),
+		papi.SksNodepool{
+			Addons:             &testSKSNodepoolAddons,
+			AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
+			CreatedAt:          &testSKSNodepoolCreatedAt,
+			DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetID},
+			Description:        &testSKSNodepoolDescription,
+			DiskSize:           &testSKSNodepoolDiskSize,
+			Id:                 &testSKSNodepoolID,
+			InstancePool:       &papi.InstancePool{Id: &testSKSNodepoolInstancePoolID},
+			InstancePrefix:     &testSKSNodepoolInstancePrefix,
+			InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
+			Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
+			Name:               &testSKSNodepoolName,
+			PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
+			SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
+			Size:               &testSKSNodepoolSize,
+			State:              &testSKSNodepoolState,
+			Template:           &papi.Template{Id: &testSKSNodepoolTemplateID},
+			Version:            &testSKSNodepoolVersion,
+		})
+
+	cluster := &SKSCluster{
+		ID: &testSKSClusterID,
+	}
+
+	expected := &SKSNodepool{
+		AddOns:               &[]string{string(testSKSNodepoolAddons[0])},
+		AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupID},
+		CreatedAt:            &testSKSNodepoolCreatedAt,
+		DeployTargetID:       &testSKSNodepoolDeployTargetID,
+		Description:          &testSKSNodepoolDescription,
+		DiskSize:             &testSKSNodepoolDiskSize,
+		ID:                   &testSKSNodepoolID,
+		InstancePoolID:       &testSKSNodepoolInstancePoolID,
+		InstancePrefix:       &testSKSNodepoolInstancePrefix,
+		InstanceTypeID:       &testSKSNodepoolInstanceTypeID,
+		Labels:               &testSKSNodepoolLabels,
+		Name:                 &testSKSNodepoolName,
+		PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkID},
+		SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupID},
+		Size:                 &testSKSNodepoolSize,
+		State:                (*string)(&testSKSNodepoolState),
+		TemplateID:           &testSKSNodepoolTemplateID,
+		Version:              &testSKSNodepoolVersion,
+	}
+
+	actual, err := ts.client.CreateSKSNodepool(context.Background(), testZone, cluster, expected)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_DeleteSKSCluster() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSClusterID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSClusterID},
+	})
+
+	ts.Require().NoError(ts.client.DeleteSKSCluster(
+		context.Background(),
+		testZone,
+		&SKSCluster{ID: &testSKSClusterID},
+	))
+	ts.Require().True(deleted)
+}
+
+func (ts *clientTestSuite) TestClient_DeleteSKSNodepool() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+	)
+
+	httpmock.RegisterResponder("DELETE",
+		fmt.Sprintf("=~^/sks-cluster/%s/nodepool/.*", testSKSClusterID),
+		func(req *http.Request) (*http.Response, error) {
+			ts.Require().Equal(fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
+				testSKSClusterID, testSKSNodepoolID), req.URL.String())
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSClusterID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	cluster := &SKSCluster{
+		ID:        &testSKSClusterID,
+		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
+	}
+
+	ts.Require().NoError(ts.client.DeleteSKSNodepool(
+		context.Background(),
+		testZone,
+		cluster,
+		cluster.Nodepools[0]),
+	)
+}
+
+func (ts *clientTestSuite) TestClient_EvictSKSNodepoolMembers() {
+	var (
+		testOperationID     = ts.randomID()
+		testOperationState  = papi.OperationStateSuccess
+		testEvictedMemberID = ts.randomID()
+		evicted             = false
+	)
+
+	cluster := &SKSCluster{
+		ID:        &testSKSClusterID,
+		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
+	}
+
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s:evict",
+		*cluster.ID,
+		*cluster.Nodepools[0].ID),
+		func(req *http.Request) (*http.Response, error) {
+			evicted = true
+
+			var actual papi.EvictSksNodepoolMembersJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.EvictSksNodepoolMembersJSONRequestBody{Instances: &[]string{testEvictedMemberID}}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSNodepoolID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	ts.Require().NoError(ts.client.EvictSKSNodepoolMembers(
+		context.Background(),
+		testZone,
+		cluster,
+		cluster.Nodepools[0],
+		[]string{testEvictedMemberID}),
+	)
+	ts.Require().True(evicted)
+}
+
+func (ts *clientTestSuite) TestClient_FindSKSCluster() {
+	ts.mockAPIRequest("GET", "/sks-cluster", struct {
+		SksClusters *[]papi.SksCluster `json:"sks-clusters,omitempty"`
+	}{
+		SksClusters: &[]papi.SksCluster{{
+			CreatedAt: &testSKSClusterCreatedAt,
+			Endpoint:  &testSKSClusterEndpoint,
+			Id:        &testSKSClusterID,
+			Level:     &testSKSClusterServiceLevel,
+			Name:      &testSKSClusterName,
+			State:     &testSKSClusterState,
+			Version:   &testSKSClusterVersion,
+		}},
+	})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID), papi.SksCluster{
+		CreatedAt: &testSKSClusterCreatedAt,
+		Endpoint:  &testSKSClusterEndpoint,
+		Id:        &testSKSClusterID,
+		Level:     &testSKSClusterServiceLevel,
+		Name:      &testSKSClusterName,
+		State:     &testSKSClusterState,
+		Version:   &testSKSClusterVersion,
+	})
+
+	expected := &SKSCluster{
+		CreatedAt:    &testSKSClusterCreatedAt,
+		Endpoint:     &testSKSClusterEndpoint,
+		ID:           &testSKSClusterID,
+		Name:         &testSKSClusterName,
+		Nodepools:    []*SKSNodepool{},
+		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
+		State:        (*string)(&testSKSClusterState),
+		Version:      &testSKSClusterVersion,
+	}
+
+	actual, err := ts.client.FindSKSCluster(context.Background(), testZone, *expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+
+	actual, err = ts.client.FindSKSCluster(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetSKSCluster() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID), papi.SksCluster{
+		Addons:      &testSKSClusterAddons,
+		AutoUpgrade: &testSKSClusterAutoUpgrade,
+		Cni:         (*papi.SksClusterCni)(&testSKSClusterCNI),
+		CreatedAt:   &testSKSClusterCreatedAt,
+		Description: &testSKSClusterDescription,
+		Endpoint:    &testSKSClusterEndpoint,
+		Id:          &testSKSClusterID,
+		Labels:      &papi.Labels{AdditionalProperties: testSKSClusterLabels},
+		Level:       &testSKSClusterServiceLevel,
+		Name:        &testSKSClusterName,
+		Nodepools: &[]papi.SksNodepool{{
+			AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
+			CreatedAt:          &testSKSNodepoolCreatedAt,
+			Description:        &testSKSNodepoolDescription,
+			DiskSize:           &testSKSNodepoolDiskSize,
+			Id:                 &testSKSNodepoolID,
+			InstancePool:       &papi.InstancePool{Id: &testSKSNodepoolInstancePoolID},
+			InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
+			Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
+			Name:               &testSKSNodepoolName,
+			PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
+			SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
+			Size:               &testSKSNodepoolSize,
+			State:              &testSKSNodepoolState,
+			Template:           &papi.Template{Id: &testSKSNodepoolTemplateID},
+			Version:            &testSKSNodepoolVersion,
+		}},
+		State:   &testSKSClusterState,
+		Version: &testSKSClusterVersion,
+	})
+
+	expected := &SKSCluster{
+		AddOns:      &[]string{string(testSKSClusterAddons[0])},
+		AutoUpgrade: &testSKSClusterAutoUpgrade,
+		CNI:         &testSKSClusterCNI,
+		CreatedAt:   &testSKSClusterCreatedAt,
+		Description: &testSKSClusterDescription,
+		Endpoint:    &testSKSClusterEndpoint,
+		ID:          &testSKSClusterID,
+		Labels:      &testSKSClusterLabels,
+		Name:        &testSKSClusterName,
+		Nodepools: []*SKSNodepool{{
+			AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupID},
+			CreatedAt:            &testSKSNodepoolCreatedAt,
+			Description:          &testSKSNodepoolDescription,
+			DiskSize:             &testSKSNodepoolDiskSize,
+			ID:                   &testSKSNodepoolID,
+			InstancePoolID:       &testSKSNodepoolInstancePoolID,
+			InstanceTypeID:       &testSKSNodepoolInstanceTypeID,
+			Labels:               &testSKSNodepoolLabels,
+			Name:                 &testSKSNodepoolName,
+			PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkID},
+			SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupID},
+			Size:                 &testSKSNodepoolSize,
+			State:                (*string)(&testSKSClusterState),
+			TemplateID:           &testSKSNodepoolTemplateID,
+			Version:              &testSKSNodepoolVersion,
+		}},
+		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
+		State:        (*string)(&testSKSClusterState),
+		Version:      &testSKSClusterVersion,
+	}
+
+	actual, err := ts.client.GetSKSCluster(context.Background(), testZone, *expected.ID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetSKSClusterAuthorityCert() {
+	var (
+		testAuthority   = "aggregation"
+		testCertificate = base64.StdEncoding.EncodeToString([]byte("test"))
+	)
+
+	cluster := &SKSCluster{
+		ID: &testSKSClusterID,
+	}
+
+	ts.mockAPIRequest("GET",
+		fmt.Sprintf("/sks-cluster/%s/authority/%s/cert", *cluster.ID, testAuthority),
+		struct {
+			Cacert string `json:"cacert,omitempty"`
+		}{
+			Cacert: testCertificate,
+		})
+
+	actual, err := ts.client.GetSKSClusterAuthorityCert(context.Background(), testZone, cluster, testAuthority)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testCertificate, actual)
+}
+
+func (ts *clientTestSuite) TestClient_GetSKSClusterKubeconfig() {
+	var (
+		testRequestUser   = "test-user"
+		testRequestGroups = []string{"system:masters"}
+		testKubeconfig    = base64.StdEncoding.EncodeToString([]byte("test"))
+	)
+
+	cluster := &SKSCluster{
+		ID: &testSKSClusterID,
+	}
+
+	ts.mockAPIRequest("POST", fmt.Sprintf("/sks-cluster-kubeconfig/%s", *cluster.ID), struct {
+		Kubeconfig string `json:"kubeconfig,omitempty"`
+	}{
+		Kubeconfig: testKubeconfig,
+	})
+
+	actual, err := ts.client.GetSKSClusterKubeconfig(
+		context.Background(),
+		testZone,
+		cluster,
+		testRequestUser,
+		testRequestGroups,
+		time.Hour,
+	)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testKubeconfig, actual)
 }
 
 func (ts *clientTestSuite) TestClient_ListSKSClusters() {
@@ -716,16 +596,10 @@ func (ts *clientTestSuite) TestClient_ListSKSClusters() {
 			State:                (*string)(&testSKSClusterState),
 			TemplateID:           &testSKSNodepoolTemplateID,
 			Version:              &testSKSNodepoolVersion,
-
-			c:    ts.client,
-			zone: testZone,
 		}},
 		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
 		State:        (*string)(&testSKSClusterState),
 		Version:      &testSKSClusterVersion,
-
-		c:    ts.client,
-		zone: testZone,
 	}}
 
 	actual, err := ts.client.ListSKSClusters(context.Background(), testZone)
@@ -754,128 +628,94 @@ func (ts *clientTestSuite) TestClient_ListSKSClusterVersions() {
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *clientTestSuite) TestClient_GetSKSCluster() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID), papi.SksCluster{
-		Addons:      &testSKSClusterAddons,
-		AutoUpgrade: &testSKSClusterAutoUpgrade,
-		Cni:         (*papi.SksClusterCni)(&testSKSClusterCNI),
-		CreatedAt:   &testSKSClusterCreatedAt,
-		Description: &testSKSClusterDescription,
-		Endpoint:    &testSKSClusterEndpoint,
-		Id:          &testSKSClusterID,
-		Labels:      &papi.Labels{AdditionalProperties: testSKSClusterLabels},
-		Level:       &testSKSClusterServiceLevel,
-		Name:        &testSKSClusterName,
-		Nodepools: &[]papi.SksNodepool{{
-			AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupID}},
-			CreatedAt:          &testSKSNodepoolCreatedAt,
-			Description:        &testSKSNodepoolDescription,
-			DiskSize:           &testSKSNodepoolDiskSize,
-			Id:                 &testSKSNodepoolID,
-			InstancePool:       &papi.InstancePool{Id: &testSKSNodepoolInstancePoolID},
-			InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeID},
-			Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabels},
-			Name:               &testSKSNodepoolName,
-			PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkID}},
-			SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupID}},
-			Size:               &testSKSNodepoolSize,
-			State:              &testSKSNodepoolState,
-			Template:           &papi.Template{Id: &testSKSNodepoolTemplateID},
-			Version:            &testSKSNodepoolVersion,
-		}},
-		State:   &testSKSClusterState,
-		Version: &testSKSClusterVersion,
-	})
+func (ts *clientTestSuite) TestClient_RotateSKSClusterCCMCredentials() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		rotated            = false
+	)
 
-	expected := &SKSCluster{
-		AddOns:      &[]string{string(testSKSClusterAddons[0])},
-		AutoUpgrade: &testSKSClusterAutoUpgrade,
-		CNI:         &testSKSClusterCNI,
-		CreatedAt:   &testSKSClusterCreatedAt,
-		Description: &testSKSClusterDescription,
-		Endpoint:    &testSKSClusterEndpoint,
-		ID:          &testSKSClusterID,
-		Labels:      &testSKSClusterLabels,
-		Name:        &testSKSClusterName,
-		Nodepools: []*SKSNodepool{{
-			AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupID},
-			CreatedAt:            &testSKSNodepoolCreatedAt,
-			Description:          &testSKSNodepoolDescription,
-			DiskSize:             &testSKSNodepoolDiskSize,
-			ID:                   &testSKSNodepoolID,
-			InstancePoolID:       &testSKSNodepoolInstancePoolID,
-			InstanceTypeID:       &testSKSNodepoolInstanceTypeID,
-			Labels:               &testSKSNodepoolLabels,
-			Name:                 &testSKSNodepoolName,
-			PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkID},
-			SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupID},
-			Size:                 &testSKSNodepoolSize,
-			State:                (*string)(&testSKSClusterState),
-			TemplateID:           &testSKSNodepoolTemplateID,
-			Version:              &testSKSNodepoolVersion,
-
-			c:    ts.client,
-			zone: testZone,
-		}},
-		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
-		State:        (*string)(&testSKSClusterState),
-		Version:      &testSKSClusterVersion,
-
-		c:    ts.client,
-		zone: testZone,
+	cluster := &SKSCluster{
+		ID: &testSKSClusterID,
 	}
 
-	actual, err := ts.client.GetSKSCluster(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/rotate-ccm-credentials", *cluster.ID),
+		func(req *http.Request) (*http.Response, error) {
+			rotated = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSClusterID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	ts.Require().NoError(ts.client.RotateSKSClusterCCMCredentials(context.Background(), testZone, cluster))
+	ts.Require().True(rotated)
 }
 
-func (ts *clientTestSuite) TestClient_FindSKSCluster() {
-	ts.mockAPIRequest("GET", "/sks-cluster", struct {
-		SksClusters *[]papi.SksCluster `json:"sks-clusters,omitempty"`
-	}{
-		SksClusters: &[]papi.SksCluster{{
-			CreatedAt: &testSKSClusterCreatedAt,
-			Endpoint:  &testSKSClusterEndpoint,
-			Id:        &testSKSClusterID,
-			Level:     &testSKSClusterServiceLevel,
-			Name:      &testSKSClusterName,
-			State:     &testSKSClusterState,
-			Version:   &testSKSClusterVersion,
-		}},
-	})
+func (ts *clientTestSuite) TestClient_ScaleSKSNodepool() {
+	var (
+		testOperationID          = ts.randomID()
+		testOperationState       = papi.OperationStateSuccess
+		testScaleSize      int64 = 3
+		scaled                   = false
+	)
 
-	ts.mockAPIRequest("GET", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID), papi.SksCluster{
-		CreatedAt: &testSKSClusterCreatedAt,
-		Endpoint:  &testSKSClusterEndpoint,
-		Id:        &testSKSClusterID,
-		Level:     &testSKSClusterServiceLevel,
-		Name:      &testSKSClusterName,
-		State:     &testSKSClusterState,
-		Version:   &testSKSClusterVersion,
-	})
-
-	expected := &SKSCluster{
-		CreatedAt:    &testSKSClusterCreatedAt,
-		Endpoint:     &testSKSClusterEndpoint,
-		ID:           &testSKSClusterID,
-		Name:         &testSKSClusterName,
-		Nodepools:    []*SKSNodepool{},
-		ServiceLevel: (*string)(&testSKSClusterServiceLevel),
-		State:        (*string)(&testSKSClusterState),
-		Version:      &testSKSClusterVersion,
-
-		c:    ts.client,
-		zone: testZone,
+	cluster := &SKSCluster{
+		ID:        &testSKSClusterID,
+		Nodepools: []*SKSNodepool{{ID: &testSKSNodepoolID}},
 	}
 
-	actual, err := ts.client.FindSKSCluster(context.Background(), testZone, *expected.ID)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s:scale",
+		*cluster.ID,
+		*cluster.Nodepools[0].ID),
+		func(req *http.Request) (*http.Response, error) {
+			scaled = true
 
-	actual, err = ts.client.FindSKSCluster(context.Background(), testZone, *expected.Name)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
+			var actual papi.ScaleSksNodepoolJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.ScaleSksNodepoolJSONRequestBody{Size: testScaleSize}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSNodepoolID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	ts.Require().NoError(ts.client.ScaleSKSNodepool(
+		context.Background(),
+		testZone,
+		cluster,
+		cluster.Nodepools[0],
+		testScaleSize,
+	))
+	ts.Require().True(scaled)
 }
 
 func (ts *clientTestSuite) TestClient_UpdateSKSCluster() {
@@ -922,14 +762,101 @@ func (ts *clientTestSuite) TestClient_UpdateSKSCluster() {
 		Reference: &papi.Reference{Id: &testSKSClusterID},
 	})
 
-	clusterUpdated := SKSCluster{
+	ts.Require().NoError(ts.client.UpdateSKSCluster(context.Background(), testZone, &SKSCluster{
 		AutoUpgrade: &testSKSClusterAutoUpgradeUpdated,
 		ID:          &testSKSClusterID,
 		Labels:      &testSKSClusterLabelsUpdated,
 		Name:        &testSKSClusterNameUpdated,
 		Description: &testSKSClusterDescriptionUpdated,
+	}))
+	ts.Require().True(updated)
+}
+
+func (ts *clientTestSuite) TestClient_UpdateSKSNodepool() {
+	var (
+		testOperationID                           = ts.randomID()
+		testSKSNodepoolAntiAffinityGroupIDUpdated = ts.randomID()
+		testSKSNodepoolDeployTargetIDUpdated      = ts.randomID()
+		testSKSNodepoolDescriptionUpdated         = testSKSNodepoolDescription + "-updated"
+		testSKSNodepoolDiskSizeUpdated            = testSKSNodepoolDiskSize + 1
+		testSKSNodepoolInstancePrefixUpdated      = testSKSNodepoolInstancePrefix + "-updated"
+		testSKSNodepoolInstanceTypeIDUpdated      = testSKSNodepoolInstanceTypeID + "-updated"
+		testSKSNodepoolLabelsUpdated              = map[string]string{"k3": "v3"}
+		testSKSNodepoolNameUpdated                = testSKSNodepoolName + "-updated"
+		testSKSNodepoolPrivateNetworkIDUpdated    = ts.randomID()
+		testSKSNodepoolSecurityGroupIDUpdated     = ts.randomID()
+		testOperationState                        = papi.OperationStateSuccess
+		updated                                   = false
+	)
+
+	cluster := &SKSCluster{
+		ID: &testSKSClusterID,
+		Nodepools: []*SKSNodepool{{
+			DeployTargetID: &testSKSNodepoolDeployTargetID,
+			Description:    &testSKSNodepoolDescription,
+			DiskSize:       &testSKSNodepoolDiskSize,
+			ID:             &testSKSNodepoolID,
+			InstancePrefix: &testSKSNodepoolInstancePrefix,
+			InstanceTypeID: &testSKSNodepoolInstanceTypeID,
+			Labels:         &testSKSNodepoolLabels,
+			Name:           &testSKSNodepoolName,
+		}},
 	}
-	ts.Require().NoError(ts.client.UpdateSKSCluster(context.Background(), testZone, &clusterUpdated))
+
+	httpmock.RegisterResponder("PUT", fmt.Sprintf("/sks-cluster/%s/nodepool/%s",
+		*cluster.ID,
+		*cluster.Nodepools[0].ID),
+		func(req *http.Request) (*http.Response, error) {
+			updated = true
+
+			var actual papi.UpdateSksNodepoolJSONRequestBody
+			ts.unmarshalJSONRequestBody(req, &actual)
+
+			expected := papi.UpdateSksNodepoolJSONRequestBody{
+				AntiAffinityGroups: &[]papi.AntiAffinityGroup{{Id: &testSKSNodepoolAntiAffinityGroupIDUpdated}},
+				DeployTarget:       &papi.DeployTarget{Id: &testSKSNodepoolDeployTargetIDUpdated},
+				Description:        &testSKSNodepoolDescriptionUpdated,
+				DiskSize:           &testSKSNodepoolDiskSizeUpdated,
+				InstancePrefix:     &testSKSNodepoolInstancePrefixUpdated,
+				InstanceType:       &papi.InstanceType{Id: &testSKSNodepoolInstanceTypeIDUpdated},
+				Labels:             &papi.Labels{AdditionalProperties: testSKSNodepoolLabelsUpdated},
+				Name:               &testSKSNodepoolNameUpdated,
+				PrivateNetworks:    &[]papi.PrivateNetwork{{Id: &testSKSNodepoolPrivateNetworkIDUpdated}},
+				SecurityGroups:     &[]papi.SecurityGroup{{Id: &testSKSNodepoolSecurityGroupIDUpdated}},
+			}
+			ts.Require().Equal(expected, actual)
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSKSNodepoolID},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSKSNodepoolID},
+	})
+
+	ts.Require().NoError(ts.client.UpdateSKSNodepool(context.Background(), testZone, cluster, &SKSNodepool{
+		AntiAffinityGroupIDs: &[]string{testSKSNodepoolAntiAffinityGroupIDUpdated},
+		DeployTargetID:       &testSKSNodepoolDeployTargetIDUpdated,
+		Description:          &testSKSNodepoolDescriptionUpdated,
+		DiskSize:             &testSKSNodepoolDiskSizeUpdated,
+		ID:                   cluster.Nodepools[0].ID,
+		InstancePrefix:       &testSKSNodepoolInstancePrefixUpdated,
+		InstanceTypeID:       &testSKSNodepoolInstanceTypeIDUpdated,
+		Labels:               &testSKSNodepoolLabelsUpdated,
+		Name:                 &testSKSNodepoolNameUpdated,
+		PrivateNetworkIDs:    &[]string{testSKSNodepoolPrivateNetworkIDUpdated},
+		SecurityGroupIDs:     &[]string{testSKSNodepoolSecurityGroupIDUpdated},
+	}))
 	ts.Require().True(updated)
 }
 
@@ -972,40 +899,7 @@ func (ts *clientTestSuite) TestClient_UgradeSKSCluster() {
 	ts.Require().NoError(ts.client.UpgradeSKSCluster(
 		context.Background(),
 		testZone,
-		testSKSClusterID,
+		&SKSCluster{ID: &testSKSClusterID},
 		testSKSClusterVersion))
 	ts.Require().True(upgraded)
-}
-
-func (ts *clientTestSuite) TestClient_DeleteSKSCluster() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		deleted            = false
-	)
-
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/sks-cluster/%s", testSKSClusterID),
-		func(req *http.Request) (*http.Response, error) {
-			deleted = true
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSKSClusterID},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSKSClusterID},
-	})
-
-	ts.Require().NoError(ts.client.DeleteSKSCluster(context.Background(), testZone, testSKSClusterID))
-	ts.Require().True(deleted)
 }

--- a/v2/snapshot.go
+++ b/v2/snapshot.go
@@ -21,85 +21,21 @@ type Snapshot struct {
 	InstanceID *string
 	Name       *string
 	State      *string
-
-	c    *Client
-	zone string
 }
 
-func snapshotFromAPI(client *Client, zone string, s *papi.Snapshot) *Snapshot {
+func snapshotFromAPI(s *papi.Snapshot) *Snapshot {
 	return &Snapshot{
 		CreatedAt:  s.CreatedAt,
 		ID:         s.Id,
 		InstanceID: s.Instance.Id,
 		Name:       s.Name,
 		State:      (*string)(s.State),
-
-		c:    client,
-		zone: zone,
 	}
 }
 
-func (s Snapshot) get(ctx context.Context, client *Client, zone, id string) (interface{}, error) {
-	return client.GetSnapshot(ctx, zone, id)
-}
-
-// Export exports the Snapshot and returns the exported Snapshot information.
-func (s *Snapshot) Export(ctx context.Context) (*SnapshotExport, error) {
-	resp, err := s.c.ExportSnapshotWithResponse(apiv2.WithZone(ctx, s.zone), *s.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := papi.NewPoller().
-		WithTimeout(s.c.timeout).
-		WithInterval(s.c.pollInterval).
-		Poll(ctx, s.c.OperationPoller(s.zone, *resp.JSON200.Id))
-	if err != nil {
-		return nil, err
-	}
-
-	expSnapshot, err := s.c.GetSnapshotWithResponse(apiv2.WithZone(ctx, s.zone), *res.(*papi.Reference).Id)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SnapshotExport{
-		MD5sum:       expSnapshot.JSON200.Export.Md5sum,
-		PresignedURL: expSnapshot.JSON200.Export.PresignedUrl,
-	}, nil
-}
-
-// ListSnapshots returns the list of existing Snapshots in the specified zone.
-func (c *Client) ListSnapshots(ctx context.Context, zone string) ([]*Snapshot, error) {
-	list := make([]*Snapshot, 0)
-
-	resp, err := c.ListSnapshotsWithResponse(apiv2.WithZone(ctx, zone))
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.JSON200.Snapshots != nil {
-		for i := range *resp.JSON200.Snapshots {
-			list = append(list, snapshotFromAPI(c, zone, &(*resp.JSON200.Snapshots)[i]))
-		}
-	}
-
-	return list, nil
-}
-
-// GetSnapshot returns the Snapshot corresponding to the specified ID in the specified zone.
-func (c *Client) GetSnapshot(ctx context.Context, zone, id string) (*Snapshot, error) {
-	resp, err := c.GetSnapshotWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return nil, err
-	}
-
-	return snapshotFromAPI(c, zone, resp.JSON200), nil
-}
-
-// DeleteSnapshot deletes the specified Snapshot in the specified zone.
-func (c *Client) DeleteSnapshot(ctx context.Context, zone, id string) error {
-	resp, err := c.DeleteSnapshotWithResponse(apiv2.WithZone(ctx, zone), id)
+// DeleteSnapshot deletes a Snapshot.
+func (c *Client) DeleteSnapshot(ctx context.Context, zone string, snapshot *Snapshot) error {
+	resp, err := c.DeleteSnapshotWithResponse(apiv2.WithZone(ctx, zone), *snapshot.ID)
 	if err != nil {
 		return err
 	}
@@ -113,4 +49,58 @@ func (c *Client) DeleteSnapshot(ctx context.Context, zone, id string) error {
 	}
 
 	return nil
+}
+
+// ExportSnapshot exports a Snapshot and returns the exported Snapshot information.
+func (c *Client) ExportSnapshot(ctx context.Context, zone string, snapshot *Snapshot) (*SnapshotExport, error) {
+	resp, err := c.ExportSnapshotWithResponse(apiv2.WithZone(ctx, zone), *snapshot.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	expSnapshot, err := c.GetSnapshotWithResponse(apiv2.WithZone(ctx, zone), *res.(*papi.Reference).Id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SnapshotExport{
+		MD5sum:       expSnapshot.JSON200.Export.Md5sum,
+		PresignedURL: expSnapshot.JSON200.Export.PresignedUrl,
+	}, nil
+}
+
+// GetSnapshot returns the Snapshot corresponding to the specified ID.
+func (c *Client) GetSnapshot(ctx context.Context, zone, id string) (*Snapshot, error) {
+	resp, err := c.GetSnapshotWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshotFromAPI(resp.JSON200), nil
+}
+
+// ListSnapshots returns the list of existing Snapshots.
+func (c *Client) ListSnapshots(ctx context.Context, zone string) ([]*Snapshot, error) {
+	list := make([]*Snapshot, 0)
+
+	resp, err := c.ListSnapshotsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.Snapshots != nil {
+		for i := range *resp.JSON200.Snapshots {
+			list = append(list, snapshotFromAPI(&(*resp.JSON200.Snapshots)[i]))
+		}
+	}
+
+	return list, nil
 }

--- a/v2/ssh_key.go
+++ b/v2/ssh_key.go
@@ -20,22 +20,35 @@ func sshKeyFromAPI(k *papi.SshKey) *SSHKey {
 	}
 }
 
-// RegisterSSHKey registers a new SSH key in the specified zone.
-func (c *Client) RegisterSSHKey(ctx context.Context, zone, name, publicKey string) (*SSHKey, error) {
-	_, err := c.RegisterSshKeyWithResponse(
-		apiv2.WithZone(ctx, zone),
-		papi.RegisterSshKeyJSONRequestBody{
-			Name:      name,
-			PublicKey: publicKey,
-		})
+// DeleteSSHKey deletes an SSH key.
+func (c *Client) DeleteSSHKey(ctx context.Context, zone string, sshKey *SSHKey) error {
+	resp, err := c.DeleteSshKeyWithResponse(apiv2.WithZone(ctx, zone), *sshKey.Name)
+	if err != nil {
+		return err
+	}
+
+	_, err = papi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetSSHKey returns the SSH key corresponding to the specified name.
+func (c *Client) GetSSHKey(ctx context.Context, zone, name string) (*SSHKey, error) {
+	resp, err := c.GetSshKeyWithResponse(apiv2.WithZone(ctx, zone), name)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.GetSSHKey(ctx, zone, name)
+	return sshKeyFromAPI(resp.JSON200), nil
 }
 
-// ListSSHKeys returns the list of existing SSH keys in the specified zone.
+// ListSSHKeys returns the list of existing SSH keys.
 func (c *Client) ListSSHKeys(ctx context.Context, zone string) ([]*SSHKey, error) {
 	list := make([]*SSHKey, 0)
 
@@ -53,30 +66,17 @@ func (c *Client) ListSSHKeys(ctx context.Context, zone string) ([]*SSHKey, error
 	return list, nil
 }
 
-// GetSSHKey returns the SSH key corresponding to the specified name in the specified zone.
-func (c *Client) GetSSHKey(ctx context.Context, zone, name string) (*SSHKey, error) {
-	resp, err := c.GetSshKeyWithResponse(apiv2.WithZone(ctx, zone), name)
+// RegisterSSHKey registers a new SSH key.
+func (c *Client) RegisterSSHKey(ctx context.Context, zone, name, publicKey string) (*SSHKey, error) {
+	_, err := c.RegisterSshKeyWithResponse(
+		apiv2.WithZone(ctx, zone),
+		papi.RegisterSshKeyJSONRequestBody{
+			Name:      name,
+			PublicKey: publicKey,
+		})
 	if err != nil {
 		return nil, err
 	}
 
-	return sshKeyFromAPI(resp.JSON200), nil
-}
-
-// DeleteSSHKey deletes the specified SSH key in the specified zone.
-func (c *Client) DeleteSSHKey(ctx context.Context, zone, id string) error {
-	resp, err := c.DeleteSshKeyWithResponse(apiv2.WithZone(ctx, zone), id)
-	if err != nil {
-		return err
-	}
-
-	_, err = papi.NewPoller().
-		WithTimeout(c.timeout).
-		WithInterval(c.pollInterval).
-		Poll(ctx, c.OperationPoller(zone, *resp.JSON200.Id))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.GetSSHKey(ctx, zone, name)
 }

--- a/v2/ssh_key_test.go
+++ b/v2/ssh_key_test.go
@@ -15,6 +15,82 @@ var (
 	testSSHKeyPublicKey   = new(clientTestSuite).randomString(10)
 )
 
+func (ts *clientTestSuite) TestClient_DeleteSSHKey() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = papi.OperationStateSuccess
+		deleted            = false
+	)
+
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/ssh-key/%s", testSSHKeyName),
+		func(req *http.Request) (*http.Response, error) {
+			deleted = true
+
+			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
+				Id:        &testOperationID,
+				State:     &testOperationState,
+				Reference: &papi.Reference{Id: &testSSHKeyName},
+			})
+			if err != nil {
+				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+			}
+
+			return resp, nil
+		})
+
+	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
+		Id:        &testOperationID,
+		State:     &testOperationState,
+		Reference: &papi.Reference{Id: &testSSHKeyName},
+	})
+
+	ts.Require().NoError(ts.client.DeleteSSHKey(context.Background(), testZone, &SSHKey{Name: &testSSHKeyName}))
+	ts.Require().True(deleted)
+}
+
+func (ts *clientTestSuite) TestClient_GetSSHKey() {
+	ts.mockAPIRequest("GET", fmt.Sprintf("/ssh-key/%s", testSSHKeyName), papi.SshKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	})
+
+	expected := &SSHKey{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	}
+
+	actual, err := ts.client.GetSSHKey(context.Background(), testZone, *expected.Name)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *clientTestSuite) TestClient_ListSSHKeys() {
+	httpmock.RegisterResponder("GET", "/ssh-key", func(req *http.Request) (*http.Response, error) {
+		resp, err := httpmock.NewJsonResponse(http.StatusOK,
+			struct {
+				SSHKeys *[]papi.SshKey `json:"ssh-keys,omitempty"`
+			}{
+				SSHKeys: &[]papi.SshKey{{
+					Fingerprint: &testSSHKeyFingerprint,
+					Name:        &testSSHKeyName,
+				}},
+			})
+		if err != nil {
+			ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
+		}
+		return resp, nil
+	})
+
+	expected := []*SSHKey{{
+		Fingerprint: &testSSHKeyFingerprint,
+		Name:        &testSSHKeyName,
+	}}
+
+	actual, err := ts.client.ListSSHKeys(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
 func (ts *clientTestSuite) TestClient_RegisterSSHKey() {
 	var (
 		testOperationID    = ts.randomID()
@@ -57,80 +133,4 @@ func (ts *clientTestSuite) TestClient_RegisterSSHKey() {
 	actual, err := ts.client.RegisterSSHKey(context.Background(), testZone, testSSHKeyName, testSSHKeyPublicKey)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_ListSSHKeys() {
-	httpmock.RegisterResponder("GET", "/ssh-key", func(req *http.Request) (*http.Response, error) {
-		resp, err := httpmock.NewJsonResponse(http.StatusOK,
-			struct {
-				SSHKeys *[]papi.SshKey `json:"ssh-keys,omitempty"`
-			}{
-				SSHKeys: &[]papi.SshKey{{
-					Fingerprint: &testSSHKeyFingerprint,
-					Name:        &testSSHKeyName,
-				}},
-			})
-		if err != nil {
-			ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-		}
-		return resp, nil
-	})
-
-	expected := []*SSHKey{{
-		Fingerprint: &testSSHKeyFingerprint,
-		Name:        &testSSHKeyName,
-	}}
-
-	actual, err := ts.client.ListSSHKeys(context.Background(), testZone)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_GetSSHKey() {
-	ts.mockAPIRequest("GET", fmt.Sprintf("/ssh-key/%s", testSSHKeyName), papi.SshKey{
-		Fingerprint: &testSSHKeyFingerprint,
-		Name:        &testSSHKeyName,
-	})
-
-	expected := &SSHKey{
-		Fingerprint: &testSSHKeyFingerprint,
-		Name:        &testSSHKeyName,
-	}
-
-	actual, err := ts.client.GetSSHKey(context.Background(), testZone, *expected.Name)
-	ts.Require().NoError(err)
-	ts.Require().Equal(expected, actual)
-}
-
-func (ts *clientTestSuite) TestClient_DeleteSSHKey() {
-	var (
-		testOperationID    = ts.randomID()
-		testOperationState = papi.OperationStateSuccess
-		deleted            = false
-	)
-
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf("/ssh-key/%s", testSSHKeyName),
-		func(req *http.Request) (*http.Response, error) {
-			deleted = true
-
-			resp, err := httpmock.NewJsonResponse(http.StatusOK, papi.Operation{
-				Id:        &testOperationID,
-				State:     &testOperationState,
-				Reference: &papi.Reference{Id: &testSSHKeyName},
-			})
-			if err != nil {
-				ts.T().Fatalf("error initializing mock HTTP responder: %s", err)
-			}
-
-			return resp, nil
-		})
-
-	ts.mockAPIRequest("GET", fmt.Sprintf("/operation/%s", testOperationID), papi.Operation{
-		Id:        &testOperationID,
-		State:     &testOperationState,
-		Reference: &papi.Reference{Id: &testSSHKeyName},
-	})
-
-	ts.Require().NoError(ts.client.DeleteSSHKey(context.Background(), testZone, testSSHKeyName))
-	ts.Require().True(deleted)
 }


### PR DESCRIPTION
## v2: major API refactor

This change overhauls the `v2` package API in a major way, relocating
the resource methods on the `v2.Client` (e.g. `Instance.Start()` ->
`Client.StartInstance()`) in order to allow mocking the client using
interfaces easily.

##  v2: add support for quotas management

This change introduces support for organization quotas management via
the Exoscale V2 API.

