### PR TITLE
v2: fix CreateSecurityGroupRule() method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ run:
   timeout: 10m
 
 linters-settings:
-  gocyclo:
-    min-complexity: 28
   goimports:
     local-prefixes: github.com
 
@@ -13,7 +11,6 @@ linters:
     - errcheck
     - exportloopref
     - gocritic
-    - gocyclo
     - goimports
     - gosimple
     - govet

--- a/v2/security_group_rule_test.go
+++ b/v2/security_group_rule_test.go
@@ -28,8 +28,9 @@ var (
 
 func (ts *testSuite) TestClient_CreateSecurityGroupRule() {
 	var (
-		testOperationID    = ts.randomID()
-		testOperationState = oapi.OperationStateSuccess
+		testOperationID                        = ts.randomID()
+		testOperationState                     = oapi.OperationStateSuccess
+		testAlreadyExistingSecurityGroupRuleID = ts.randomID()
 	)
 
 	ts.mock().
@@ -89,23 +90,77 @@ func (ts *testSuite) TestClient_CreateSecurityGroupRule() {
 				Description: &testSecurityGroupDescription,
 				Id:          &testSecurityGroupID,
 				Name:        &testSecurityGroupName,
-				Rules: &[]oapi.SecurityGroupRule{{
-					Description:   &testSecurityGroupRuleDescription,
-					EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort); return &v }(),
-					FlowDirection: &testSecurityGroupRuleFlowDirection,
-					Icmp: &struct {
-						Code *int64 `json:"code,omitempty"`
-						Type *int64 `json:"type,omitempty"`
-					}{
-						Code: &testSecurityGroupRuleICMPCode,
-						Type: &testSecurityGroupRuleICMPType,
+				Rules: &[]oapi.SecurityGroupRule{
+					{
+						Description:   &testSecurityGroupRuleDescription,
+						EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort - 1); return &v }(),
+						FlowDirection: &testSecurityGroupRuleFlowDirection,
+						Icmp: &struct {
+							Code *int64 `json:"code,omitempty"`
+							Type *int64 `json:"type,omitempty"`
+						}{
+							Code: &testSecurityGroupRuleICMPCode,
+							Type: &testSecurityGroupRuleICMPType,
+						},
+						Id:            &testAlreadyExistingSecurityGroupRuleID,
+						Network:       &testSecurityGroupRuleNetwork,
+						Protocol:      &testSecurityGroupRuleProtocol,
+						SecurityGroup: &oapi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
+						StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
 					},
-					Id:            &testSecurityGroupRuleID,
-					Network:       &testSecurityGroupRuleNetwork,
-					Protocol:      &testSecurityGroupRuleProtocol,
-					SecurityGroup: &oapi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
-					StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
-				}},
+				},
+			},
+		}, nil).
+		Once()
+
+	ts.mock().
+		On("GetSecurityGroupWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // id
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Return(&oapi.GetSecurityGroupResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &oapi.SecurityGroup{
+				Description: &testSecurityGroupDescription,
+				Id:          &testSecurityGroupID,
+				Name:        &testSecurityGroupName,
+				Rules: &[]oapi.SecurityGroupRule{
+					{
+						Description:   &testSecurityGroupRuleDescription,
+						EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort - 1); return &v }(),
+						FlowDirection: &testSecurityGroupRuleFlowDirection,
+						Icmp: &struct {
+							Code *int64 `json:"code,omitempty"`
+							Type *int64 `json:"type,omitempty"`
+						}{
+							Code: &testSecurityGroupRuleICMPCode,
+							Type: &testSecurityGroupRuleICMPType,
+						},
+						Id:            &testAlreadyExistingSecurityGroupRuleID,
+						Network:       &testSecurityGroupRuleNetwork,
+						Protocol:      &testSecurityGroupRuleProtocol,
+						SecurityGroup: &oapi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
+						StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
+					},
+					{
+						Description:   &testSecurityGroupRuleDescription,
+						EndPort:       func() *int64 { v := int64(testSecurityGroupRuleEndPort); return &v }(),
+						FlowDirection: &testSecurityGroupRuleFlowDirection,
+						Icmp: &struct {
+							Code *int64 `json:"code,omitempty"`
+							Type *int64 `json:"type,omitempty"`
+						}{
+							Code: &testSecurityGroupRuleICMPCode,
+							Type: &testSecurityGroupRuleICMPType,
+						},
+						Id:            &testSecurityGroupRuleID,
+						Network:       &testSecurityGroupRuleNetwork,
+						Protocol:      &testSecurityGroupRuleProtocol,
+						SecurityGroup: &oapi.SecurityGroupResource{Id: testSecurityGroupRuleSecurityGroupID},
+						StartPort:     func() *int64 { v := int64(testSecurityGroupRuleStartPort); return &v }(),
+					},
+				},
 			},
 		}, nil)
 


### PR DESCRIPTION
This change fixes a bug in the `CreateSecurityGroupRule()` method, which
previous heuristic to identify which Security Group rule to return to
the call was too lax and resulted in incorrect results. The new
implementation is now stricter, at the cost of an extra API call.