### PR TITLE
v2: add "AntiAffinityGroup.InstanceIDs" field

### DIFF
--- a/v2/anti_affinity_group.go
+++ b/v2/anti_affinity_group.go
@@ -11,6 +11,7 @@ import (
 type AntiAffinityGroup struct {
 	Description *string
 	ID          *string
+	InstanceIDs *[]string
 	Name        *string `req-for:"create"`
 }
 
@@ -18,7 +19,17 @@ func antiAffinityGroupFromAPI(a *papi.AntiAffinityGroup) *AntiAffinityGroup {
 	return &AntiAffinityGroup{
 		Description: a.Description,
 		ID:          a.Id,
-		Name:        a.Name,
+		InstanceIDs: func() (v *[]string) {
+			if a.Instances != nil && len(*a.Instances) > 0 {
+				ids := make([]string, len(*a.Instances))
+				for i, item := range *a.Instances {
+					ids[i] = *item.Id
+				}
+				v = &ids
+			}
+			return
+		}(),
+		Name: a.Name,
 	}
 }
 

--- a/v2/anti_affinity_group_test.go
+++ b/v2/anti_affinity_group_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	testAntiAffinityGroupDescription = new(clientTestSuite).randomString(10)
 	testAntiAffinityGroupID          = new(clientTestSuite).randomID()
+	testAntiAffinityGroupInstanceID  = new(clientTestSuite).randomID()
 	testAntiAffinityGroupName        = new(clientTestSuite).randomString(10)
 )
 
@@ -126,12 +127,14 @@ func (ts *clientTestSuite) TestClient_FindAntiAffinityGroup() {
 		papi.AntiAffinityGroup{
 			Description: &testAntiAffinityGroupDescription,
 			Id:          &testAntiAffinityGroupID,
+			Instances:   &[]papi.Instance{{Id: &testAntiAffinityGroupInstanceID}},
 			Name:        &testAntiAffinityGroupName,
 		})
 
 	expected := &AntiAffinityGroup{
 		Description: &testAntiAffinityGroupDescription,
 		ID:          &testAntiAffinityGroupID,
+		InstanceIDs: &[]string{testAntiAffinityGroupInstanceID},
 		Name:        &testAntiAffinityGroupName,
 	}
 
@@ -151,12 +154,14 @@ func (ts *clientTestSuite) TestClient_GetAntiAffinityGroup() {
 		papi.AntiAffinityGroup{
 			Description: &testAntiAffinityGroupDescription,
 			Id:          &testAntiAffinityGroupID,
+			Instances:   &[]papi.Instance{{Id: &testAntiAffinityGroupInstanceID}},
 			Name:        &testAntiAffinityGroupName,
 		})
 
 	expected := &AntiAffinityGroup{
 		Description: &testAntiAffinityGroupDescription,
 		ID:          &testAntiAffinityGroupID,
+		InstanceIDs: &[]string{testAntiAffinityGroupInstanceID},
 		Name:        &testAntiAffinityGroupName,
 	}
 
@@ -172,6 +177,7 @@ func (ts *clientTestSuite) TestClient_ListAntiAffinityGroups() {
 		AntiAffinityGroups: &[]papi.AntiAffinityGroup{{
 			Description: &testAntiAffinityGroupDescription,
 			Id:          &testAntiAffinityGroupID,
+			Instances:   &[]papi.Instance{{Id: &testAntiAffinityGroupInstanceID}},
 			Name:        &testAntiAffinityGroupName,
 		}},
 	})
@@ -179,6 +185,7 @@ func (ts *clientTestSuite) TestClient_ListAntiAffinityGroups() {
 	expected := []*AntiAffinityGroup{{
 		Description: &testAntiAffinityGroupDescription,
 		ID:          &testAntiAffinityGroupID,
+		InstanceIDs: &[]string{testAntiAffinityGroupInstanceID},
 		Name:        &testAntiAffinityGroupName,
 	}}
 


### PR DESCRIPTION
This change adds a new `InstanceIDs` field to the `AntiAffinityGroup`
resource.