### PR TITLE
v2: add method Client.GetDatabaseCACertificate()

### DIFF
--- a/v2/database.go
+++ b/v2/database.go
@@ -228,6 +228,16 @@ func databaseServiceFromAPI(s *papi.DbaasService) *DatabaseService {
 	}
 }
 
+// GetDatabaseCACertificate returns the CA certificate required to access Database Services using a TLS connection.
+func (c *Client) GetDatabaseCACertificate(ctx context.Context, zone string) (string, error) {
+	resp, err := c.GetDbaasCaCertificateWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return "", err
+	}
+
+	return *resp.JSON200.Certificate, nil
+}
+
 // GetDatabaseServiceType returns the Database Service type corresponding to the specified name.
 func (c *Client) GetDatabaseServiceType(ctx context.Context, zone, name string) (*DatabaseServiceType, error) {
 	resp, err := c.GetDbaasServiceTypeWithResponse(apiv2.WithZone(ctx, zone), name)

--- a/v2/database_test.go
+++ b/v2/database_test.go
@@ -228,6 +228,23 @@ func (ts *clientTestSuite) TestClient_DeleteDatabaseService() {
 	ts.Require().True(deleted)
 }
 
+func (ts *clientTestSuite) TestClient_GetDatabaseCACertificate() {
+	testCACertificate := `-----BEGIN CERTIFICATE-----
+` + ts.randomString(1000) +
+		`-----END CERTIFICATE-----
+`
+
+	ts.mockAPIRequest("GET", "/dbaas-ca-certificate", struct {
+		Certificate *string "json:\"certificate,omitempty\""
+	}{
+		Certificate: &testCACertificate,
+	})
+
+	actual, err := ts.client.GetDatabaseCACertificate(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(testCACertificate, actual)
+}
+
 func (ts *clientTestSuite) TestClient_GetDatabaseService() {
 	ts.mockAPIRequest("GET",
 		fmt.Sprintf("/dbaas-service/%s", testDatabaseServiceName),


### PR DESCRIPTION
This change introduces a new method `GetDatabaseCACertificate()`
allowing users to retrieve the CA certificate to be used to access
Database Service using a TLS connection.