### PR TITLE
Add an helper function to list sks cluster deprecated resources

### DIFF
--- a/v2/sks_cluster.go
+++ b/v2/sks_cluster.go
@@ -258,6 +258,55 @@ func (c *Client) GetSKSClusterAuthorityCert(
 	return oapi.OptionalString(resp.JSON200.Cacert), nil
 }
 
+// SKSClusterDeprecatedResource represents an resources deployed in a cluster
+// that will be removed in a future release of Kubernetes.
+type SKSClusterDeprecatedResource struct {
+	Group          *string
+	RemovedRelease *string
+	Resource       *string
+	SubResource    *string
+	Version        *string
+	RawProperties  map[string]string
+}
+
+func sksClusterDeprecatedResourcesFromAPI(c *oapi.SksClusterDeprecatedResource, zone string) *SKSClusterDeprecatedResource {
+	return &SKSClusterDeprecatedResource{
+		Group:          (*string)(mapValueOrNil(c.AdditionalProperties, "group")),
+		RemovedRelease: (*string)(mapValueOrNil(c.AdditionalProperties, "removed_release")),
+		Resource:       (*string)(mapValueOrNil(c.AdditionalProperties, "resource")),
+		SubResource:    (*string)(mapValueOrNil(c.AdditionalProperties, "subresource")),
+		Version:        (*string)(mapValueOrNil(c.AdditionalProperties, "version")),
+		RawProperties:  c.AdditionalProperties,
+	}
+}
+
+func (c *Client) ListSKSClusterDeprecatedResources(
+	ctx context.Context,
+	zone string,
+	cluster *SKSCluster,
+) ([]*SKSClusterDeprecatedResource, error) {
+	if err := validateOperationParams(cluster, "update"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.ListSksClusterDeprecatedResourcesWithResponse(
+		apiv2.WithZone(ctx, zone),
+		*cluster.ID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var list []*SKSClusterDeprecatedResource
+	if resp.JSON200 != nil && len(*resp.JSON200) > 0 {
+		for i := range *resp.JSON200 {
+			list = append(list, sksClusterDeprecatedResourcesFromAPI(&(*resp.JSON200)[i], zone))
+		}
+	}
+
+	return list, nil
+}
+
 // GetSKSClusterKubeconfig returns a base64-encoded kubeconfig content for the specified user name, optionally
 // associated to specified groups for a duration d (default API-set TTL applies if not specified).
 // Fore more information: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -1,0 +1,9 @@
+package v2
+
+func mapValueOrNil(src map[string]string, key string) *string {
+	if x, found := src[key]; found {
+		return &x
+	}
+
+	return nil
+}


### PR DESCRIPTION
Returns an array of structures like that:

```
type SKSClusterDeprecatedResource struct {
	Group          *string
	RemovedRelease *string
	Resource       *string
	SubResource    *string
	Version        *string
	RawProperties  map[string]string
}
```
Example data:
```
{
  "Group": "policy",
  "RemovedRelease": "1.25",
  "Resource": "podsecuritypolicies",
  "SubResource": "",
  "Version": "v1beta1",
  "RawProperties": {
    "group": "policy",
    "removed_release": "1.25",
    "resource": "podsecuritypolicies",
    "subresource": "",
    "version": "v1beta1"
  }
}
```