### PR TITLE
security: use escaped path in signature to align with public API

### DIFF
--- a/v2/api/security.go
+++ b/v2/api/security.go
@@ -56,7 +56,7 @@ func (s *SecurityProviderExoscale) signRequest(req *http.Request, expiration tim
 	)
 
 	// Request method/URL path
-	sigParts = append(sigParts, fmt.Sprintf("%s %s", req.Method, req.URL.Path))
+	sigParts = append(sigParts, fmt.Sprintf("%s %s", req.Method, req.URL.EscapedPath()))
 	headerParts = append(headerParts, "EXO2-HMAC-SHA256 credential="+s.apiKey)
 
 	// Request body if present


### PR DESCRIPTION
This PR fixes a bug with signature validation on some API calls.

One component that is signed is the URL path parameter. Public API checks signature against urlencoded path while egoscale signs unencoded one. This means public API would fail signature check when path component has unsafe character in url (observed for SSH key name with space character, endpoint: `https://<zone>.exoscale.com/v2/ssh-key/some%20key`). This PR aligns request signature logic to the public API.