### PR TITLE
v2: add Snapshot.Size field

### DIFF
--- a/v2/internal/public-api/public-api.gen.go
+++ b/v2/internal/public-api/public-api.gen.go
@@ -1659,6 +1659,9 @@ type Snapshot struct {
 	// Snapshot name
 	Name *string `json:"name,omitempty"`
 
+	// Snapshot size in GB
+	Size *int64 `json:"size,omitempty"`
+
 	// Snapshot state
 	State *SnapshotState `json:"state,omitempty"`
 }

--- a/v2/internal/public-api/snapshot.go
+++ b/v2/internal/public-api/snapshot.go
@@ -18,6 +18,7 @@ func (t *Snapshot) UnmarshalJSON(data []byte) error {
 		Id       *string        `json:"id,omitempty"` // nolint:revive
 		Instance *Instance      `json:"instance,omitempty"`
 		Name     *string        `json:"name,omitempty"`
+		Size     *int64         `json:"size,omitempty"`
 		State    *SnapshotState `json:"state,omitempty"`
 	}{}
 
@@ -37,6 +38,7 @@ func (t *Snapshot) UnmarshalJSON(data []byte) error {
 	t.Id = raw.Id
 	t.Instance = raw.Instance
 	t.Name = raw.Name
+	t.Size = raw.Size
 	t.State = raw.State
 
 	return nil
@@ -54,6 +56,7 @@ func (t *Snapshot) MarshalJSON() ([]byte, error) {
 		Id       *string        `json:"id,omitempty"` // nolint:revive
 		Instance *Instance      `json:"instance,omitempty"`
 		Name     *string        `json:"name,omitempty"`
+		Size     *int64         `json:"size,omitempty"`
 		State    *SnapshotState `json:"state,omitempty"`
 	}{}
 
@@ -66,6 +69,7 @@ func (t *Snapshot) MarshalJSON() ([]byte, error) {
 	raw.Id = t.Id
 	raw.Instance = t.Instance
 	raw.Name = t.Name
+	raw.Size = t.Size
 	raw.State = t.State
 
 	return json.Marshal(raw)

--- a/v2/internal/public-api/snapshot_test.go
+++ b/v2/internal/public-api/snapshot_test.go
@@ -11,13 +11,14 @@ import (
 
 func TestSnapshot_UnmarshalJSON(t *testing.T) {
 	var (
-		testCreatedAt, _ = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
-		testID           = testRandomID(t)
-		testInstanceID   = testRandomID(t)
-		testName         = "test_ROOT-846459_20200706132534"
-		testExportMD5Sum = "c9887de796993c2519b463bcd9509e08"
-		testExportURL    = fmt.Sprintf("https://sos-ch-gva-2.exo.io/test/%s/%s", testRandomID(t), testID)
-		testState        = SnapshotStateExported
+		testCreatedAt, _       = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
+		testID                 = testRandomID(t)
+		testInstanceID         = testRandomID(t)
+		testName               = "test_ROOT-846459_20200706132534"
+		testExportMD5Sum       = "c9887de796993c2519b463bcd9509e08"
+		testExportURL          = fmt.Sprintf("https://sos-ch-gva-2.exo.io/test/%s/%s", testRandomID(t), testID)
+		testSize         int64 = 10
+		testState              = SnapshotStateExported
 
 		expected = Snapshot{
 			CreatedAt: &testCreatedAt,
@@ -31,6 +32,7 @@ func TestSnapshot_UnmarshalJSON(t *testing.T) {
 			Id:       &testID,
 			Instance: &Instance{Id: &testInstanceID},
 			Name:     &testName,
+			Size:     &testSize,
 			State:    &testState,
 		}
 
@@ -42,6 +44,7 @@ func TestSnapshot_UnmarshalJSON(t *testing.T) {
   "id": "` + testID + `",
   "instance": {"id": "` + testInstanceID + `"},
   "name": "` + testName + `",
+  "size": ` + fmt.Sprint(testSize) + `,
   "state": "` + string(testState) + `"
 }`
 	)
@@ -52,13 +55,14 @@ func TestSnapshot_UnmarshalJSON(t *testing.T) {
 
 func TestSnapshot_MarshalJSON(t *testing.T) {
 	var (
-		testCreatedAt, _ = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
-		testID           = testRandomID(t)
-		testInstanceID   = testRandomID(t)
-		testName         = "test_ROOT-846459_20200706132534"
-		testExportMD5Sum = "c9887de796993c2519b463bcd9509e08"
-		testExportURL    = fmt.Sprintf("https://sos-ch-gva-2.exo.io/test/%s/%s", testRandomID(t), testID)
-		testState        = SnapshotStateExported
+		testCreatedAt, _       = time.Parse(iso8601Format, "2020-08-12T11:12:36Z")
+		testID                 = testRandomID(t)
+		testInstanceID         = testRandomID(t)
+		testName               = "test_ROOT-846459_20200706132534"
+		testExportMD5Sum       = "c9887de796993c2519b463bcd9509e08"
+		testExportURL          = fmt.Sprintf("https://sos-ch-gva-2.exo.io/test/%s/%s", testRandomID(t), testID)
+		testSize         int64 = 10
+		testState              = SnapshotStateExported
 
 		snapshot = Snapshot{
 			CreatedAt: &testCreatedAt,
@@ -72,6 +76,7 @@ func TestSnapshot_MarshalJSON(t *testing.T) {
 			Id:       &testID,
 			Instance: &Instance{Id: &testInstanceID},
 			Name:     &testName,
+			Size:     &testSize,
 			State:    &testState,
 		}
 
@@ -81,6 +86,7 @@ func TestSnapshot_MarshalJSON(t *testing.T) {
 			`"id":"` + testID + `",` +
 			`"instance":{"id":"` + testInstanceID + `"},` +
 			`"name":"` + testName + `",` +
+			`"size":` + fmt.Sprint(testSize) + "," +
 			`"state":"` + string(testState) + `"` +
 			`}`)
 	)

--- a/v2/snapshot.go
+++ b/v2/snapshot.go
@@ -20,6 +20,7 @@ type Snapshot struct {
 	ID         *string
 	InstanceID *string
 	Name       *string
+	Size       *int64
 	State      *string
 }
 
@@ -29,6 +30,7 @@ func snapshotFromAPI(s *papi.Snapshot) *Snapshot {
 		ID:         s.Id,
 		InstanceID: s.Instance.Id,
 		Name:       s.Name,
+		Size:       s.Size,
 		State:      (*string)(s.State),
 	}
 }

--- a/v2/snapshot_test.go
+++ b/v2/snapshot_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	testSnapshotCreatedAt, _ = time.Parse(iso8601Format, "2020-05-26T12:09:42Z")
-	testSnapshotID           = new(clientTestSuite).randomID()
-	testSnapshotInstanceID   = new(clientTestSuite).randomID()
-	testSnapshotName         = new(clientTestSuite).randomString(10)
-	testSnapshotState        = papi.SnapshotStateExported
+	testSnapshotCreatedAt, _       = time.Parse(iso8601Format, "2020-05-26T12:09:42Z")
+	testSnapshotID                 = new(clientTestSuite).randomID()
+	testSnapshotInstanceID         = new(clientTestSuite).randomID()
+	testSnapshotName               = new(clientTestSuite).randomString(10)
+	testSnapshotSize         int64 = 10
+	testSnapshotState              = papi.SnapshotStateExported
 )
 
 func (ts *clientTestSuite) TestClient_DeleteSnapshot() {
@@ -120,6 +121,7 @@ func (ts *clientTestSuite) TestClient_ListSnapshots() {
 			Id:        &testSnapshotID,
 			Instance:  &papi.Instance{Id: &testSnapshotInstanceID},
 			Name:      &testSnapshotName,
+			Size:      &testSnapshotSize,
 			State:     &testSnapshotState,
 		}},
 	})
@@ -129,6 +131,7 @@ func (ts *clientTestSuite) TestClient_ListSnapshots() {
 		ID:         &testSnapshotID,
 		InstanceID: &testSnapshotInstanceID,
 		Name:       &testSnapshotName,
+		Size:       &testSnapshotSize,
 		State:      (*string)(&testSnapshotState),
 	}}
 
@@ -143,6 +146,7 @@ func (ts *clientTestSuite) TestClient_GetSnapshot() {
 		Id:        &testSnapshotID,
 		Instance:  &papi.Instance{Id: &testSnapshotInstanceID},
 		Name:      &testSnapshotName,
+		Size:      &testSnapshotSize,
 		State:     &testSnapshotState,
 	})
 
@@ -151,6 +155,7 @@ func (ts *clientTestSuite) TestClient_GetSnapshot() {
 		ID:         &testSnapshotID,
 		InstanceID: &testSnapshotInstanceID,
 		Name:       &testSnapshotName,
+		Size:       &testSnapshotSize,
 		State:      (*string)(&testSnapshotState),
 	}
 


### PR DESCRIPTION
This change introduces the missing `Snapshot.Size` struct field.