### PR TITLE
v2: DNS resources from Public API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,3 +25,16 @@ linters:
     - unused
     - varcheck
   disable-all: true
+
+issues:
+  exclude-rules:
+    # stop revive from complaining about naming issues that originate from oapi generated code.
+    - path: v2/dns.go
+      linters:
+        - revive
+    - path: v2/dns_test.go
+      linters:
+        - revive
+    - path: v2/client_mock.go
+      linters:
+        - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,12 +29,6 @@ linters:
 issues:
   exclude-rules:
     # stop revive from complaining about naming issues that originate from oapi generated code.
-    - path: v2/dns.go
-      linters:
-        - revive
-    - path: v2/dns_test.go
-      linters:
-        - revive
     - path: v2/client_mock.go
       linters:
         - revive

--- a/v2/client_mock.go
+++ b/v2/client_mock.go
@@ -1006,3 +1006,97 @@ func (m *oapiClientMock) GetDbaasMigrationStatusWithResponse(
 	args := m.Called(ctx, name, reqEditors)
 	return args.Get(0).(*oapi.GetDbaasMigrationStatusResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) ListDnsDomainsWithResponse(
+	ctx context.Context,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.ListDnsDomainsResponse, error) {
+	args := m.Called(ctx, reqEditors)
+	return args.Get(0).(*oapi.ListDnsDomainsResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) CreateDnsDomainWithResponse(
+	ctx context.Context,
+	body oapi.CreateDnsDomainJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.CreateDnsDomainResponse, error) {
+	args := m.Called(ctx, body, reqEditors)
+	return args.Get(0).(*oapi.CreateDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteDnsDomainWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteDnsDomainResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.DeleteDnsDomainResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainZoneFileWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainZoneFileResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainZoneFileResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) ListDnsDomainRecordsWithResponse(
+	ctx context.Context,
+	id string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.ListDnsDomainRecordsResponse, error) {
+	args := m.Called(ctx, id, reqEditors)
+	return args.Get(0).(*oapi.ListDnsDomainRecordsResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) GetDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.GetDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, reqEditors)
+	return args.Get(0).(*oapi.GetDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) CreateDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	body oapi.CreateDnsDomainRecordJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.CreateDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, body, reqEditors)
+	return args.Get(0).(*oapi.CreateDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) DeleteDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.DeleteDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, reqEditors)
+	return args.Get(0).(*oapi.DeleteDnsDomainRecordResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) UpdateDnsDomainRecordWithResponse(
+	ctx context.Context,
+	domainId string,
+	recordId string,
+	body oapi.UpdateDnsDomainRecordJSONRequestBody,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.UpdateDnsDomainRecordResponse, error) {
+	args := m.Called(ctx, domainId, recordId, body, reqEditors)
+	return args.Get(0).(*oapi.UpdateDnsDomainRecordResponse), args.Error(1)
+}

--- a/v2/dns.go
+++ b/v2/dns.go
@@ -1,0 +1,260 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// DnsDomain represents a DNS domain.
+type DnsDomain struct {
+	CreatedAt   *time.Time
+	ID          *string `req-for:"delete"`
+	UnicodeName *string `req-for:"create"`
+}
+
+// DnsDomainRecord represents a DNS record.
+type DnsDomainRecord struct {
+	Content   *string `req-for:"create"`
+	CreatedAt *time.Time
+	ID        *string `req-for:"delete,update"`
+	Name      *string `req-for:"create"`
+	Priority  *int64
+	Ttl       *int64
+	Type      *string `req-for:"create"`
+	UpdatedAt *time.Time
+}
+
+func dnsDomainFromAPI(d *oapi.DnsDomain) *DnsDomain {
+	return &DnsDomain{
+		CreatedAt:   d.CreatedAt,
+		ID:          d.Id,
+		UnicodeName: d.UnicodeName,
+	}
+}
+
+func dnsDomainRecordFromAPI(d *oapi.DnsDomainRecord) *DnsDomainRecord {
+	var t *string
+	if d.Type != nil {
+		x := string(*d.Type)
+		t = &x
+	}
+	return &DnsDomainRecord{
+		Content:   d.Content,
+		CreatedAt: d.CreatedAt,
+		ID:        d.Id,
+		Name:      d.Name,
+		Priority:  d.Priority,
+		Ttl:       d.Ttl,
+		Type:      t,
+		UpdatedAt: d.UpdatedAt,
+	}
+}
+
+// ListDnsDomains returns the list of DNS domains.
+func (c *Client) ListDnsDomains(ctx context.Context, zone string) ([]DnsDomain, error) {
+	var list []DnsDomain
+
+	resp, err := c.ListDnsDomainsWithResponse(apiv2.WithZone(ctx, zone))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.DnsDomains != nil {
+		for _, domain := range *resp.JSON200.DnsDomains {
+			list = append(list, *dnsDomainFromAPI(&domain))
+		}
+	}
+
+	return list, nil
+}
+
+// GetDnsDomain returns DNS domain details.
+func (c *Client) GetDnsDomain(ctx context.Context, zone, id string) (*DnsDomain, error) {
+	resp, err := c.GetDnsDomainWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return dnsDomainFromAPI(resp.JSON200), nil
+}
+
+// DeleteDnsDomain deletes a DNS domain.
+func (c *Client) DeleteDnsDomain(ctx context.Context, zone string, domain *DnsDomain) error {
+	if err := validateOperationParams(domain, "delete"); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteDnsDomainWithResponse(apiv2.WithZone(ctx, zone), *domain.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateDnsDomain adds a new DNS domain.
+func (c *Client) CreateDnsDomain(
+	ctx context.Context,
+	zone string,
+	domain *DnsDomain,
+) (*DnsDomain, error) {
+	if err := validateOperationParams(domain, "create"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.CreateDnsDomainWithResponse(apiv2.WithZone(ctx, zone), oapi.CreateDnsDomainJSONRequestBody{
+		UnicodeName: domain.UnicodeName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetDnsDomain(ctx, zone, *r.(*struct {
+		Command *string `json:"command,omitempty"`
+		Id      *string `json:"id,omitempty"` // revive:disable-line
+		Link    *string `json:"link,omitempty"`
+	}).Id)
+}
+
+// GetDnsDomainZoneFile returns zone file of a DNS domain.
+func (c *Client) GetDnsDomainZoneFile(ctx context.Context, zone, id string) ([]byte, error) {
+	resp, err := c.GetDnsDomainZoneFileWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// ListDnsDomainRecords returns the list of records for DNS domain.
+func (c *Client) ListDnsDomainRecords(ctx context.Context, zone, id string) ([]DnsDomainRecord, error) {
+	var list []DnsDomainRecord
+
+	resp, err := c.ListDnsDomainRecordsWithResponse(apiv2.WithZone(ctx, zone), id)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON200.DnsDomainRecords != nil {
+		for _, record := range *resp.JSON200.DnsDomainRecords {
+			list = append(list, *dnsDomainRecordFromAPI(&record))
+		}
+	}
+
+	return list, nil
+}
+
+// GetDnsDomainRecord returns a single DNS domain record.
+func (c *Client) GetDnsDomainRecord(ctx context.Context, zone, domainID, recordID string) (*DnsDomainRecord, error) {
+	resp, err := c.GetDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, recordID)
+	if err != nil {
+		return nil, err
+	}
+
+	return dnsDomainRecordFromAPI(resp.JSON200), nil
+}
+
+// CreateDnsDomainRecord adds a new DNS record for domain.
+func (c *Client) CreateDnsDomainRecord(
+	ctx context.Context,
+	zone string,
+	domainID string,
+	record *DnsDomainRecord,
+) (*DnsDomainRecord, error) {
+	if err := validateOperationParams(record, "create"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.CreateDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, oapi.CreateDnsDomainRecordJSONRequestBody{
+		Content:  *record.Content,
+		Name:     *record.Name,
+		Priority: record.Priority,
+		Ttl:      record.Ttl,
+		Type:     oapi.CreateDnsDomainRecordJSONBodyType(*record.Type),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetDnsDomainRecord(ctx, zone, domainID, *r.(*struct {
+		Command *string `json:"command,omitempty"`
+		Id      *string `json:"id,omitempty"` // revive:disable-line
+		Link    *string `json:"link,omitempty"`
+	}).Id)
+}
+
+// DeleteDnsDomainRecord deletes a DNS domain record.
+func (c *Client) DeleteDnsDomainRecord(ctx context.Context, zone, domainID string, record *DnsDomainRecord) error {
+	if err := validateOperationParams(record, "delete"); err != nil {
+		return err
+	}
+
+	resp, err := c.DeleteDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, *record.ID)
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateDnsDomainRecord updates existing DNS domain record.
+func (c *Client) UpdateDnsDomainRecord(ctx context.Context, zone, domainID string, record *DnsDomainRecord) error {
+	if err := validateOperationParams(record, "update"); err != nil {
+		return err
+	}
+
+	resp, err := c.UpdateDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, *record.ID, oapi.UpdateDnsDomainRecordJSONRequestBody{
+		Content:  record.Content,
+		Name:     record.Name,
+		Priority: record.Priority,
+		Ttl:      record.Ttl,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/dns.go
+++ b/v2/dns.go
@@ -8,54 +8,54 @@ import (
 	"github.com/exoscale/egoscale/v2/oapi"
 )
 
-// DnsDomain represents a DNS domain.
-type DnsDomain struct {
+// DNSDomain represents a DNS domain.
+type DNSDomain struct {
 	CreatedAt   *time.Time
 	ID          *string `req-for:"delete"`
 	UnicodeName *string `req-for:"create"`
 }
 
-// DnsDomainRecord represents a DNS record.
-type DnsDomainRecord struct {
+// DNSDomainRecord represents a DNS record.
+type DNSDomainRecord struct {
 	Content   *string `req-for:"create"`
 	CreatedAt *time.Time
 	ID        *string `req-for:"delete,update"`
 	Name      *string `req-for:"create"`
 	Priority  *int64
-	Ttl       *int64
+	TTL       *int64
 	Type      *string `req-for:"create"`
 	UpdatedAt *time.Time
 }
 
-func dnsDomainFromAPI(d *oapi.DnsDomain) *DnsDomain {
-	return &DnsDomain{
+func dnsDomainFromAPI(d *oapi.DnsDomain) *DNSDomain {
+	return &DNSDomain{
 		CreatedAt:   d.CreatedAt,
 		ID:          d.Id,
 		UnicodeName: d.UnicodeName,
 	}
 }
 
-func dnsDomainRecordFromAPI(d *oapi.DnsDomainRecord) *DnsDomainRecord {
+func dnsDomainRecordFromAPI(d *oapi.DnsDomainRecord) *DNSDomainRecord {
 	var t *string
 	if d.Type != nil {
 		x := string(*d.Type)
 		t = &x
 	}
-	return &DnsDomainRecord{
+	return &DNSDomainRecord{
 		Content:   d.Content,
 		CreatedAt: d.CreatedAt,
 		ID:        d.Id,
 		Name:      d.Name,
 		Priority:  d.Priority,
-		Ttl:       d.Ttl,
+		TTL:       d.Ttl,
 		Type:      t,
 		UpdatedAt: d.UpdatedAt,
 	}
 }
 
-// ListDnsDomains returns the list of DNS domains.
-func (c *Client) ListDnsDomains(ctx context.Context, zone string) ([]DnsDomain, error) {
-	var list []DnsDomain
+// ListDNSDomains returns the list of DNS domains.
+func (c *Client) ListDNSDomains(ctx context.Context, zone string) ([]DNSDomain, error) {
+	var list []DNSDomain
 
 	resp, err := c.ListDnsDomainsWithResponse(apiv2.WithZone(ctx, zone))
 	if err != nil {
@@ -71,8 +71,8 @@ func (c *Client) ListDnsDomains(ctx context.Context, zone string) ([]DnsDomain, 
 	return list, nil
 }
 
-// GetDnsDomain returns DNS domain details.
-func (c *Client) GetDnsDomain(ctx context.Context, zone, id string) (*DnsDomain, error) {
+// GetDNSDomain returns DNS domain details.
+func (c *Client) GetDNSDomain(ctx context.Context, zone, id string) (*DNSDomain, error) {
 	resp, err := c.GetDnsDomainWithResponse(apiv2.WithZone(ctx, zone), id)
 	if err != nil {
 		return nil, err
@@ -81,8 +81,8 @@ func (c *Client) GetDnsDomain(ctx context.Context, zone, id string) (*DnsDomain,
 	return dnsDomainFromAPI(resp.JSON200), nil
 }
 
-// DeleteDnsDomain deletes a DNS domain.
-func (c *Client) DeleteDnsDomain(ctx context.Context, zone string, domain *DnsDomain) error {
+// DeleteDNSDomain deletes a DNS domain.
+func (c *Client) DeleteDNSDomain(ctx context.Context, zone string, domain *DNSDomain) error {
 	if err := validateOperationParams(domain, "delete"); err != nil {
 		return err
 	}
@@ -103,12 +103,12 @@ func (c *Client) DeleteDnsDomain(ctx context.Context, zone string, domain *DnsDo
 	return nil
 }
 
-// CreateDnsDomain adds a new DNS domain.
-func (c *Client) CreateDnsDomain(
+// CreateDNSDomain adds a new DNS domain.
+func (c *Client) CreateDNSDomain(
 	ctx context.Context,
 	zone string,
-	domain *DnsDomain,
-) (*DnsDomain, error) {
+	domain *DNSDomain,
+) (*DNSDomain, error) {
 	if err := validateOperationParams(domain, "create"); err != nil {
 		return nil, err
 	}
@@ -128,15 +128,15 @@ func (c *Client) CreateDnsDomain(
 		return nil, err
 	}
 
-	return c.GetDnsDomain(ctx, zone, *r.(*struct {
+	return c.GetDNSDomain(ctx, zone, *r.(*struct {
 		Command *string `json:"command,omitempty"`
 		Id      *string `json:"id,omitempty"` // revive:disable-line
 		Link    *string `json:"link,omitempty"`
 	}).Id)
 }
 
-// GetDnsDomainZoneFile returns zone file of a DNS domain.
-func (c *Client) GetDnsDomainZoneFile(ctx context.Context, zone, id string) ([]byte, error) {
+// GetDNSDomainZoneFile returns zone file of a DNS domain.
+func (c *Client) GetDNSDomainZoneFile(ctx context.Context, zone, id string) ([]byte, error) {
 	resp, err := c.GetDnsDomainZoneFileWithResponse(apiv2.WithZone(ctx, zone), id)
 	if err != nil {
 		return nil, err
@@ -145,9 +145,9 @@ func (c *Client) GetDnsDomainZoneFile(ctx context.Context, zone, id string) ([]b
 	return resp.Body, nil
 }
 
-// ListDnsDomainRecords returns the list of records for DNS domain.
-func (c *Client) ListDnsDomainRecords(ctx context.Context, zone, id string) ([]DnsDomainRecord, error) {
-	var list []DnsDomainRecord
+// ListDNSDomainRecords returns the list of records for DNS domain.
+func (c *Client) ListDNSDomainRecords(ctx context.Context, zone, id string) ([]DNSDomainRecord, error) {
+	var list []DNSDomainRecord
 
 	resp, err := c.ListDnsDomainRecordsWithResponse(apiv2.WithZone(ctx, zone), id)
 	if err != nil {
@@ -163,8 +163,8 @@ func (c *Client) ListDnsDomainRecords(ctx context.Context, zone, id string) ([]D
 	return list, nil
 }
 
-// GetDnsDomainRecord returns a single DNS domain record.
-func (c *Client) GetDnsDomainRecord(ctx context.Context, zone, domainID, recordID string) (*DnsDomainRecord, error) {
+// GetDNSDomainRecord returns a single DNS domain record.
+func (c *Client) GetDNSDomainRecord(ctx context.Context, zone, domainID, recordID string) (*DNSDomainRecord, error) {
 	resp, err := c.GetDnsDomainRecordWithResponse(apiv2.WithZone(ctx, zone), domainID, recordID)
 	if err != nil {
 		return nil, err
@@ -173,13 +173,13 @@ func (c *Client) GetDnsDomainRecord(ctx context.Context, zone, domainID, recordI
 	return dnsDomainRecordFromAPI(resp.JSON200), nil
 }
 
-// CreateDnsDomainRecord adds a new DNS record for domain.
-func (c *Client) CreateDnsDomainRecord(
+// CreateDNSDomainRecord adds a new DNS record for domain.
+func (c *Client) CreateDNSDomainRecord(
 	ctx context.Context,
 	zone string,
 	domainID string,
-	record *DnsDomainRecord,
-) (*DnsDomainRecord, error) {
+	record *DNSDomainRecord,
+) (*DNSDomainRecord, error) {
 	if err := validateOperationParams(record, "create"); err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *Client) CreateDnsDomainRecord(
 		Content:  *record.Content,
 		Name:     *record.Name,
 		Priority: record.Priority,
-		Ttl:      record.Ttl,
+		Ttl:      record.TTL,
 		Type:     oapi.CreateDnsDomainRecordJSONBodyType(*record.Type),
 	})
 	if err != nil {
@@ -203,15 +203,15 @@ func (c *Client) CreateDnsDomainRecord(
 		return nil, err
 	}
 
-	return c.GetDnsDomainRecord(ctx, zone, domainID, *r.(*struct {
+	return c.GetDNSDomainRecord(ctx, zone, domainID, *r.(*struct {
 		Command *string `json:"command,omitempty"`
 		Id      *string `json:"id,omitempty"` // revive:disable-line
 		Link    *string `json:"link,omitempty"`
 	}).Id)
 }
 
-// DeleteDnsDomainRecord deletes a DNS domain record.
-func (c *Client) DeleteDnsDomainRecord(ctx context.Context, zone, domainID string, record *DnsDomainRecord) error {
+// DeleteDNSDomainRecord deletes a DNS domain record.
+func (c *Client) DeleteDNSDomainRecord(ctx context.Context, zone, domainID string, record *DNSDomainRecord) error {
 	if err := validateOperationParams(record, "delete"); err != nil {
 		return err
 	}
@@ -232,8 +232,8 @@ func (c *Client) DeleteDnsDomainRecord(ctx context.Context, zone, domainID strin
 	return nil
 }
 
-// UpdateDnsDomainRecord updates existing DNS domain record.
-func (c *Client) UpdateDnsDomainRecord(ctx context.Context, zone, domainID string, record *DnsDomainRecord) error {
+// UpdateDNSDomainRecord updates existing DNS domain record.
+func (c *Client) UpdateDNSDomainRecord(ctx context.Context, zone, domainID string, record *DNSDomainRecord) error {
 	if err := validateOperationParams(record, "update"); err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func (c *Client) UpdateDnsDomainRecord(ctx context.Context, zone, domainID strin
 		Content:  record.Content,
 		Name:     record.Name,
 		Priority: record.Priority,
-		Ttl:      record.Ttl,
+		Ttl:      record.TTL,
 	})
 	if err != nil {
 		return err

--- a/v2/dns_test.go
+++ b/v2/dns_test.go
@@ -11,29 +11,29 @@ import (
 )
 
 var (
-	testDnsDomainCreatedAt, _ = time.Parse(iso8601Format, "2020-05-26T12:09:42Z")
-	testDnsDomainId           = new(testSuite).randomID()
-	testDnsDomainUnicodeName  = "test.domain"
+	testDNSDomainCreatedAt, _ = time.Parse(iso8601Format, "2020-05-26T12:09:42Z")
+	testDNSDomainID           = new(testSuite).randomID()
+	testDNSDomainUnicodeName  = "test.domain"
 
-	testDnsDomainRecordContent            = new(testSuite).randomString(10)
-	testDnsDomainRecordCreatedAt, _       = time.Parse(iso8601Format, "2021-04-27T12:09:42Z")
-	testDnsDomainRecordId                 = new(testSuite).randomID()
-	testDnsDomainRecordName               = new(testSuite).randomString(10)
-	testDnsDomainRecordPriority     int64 = 5
-	testDnsDomainRecordTtl          int64 = 1800
-	testDnsDomainRecordType               = "CNAME"
-	testDnsDomainRecordUpdatedAt, _       = time.Parse(iso8601Format, "2021-06-27T12:09:42Z")
+	testDNSDomainRecordContent            = new(testSuite).randomString(10)
+	testDNSDomainRecordCreatedAt, _       = time.Parse(iso8601Format, "2021-04-27T12:09:42Z")
+	testDNSDomainRecordID                 = new(testSuite).randomID()
+	testDNSDomainRecordName               = new(testSuite).randomString(10)
+	testDNSDomainRecordPriority     int64 = 5
+	testDNSDomainRecordTTL          int64 = 1800
+	testDNSDomainRecordType               = "CNAME"
+	testDNSDomainRecordUpdatedAt, _       = time.Parse(iso8601Format, "2021-06-27T12:09:42Z")
 )
 
 func (ts *testSuite) TestClient_ListDnsDomains() {
 	domains := struct {
-		DnsDomains *[]oapi.DnsDomain `json:"dns-domains,omitempty"`
+		DnsDomains *[]oapi.DnsDomain `json:"dns-domains,omitempty"` //nolint: revive
 	}{
-		DnsDomains: &[]oapi.DnsDomain{
+		&[]oapi.DnsDomain{
 			oapi.DnsDomain{
-				CreatedAt:   &testDnsDomainCreatedAt,
-				Id:          &testDnsDomainId,
-				UnicodeName: &testDnsDomainUnicodeName,
+				CreatedAt:   &testDNSDomainCreatedAt,
+				Id:          &testDNSDomainID,
+				UnicodeName: &testDNSDomainUnicodeName,
 			},
 		},
 	}
@@ -51,20 +51,20 @@ func (ts *testSuite) TestClient_ListDnsDomains() {
 			nil,
 		)
 
-	expected := []DnsDomain{
+	expected := []DNSDomain{
 		{
-			CreatedAt:   &testDnsDomainCreatedAt,
-			ID:          &testDnsDomainId,
-			UnicodeName: &testDnsDomainUnicodeName,
+			CreatedAt:   &testDNSDomainCreatedAt,
+			ID:          &testDNSDomainID,
+			UnicodeName: &testDNSDomainUnicodeName,
 		},
 	}
 
-	actual, err := ts.client.ListDnsDomains(context.Background(), testZone)
+	actual, err := ts.client.ListDNSDomains(context.Background(), testZone)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *testSuite) TestClient_GetDnsDomain() {
+func (ts *testSuite) TestClient_GetDNSDomain() {
 	ts.mock().
 		On(
 			"GetDnsDomainWithResponse",
@@ -74,7 +74,7 @@ func (ts *testSuite) TestClient_GetDnsDomain() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 		}).
@@ -82,26 +82,26 @@ func (ts *testSuite) TestClient_GetDnsDomain() {
 			&oapi.GetDnsDomainResponse{
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.DnsDomain{
-					CreatedAt:   &testDnsDomainCreatedAt,
-					Id:          &testDnsDomainId,
-					UnicodeName: &testDnsDomainUnicodeName,
+					CreatedAt:   &testDNSDomainCreatedAt,
+					Id:          &testDNSDomainID,
+					UnicodeName: &testDNSDomainUnicodeName,
 				},
 			},
 			nil,
 		)
 
-	expected := &DnsDomain{
-		CreatedAt:   &testDnsDomainCreatedAt,
-		ID:          &testDnsDomainId,
-		UnicodeName: &testDnsDomainUnicodeName,
+	expected := &DNSDomain{
+		CreatedAt:   &testDNSDomainCreatedAt,
+		ID:          &testDNSDomainID,
+		UnicodeName: &testDNSDomainUnicodeName,
 	}
 
-	actual, err := ts.client.GetDnsDomain(context.Background(), testZone, testDnsDomainId)
+	actual, err := ts.client.GetDNSDomain(context.Background(), testZone, testDNSDomainID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *testSuite) TestClient_CreateDnsDomain() {
+func (ts *testSuite) TestClient_CreateDNSDomain() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = oapi.OperationStateSuccess
@@ -117,7 +117,7 @@ func (ts *testSuite) TestClient_CreateDnsDomain() {
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
 				oapi.CreateDnsDomainJSONRequestBody{
-					UnicodeName: &testDnsDomainUnicodeName,
+					UnicodeName: &testDNSDomainUnicodeName,
 				},
 				args.Get(1),
 			)
@@ -134,7 +134,7 @@ func (ts *testSuite) TestClient_CreateDnsDomain() {
 
 	ts.mockGetOperation(&oapi.Operation{
 		Id:        &testOperationID,
-		Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+		Reference: oapi.NewReference(nil, &testDNSDomainID, nil),
 		State:     &testOperationState,
 	})
 
@@ -147,20 +147,20 @@ func (ts *testSuite) TestClient_CreateDnsDomain() {
 		Return(&oapi.GetDnsDomainResponse{
 			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 			JSON200: &oapi.DnsDomain{
-				CreatedAt:   &testDnsDomainCreatedAt,
-				Id:          &testDnsDomainId,
-				UnicodeName: &testDnsDomainUnicodeName,
+				CreatedAt:   &testDNSDomainCreatedAt,
+				Id:          &testDNSDomainID,
+				UnicodeName: &testDNSDomainUnicodeName,
 			},
 		}, nil)
 
-	expected := &DnsDomain{
-		CreatedAt:   &testDnsDomainCreatedAt,
-		ID:          &testDnsDomainId,
-		UnicodeName: &testDnsDomainUnicodeName,
+	expected := &DNSDomain{
+		CreatedAt:   &testDNSDomainCreatedAt,
+		ID:          &testDNSDomainID,
+		UnicodeName: &testDNSDomainUnicodeName,
 	}
 
-	actual, err := ts.client.CreateDnsDomain(context.Background(), testZone, &DnsDomain{
-		UnicodeName: &testDnsDomainUnicodeName,
+	actual, err := ts.client.CreateDNSDomain(context.Background(), testZone, &DNSDomain{
+		UnicodeName: &testDNSDomainUnicodeName,
 	})
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
@@ -181,7 +181,7 @@ func (ts *testSuite) TestClient_DeleteDnsDomain() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 		}).
@@ -190,7 +190,7 @@ func (ts *testSuite) TestClient_DeleteDnsDomain() {
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.Operation{
 					Id:        &testOperationID,
-					Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+					Reference: oapi.NewReference(nil, &testDNSDomainID, nil),
 					State:     &testOperationState,
 				},
 			},
@@ -199,16 +199,16 @@ func (ts *testSuite) TestClient_DeleteDnsDomain() {
 
 	ts.mockGetOperation(&oapi.Operation{
 		Id:        &testOperationID,
-		Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+		Reference: oapi.NewReference(nil, &testDNSDomainID, nil),
 		State:     &testOperationState,
 	})
 
-	err := ts.client.DeleteDnsDomain(context.Background(), testZone, &DnsDomain{ID: &testDnsDomainId})
+	err := ts.client.DeleteDNSDomain(context.Background(), testZone, &DNSDomain{ID: &testDNSDomainID})
 	ts.Require().NoError(err)
 }
 
-func (ts *testSuite) TestClient_GetDnsDomainZoneFile() {
-	var expected string = `$ORIGIN example.com.
+func (ts *testSuite) TestClient_GetDNSDomainZoneFile() {
+	var expected = `$ORIGIN example.com.
 $TTL 1h
 example.com. 3600 IN SOA ns1.exoscale.ch. admin.dnsimple.com. 1654788358 86400 7200 604800 300
 example.com. 3600 IN NS ns1.exoscale.ch.
@@ -225,7 +225,7 @@ example.com. 3600 IN NS ns1.exoscale.net.`
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 		}).
@@ -237,26 +237,26 @@ example.com. 3600 IN NS ns1.exoscale.net.`
 			nil,
 		)
 
-	actual, err := ts.client.GetDnsDomainZoneFile(context.Background(), testZone, testDnsDomainId)
+	actual, err := ts.client.GetDNSDomainZoneFile(context.Background(), testZone, testDNSDomainID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(actual, []byte(expected))
 }
 
-func (ts *testSuite) TestClient_ListDnsDomainRecords() {
-	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+func (ts *testSuite) TestClient_ListDNSDomainRecords() {
+	tp := oapi.DnsDomainRecordType(testDNSDomainRecordType)
 	records := struct {
-		DnsDomainRecords *[]oapi.DnsDomainRecord `json:"dns-domain-records,omitempty"`
+		DnsDomainRecords *[]oapi.DnsDomainRecord `json:"dns-domain-records,omitempty"` //nolint: revive
 	}{
 		&[]oapi.DnsDomainRecord{
 			oapi.DnsDomainRecord{
-				Content:   &testDnsDomainRecordContent,
-				CreatedAt: &testDnsDomainRecordCreatedAt,
-				Id:        &testDnsDomainRecordId,
-				Name:      &testDnsDomainRecordName,
-				Priority:  &testDnsDomainRecordPriority,
-				Ttl:       &testDnsDomainRecordTtl,
+				Content:   &testDNSDomainRecordContent,
+				CreatedAt: &testDNSDomainRecordCreatedAt,
+				Id:        &testDNSDomainRecordID,
+				Name:      &testDNSDomainRecordName,
+				Priority:  &testDNSDomainRecordPriority,
+				Ttl:       &testDNSDomainRecordTTL,
 				Type:      &tp,
-				UpdatedAt: &testDnsDomainRecordUpdatedAt,
+				UpdatedAt: &testDNSDomainRecordUpdatedAt,
 			},
 		},
 	}
@@ -275,26 +275,26 @@ func (ts *testSuite) TestClient_ListDnsDomainRecords() {
 			nil,
 		)
 
-	expected := []DnsDomainRecord{
+	expected := []DNSDomainRecord{
 		{
-			Content:   &testDnsDomainRecordContent,
-			CreatedAt: &testDnsDomainRecordCreatedAt,
-			ID:        &testDnsDomainRecordId,
-			Name:      &testDnsDomainRecordName,
-			Priority:  &testDnsDomainRecordPriority,
-			Ttl:       &testDnsDomainRecordTtl,
-			Type:      &testDnsDomainRecordType,
-			UpdatedAt: &testDnsDomainRecordUpdatedAt,
+			Content:   &testDNSDomainRecordContent,
+			CreatedAt: &testDNSDomainRecordCreatedAt,
+			ID:        &testDNSDomainRecordID,
+			Name:      &testDNSDomainRecordName,
+			Priority:  &testDNSDomainRecordPriority,
+			TTL:       &testDNSDomainRecordTTL,
+			Type:      &testDNSDomainRecordType,
+			UpdatedAt: &testDNSDomainRecordUpdatedAt,
 		},
 	}
 
-	actual, err := ts.client.ListDnsDomainRecords(context.Background(), testZone, testDnsDomainId)
+	actual, err := ts.client.ListDNSDomainRecords(context.Background(), testZone, testDNSDomainID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *testSuite) TestClient_GetDnsDomainRecord() {
-	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+func (ts *testSuite) TestClient_GetDNSDomainRecord() {
+	tp := oapi.DnsDomainRecordType(testDNSDomainRecordType)
 	ts.mock().
 		On(
 			"GetDnsDomainRecordWithResponse",
@@ -305,11 +305,11 @@ func (ts *testSuite) TestClient_GetDnsDomainRecord() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 			ts.Require().Equal(
-				testDnsDomainRecordId,
+				testDNSDomainRecordID,
 				args.Get(2),
 			)
 		}).
@@ -317,41 +317,41 @@ func (ts *testSuite) TestClient_GetDnsDomainRecord() {
 			&oapi.GetDnsDomainRecordResponse{
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.DnsDomainRecord{
-					Content:   &testDnsDomainRecordContent,
-					CreatedAt: &testDnsDomainRecordCreatedAt,
-					Id:        &testDnsDomainRecordId,
-					Name:      &testDnsDomainRecordName,
-					Priority:  &testDnsDomainRecordPriority,
-					Ttl:       &testDnsDomainRecordTtl,
+					Content:   &testDNSDomainRecordContent,
+					CreatedAt: &testDNSDomainRecordCreatedAt,
+					Id:        &testDNSDomainRecordID,
+					Name:      &testDNSDomainRecordName,
+					Priority:  &testDNSDomainRecordPriority,
+					Ttl:       &testDNSDomainRecordTTL,
 					Type:      &tp,
-					UpdatedAt: &testDnsDomainRecordUpdatedAt,
+					UpdatedAt: &testDNSDomainRecordUpdatedAt,
 				},
 			},
 			nil,
 		)
 
-	expected := &DnsDomainRecord{
-		Content:   &testDnsDomainRecordContent,
-		CreatedAt: &testDnsDomainRecordCreatedAt,
-		ID:        &testDnsDomainRecordId,
-		Name:      &testDnsDomainRecordName,
-		Priority:  &testDnsDomainRecordPriority,
-		Ttl:       &testDnsDomainRecordTtl,
-		Type:      &testDnsDomainRecordType,
-		UpdatedAt: &testDnsDomainRecordUpdatedAt,
+	expected := &DNSDomainRecord{
+		Content:   &testDNSDomainRecordContent,
+		CreatedAt: &testDNSDomainRecordCreatedAt,
+		ID:        &testDNSDomainRecordID,
+		Name:      &testDNSDomainRecordName,
+		Priority:  &testDNSDomainRecordPriority,
+		TTL:       &testDNSDomainRecordTTL,
+		Type:      &testDNSDomainRecordType,
+		UpdatedAt: &testDNSDomainRecordUpdatedAt,
 	}
 
-	actual, err := ts.client.GetDnsDomainRecord(context.Background(), testZone, testDnsDomainId, testDnsDomainRecordId)
+	actual, err := ts.client.GetDNSDomainRecord(context.Background(), testZone, testDNSDomainID, testDNSDomainRecordID)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
+func (ts *testSuite) TestClient_CreateDNSDomainRecord() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = oapi.OperationStateSuccess
 	)
-	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+	tp := oapi.DnsDomainRecordType(testDNSDomainRecordType)
 
 	ts.mock().
 		On(
@@ -363,16 +363,16 @@ func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 			ts.Require().Equal(
 				oapi.CreateDnsDomainRecordJSONRequestBody{
-					Content:  testDnsDomainRecordContent,
-					Name:     testDnsDomainRecordName,
-					Priority: &testDnsDomainRecordPriority,
-					Ttl:      &testDnsDomainRecordTtl,
-					Type:     oapi.CreateDnsDomainRecordJSONBodyType(testDnsDomainRecordType),
+					Content:  testDNSDomainRecordContent,
+					Name:     testDNSDomainRecordName,
+					Priority: &testDNSDomainRecordPriority,
+					Ttl:      &testDNSDomainRecordTTL,
+					Type:     oapi.CreateDnsDomainRecordJSONBodyType(testDNSDomainRecordType),
 				},
 				args.Get(2),
 			)
@@ -382,7 +382,7 @@ func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.Operation{
 					Id:        &testOperationID,
-					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 					State:     &testOperationState,
 				},
 			},
@@ -391,7 +391,7 @@ func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
 
 	ts.mockGetOperation(&oapi.Operation{
 		Id:        &testOperationID,
-		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 		State:     &testOperationState,
 	})
 
@@ -405,40 +405,40 @@ func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
 		Return(&oapi.GetDnsDomainRecordResponse{
 			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 			JSON200: &oapi.DnsDomainRecord{
-				Content:   &testDnsDomainRecordContent,
-				CreatedAt: &testDnsDomainRecordCreatedAt,
-				Id:        &testDnsDomainRecordId,
-				Name:      &testDnsDomainRecordName,
-				Priority:  &testDnsDomainRecordPriority,
-				Ttl:       &testDnsDomainRecordTtl,
+				Content:   &testDNSDomainRecordContent,
+				CreatedAt: &testDNSDomainRecordCreatedAt,
+				Id:        &testDNSDomainRecordID,
+				Name:      &testDNSDomainRecordName,
+				Priority:  &testDNSDomainRecordPriority,
+				Ttl:       &testDNSDomainRecordTTL,
 				Type:      &tp,
-				UpdatedAt: &testDnsDomainRecordUpdatedAt,
+				UpdatedAt: &testDNSDomainRecordUpdatedAt,
 			},
 		}, nil)
 
-	expected := &DnsDomainRecord{
-		Content:   &testDnsDomainRecordContent,
-		CreatedAt: &testDnsDomainRecordCreatedAt,
-		ID:        &testDnsDomainRecordId,
-		Name:      &testDnsDomainRecordName,
-		Priority:  &testDnsDomainRecordPriority,
-		Ttl:       &testDnsDomainRecordTtl,
-		Type:      &testDnsDomainRecordType,
-		UpdatedAt: &testDnsDomainRecordUpdatedAt,
+	expected := &DNSDomainRecord{
+		Content:   &testDNSDomainRecordContent,
+		CreatedAt: &testDNSDomainRecordCreatedAt,
+		ID:        &testDNSDomainRecordID,
+		Name:      &testDNSDomainRecordName,
+		Priority:  &testDNSDomainRecordPriority,
+		TTL:       &testDNSDomainRecordTTL,
+		Type:      &testDNSDomainRecordType,
+		UpdatedAt: &testDNSDomainRecordUpdatedAt,
 	}
 
-	actual, err := ts.client.CreateDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{
-		Content:  &testDnsDomainRecordContent,
-		Name:     &testDnsDomainRecordName,
-		Priority: &testDnsDomainRecordPriority,
-		Ttl:      &testDnsDomainRecordTtl,
-		Type:     &testDnsDomainRecordType,
+	actual, err := ts.client.CreateDNSDomainRecord(context.Background(), testZone, testDNSDomainID, &DNSDomainRecord{
+		Content:  &testDNSDomainRecordContent,
+		Name:     &testDNSDomainRecordName,
+		Priority: &testDNSDomainRecordPriority,
+		TTL:      &testDNSDomainRecordTTL,
+		Type:     &testDNSDomainRecordType,
 	})
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
 
-func (ts *testSuite) TestClient_DeleteDnsDomainRecord() {
+func (ts *testSuite) TestClient_DeleteDNSDomainRecord() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = oapi.OperationStateSuccess
@@ -454,11 +454,11 @@ func (ts *testSuite) TestClient_DeleteDnsDomainRecord() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 			ts.Require().Equal(
-				testDnsDomainRecordId,
+				testDNSDomainRecordID,
 				args.Get(2),
 			)
 		}).
@@ -467,7 +467,7 @@ func (ts *testSuite) TestClient_DeleteDnsDomainRecord() {
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.Operation{
 					Id:        &testOperationID,
-					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 					State:     &testOperationState,
 				},
 			},
@@ -476,15 +476,15 @@ func (ts *testSuite) TestClient_DeleteDnsDomainRecord() {
 
 	ts.mockGetOperation(&oapi.Operation{
 		Id:        &testOperationID,
-		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 		State:     &testOperationState,
 	})
 
-	err := ts.client.DeleteDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{ID: &testDnsDomainRecordId})
+	err := ts.client.DeleteDNSDomainRecord(context.Background(), testZone, testDNSDomainID, &DNSDomainRecord{ID: &testDNSDomainRecordID})
 	ts.Require().NoError(err)
 }
 
-func (ts *testSuite) TestClient_UpdateDnsDomainRecord() {
+func (ts *testSuite) TestClient_UpdateDNSDomainRecord() {
 	var (
 		testOperationID    = ts.randomID()
 		testOperationState = oapi.OperationStateSuccess
@@ -501,19 +501,19 @@ func (ts *testSuite) TestClient_UpdateDnsDomainRecord() {
 		).
 		Run(func(args mock.Arguments) {
 			ts.Require().Equal(
-				testDnsDomainId,
+				testDNSDomainID,
 				args.Get(1),
 			)
 			ts.Require().Equal(
-				testDnsDomainRecordId,
+				testDNSDomainRecordID,
 				args.Get(2),
 			)
 			ts.Require().Equal(
 				oapi.UpdateDnsDomainRecordJSONRequestBody{
-					Content:  &testDnsDomainRecordContent,
-					Name:     &testDnsDomainRecordName,
-					Priority: &testDnsDomainRecordPriority,
-					Ttl:      &testDnsDomainRecordTtl,
+					Content:  &testDNSDomainRecordContent,
+					Name:     &testDNSDomainRecordName,
+					Priority: &testDNSDomainRecordPriority,
+					Ttl:      &testDNSDomainRecordTTL,
 				},
 				args.Get(3),
 			)
@@ -523,7 +523,7 @@ func (ts *testSuite) TestClient_UpdateDnsDomainRecord() {
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &oapi.Operation{
 					Id:        &testOperationID,
-					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 					State:     &testOperationState,
 				},
 			},
@@ -532,17 +532,17 @@ func (ts *testSuite) TestClient_UpdateDnsDomainRecord() {
 
 	ts.mockGetOperation(&oapi.Operation{
 		Id:        &testOperationID,
-		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		Reference: oapi.NewReference(nil, &testDNSDomainRecordID, nil),
 		State:     &testOperationState,
 	})
 
-	err := ts.client.UpdateDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{
-		ID:       &testDnsDomainRecordId,
-		Content:  &testDnsDomainRecordContent,
-		Name:     &testDnsDomainRecordName,
-		Priority: &testDnsDomainRecordPriority,
-		Ttl:      &testDnsDomainRecordTtl,
-		Type:     &testDnsDomainRecordType,
+	err := ts.client.UpdateDNSDomainRecord(context.Background(), testZone, testDNSDomainID, &DNSDomainRecord{
+		ID:       &testDNSDomainRecordID,
+		Content:  &testDNSDomainRecordContent,
+		Name:     &testDNSDomainRecordName,
+		Priority: &testDNSDomainRecordPriority,
+		TTL:      &testDNSDomainRecordTTL,
+		Type:     &testDNSDomainRecordType,
 	})
 	ts.Require().NoError(err)
 }

--- a/v2/dns_test.go
+++ b/v2/dns_test.go
@@ -1,0 +1,548 @@
+package v2
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+var (
+	testDnsDomainCreatedAt, _ = time.Parse(iso8601Format, "2020-05-26T12:09:42Z")
+	testDnsDomainId           = new(testSuite).randomID()
+	testDnsDomainUnicodeName  = "test.domain"
+
+	testDnsDomainRecordContent            = new(testSuite).randomString(10)
+	testDnsDomainRecordCreatedAt, _       = time.Parse(iso8601Format, "2021-04-27T12:09:42Z")
+	testDnsDomainRecordId                 = new(testSuite).randomID()
+	testDnsDomainRecordName               = new(testSuite).randomString(10)
+	testDnsDomainRecordPriority     int64 = 5
+	testDnsDomainRecordTtl          int64 = 1800
+	testDnsDomainRecordType               = "CNAME"
+	testDnsDomainRecordUpdatedAt, _       = time.Parse(iso8601Format, "2021-06-27T12:09:42Z")
+)
+
+func (ts *testSuite) TestClient_ListDnsDomains() {
+	domains := struct {
+		DnsDomains *[]oapi.DnsDomain `json:"dns-domains,omitempty"`
+	}{
+		DnsDomains: &[]oapi.DnsDomain{
+			oapi.DnsDomain{
+				CreatedAt:   &testDnsDomainCreatedAt,
+				Id:          &testDnsDomainId,
+				UnicodeName: &testDnsDomainUnicodeName,
+			},
+		},
+	}
+	ts.mock().
+		On(
+			"ListDnsDomainsWithResponse",
+			mock.Anything,                 // ctx
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Return(
+			&oapi.ListDnsDomainsResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200:      &domains,
+			},
+			nil,
+		)
+
+	expected := []DnsDomain{
+		{
+			CreatedAt:   &testDnsDomainCreatedAt,
+			ID:          &testDnsDomainId,
+			UnicodeName: &testDnsDomainUnicodeName,
+		},
+	}
+
+	actual, err := ts.client.ListDnsDomains(context.Background(), testZone)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_GetDnsDomain() {
+	ts.mock().
+		On(
+			"GetDnsDomainWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // id
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+		}).
+		Return(
+			&oapi.GetDnsDomainResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.DnsDomain{
+					CreatedAt:   &testDnsDomainCreatedAt,
+					Id:          &testDnsDomainId,
+					UnicodeName: &testDnsDomainUnicodeName,
+				},
+			},
+			nil,
+		)
+
+	expected := &DnsDomain{
+		CreatedAt:   &testDnsDomainCreatedAt,
+		ID:          &testDnsDomainId,
+		UnicodeName: &testDnsDomainUnicodeName,
+	}
+
+	actual, err := ts.client.GetDnsDomain(context.Background(), testZone, testDnsDomainId)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_CreateDnsDomain() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+	)
+
+	ts.mock().
+		On(
+			"CreateDnsDomainWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // body
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				oapi.CreateDnsDomainJSONRequestBody{
+					UnicodeName: &testDnsDomainUnicodeName,
+				},
+				args.Get(1),
+			)
+		}).
+		Return(
+			&oapi.CreateDnsDomainResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.DnsDomain{
+					Id: &testOperationID,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+		State:     &testOperationState,
+	})
+
+	ts.mock().
+		On("GetDnsDomainWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // id
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Return(&oapi.GetDnsDomainResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &oapi.DnsDomain{
+				CreatedAt:   &testDnsDomainCreatedAt,
+				Id:          &testDnsDomainId,
+				UnicodeName: &testDnsDomainUnicodeName,
+			},
+		}, nil)
+
+	expected := &DnsDomain{
+		CreatedAt:   &testDnsDomainCreatedAt,
+		ID:          &testDnsDomainId,
+		UnicodeName: &testDnsDomainUnicodeName,
+	}
+
+	actual, err := ts.client.CreateDnsDomain(context.Background(), testZone, &DnsDomain{
+		UnicodeName: &testDnsDomainUnicodeName,
+	})
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_DeleteDnsDomain() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+	)
+
+	ts.mock().
+		On(
+			"DeleteDnsDomainWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // id
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+		}).
+		Return(
+			&oapi.DeleteDnsDomainResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDnsDomainId, nil),
+		State:     &testOperationState,
+	})
+
+	err := ts.client.DeleteDnsDomain(context.Background(), testZone, &DnsDomain{ID: &testDnsDomainId})
+	ts.Require().NoError(err)
+}
+
+func (ts *testSuite) TestClient_GetDnsDomainZoneFile() {
+	var expected string = `$ORIGIN example.com.
+$TTL 1h
+example.com. 3600 IN SOA ns1.exoscale.ch. admin.dnsimple.com. 1654788358 86400 7200 604800 300
+example.com. 3600 IN NS ns1.exoscale.ch.
+example.com. 3600 IN NS ns1.exoscale.com.
+example.com. 3600 IN NS ns1.exoscale.io.
+example.com. 3600 IN NS ns1.exoscale.net.`
+
+	ts.mock().
+		On(
+			"GetDnsDomainZoneFileWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // id
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+		}).
+		Return(
+			&oapi.GetDnsDomainZoneFileResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				Body:         []byte(expected),
+			},
+			nil,
+		)
+
+	actual, err := ts.client.GetDnsDomainZoneFile(context.Background(), testZone, testDnsDomainId)
+	ts.Require().NoError(err)
+	ts.Require().Equal(actual, []byte(expected))
+}
+
+func (ts *testSuite) TestClient_ListDnsDomainRecords() {
+	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+	records := struct {
+		DnsDomainRecords *[]oapi.DnsDomainRecord `json:"dns-domain-records,omitempty"`
+	}{
+		&[]oapi.DnsDomainRecord{
+			oapi.DnsDomainRecord{
+				Content:   &testDnsDomainRecordContent,
+				CreatedAt: &testDnsDomainRecordCreatedAt,
+				Id:        &testDnsDomainRecordId,
+				Name:      &testDnsDomainRecordName,
+				Priority:  &testDnsDomainRecordPriority,
+				Ttl:       &testDnsDomainRecordTtl,
+				Type:      &tp,
+				UpdatedAt: &testDnsDomainRecordUpdatedAt,
+			},
+		},
+	}
+	ts.mock().
+		On(
+			"ListDnsDomainRecordsWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Return(
+			&oapi.ListDnsDomainRecordsResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200:      &records,
+			},
+			nil,
+		)
+
+	expected := []DnsDomainRecord{
+		{
+			Content:   &testDnsDomainRecordContent,
+			CreatedAt: &testDnsDomainRecordCreatedAt,
+			ID:        &testDnsDomainRecordId,
+			Name:      &testDnsDomainRecordName,
+			Priority:  &testDnsDomainRecordPriority,
+			Ttl:       &testDnsDomainRecordTtl,
+			Type:      &testDnsDomainRecordType,
+			UpdatedAt: &testDnsDomainRecordUpdatedAt,
+		},
+	}
+
+	actual, err := ts.client.ListDnsDomainRecords(context.Background(), testZone, testDnsDomainId)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_GetDnsDomainRecord() {
+	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+	ts.mock().
+		On(
+			"GetDnsDomainRecordWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			mock.Anything,                 // recordId
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+			ts.Require().Equal(
+				testDnsDomainRecordId,
+				args.Get(2),
+			)
+		}).
+		Return(
+			&oapi.GetDnsDomainRecordResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.DnsDomainRecord{
+					Content:   &testDnsDomainRecordContent,
+					CreatedAt: &testDnsDomainRecordCreatedAt,
+					Id:        &testDnsDomainRecordId,
+					Name:      &testDnsDomainRecordName,
+					Priority:  &testDnsDomainRecordPriority,
+					Ttl:       &testDnsDomainRecordTtl,
+					Type:      &tp,
+					UpdatedAt: &testDnsDomainRecordUpdatedAt,
+				},
+			},
+			nil,
+		)
+
+	expected := &DnsDomainRecord{
+		Content:   &testDnsDomainRecordContent,
+		CreatedAt: &testDnsDomainRecordCreatedAt,
+		ID:        &testDnsDomainRecordId,
+		Name:      &testDnsDomainRecordName,
+		Priority:  &testDnsDomainRecordPriority,
+		Ttl:       &testDnsDomainRecordTtl,
+		Type:      &testDnsDomainRecordType,
+		UpdatedAt: &testDnsDomainRecordUpdatedAt,
+	}
+
+	actual, err := ts.client.GetDnsDomainRecord(context.Background(), testZone, testDnsDomainId, testDnsDomainRecordId)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_CreateDnsDomainRecord() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+	)
+	tp := oapi.DnsDomainRecordType(testDnsDomainRecordType)
+
+	ts.mock().
+		On(
+			"CreateDnsDomainRecordWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			mock.Anything,                 // body
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+			ts.Require().Equal(
+				oapi.CreateDnsDomainRecordJSONRequestBody{
+					Content:  testDnsDomainRecordContent,
+					Name:     testDnsDomainRecordName,
+					Priority: &testDnsDomainRecordPriority,
+					Ttl:      &testDnsDomainRecordTtl,
+					Type:     oapi.CreateDnsDomainRecordJSONBodyType(testDnsDomainRecordType),
+				},
+				args.Get(2),
+			)
+		}).
+		Return(
+			&oapi.CreateDnsDomainRecordResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		State:     &testOperationState,
+	})
+
+	ts.mock().
+		On("GetDnsDomainRecordWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			mock.Anything,                 // recordId
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Return(&oapi.GetDnsDomainRecordResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+			JSON200: &oapi.DnsDomainRecord{
+				Content:   &testDnsDomainRecordContent,
+				CreatedAt: &testDnsDomainRecordCreatedAt,
+				Id:        &testDnsDomainRecordId,
+				Name:      &testDnsDomainRecordName,
+				Priority:  &testDnsDomainRecordPriority,
+				Ttl:       &testDnsDomainRecordTtl,
+				Type:      &tp,
+				UpdatedAt: &testDnsDomainRecordUpdatedAt,
+			},
+		}, nil)
+
+	expected := &DnsDomainRecord{
+		Content:   &testDnsDomainRecordContent,
+		CreatedAt: &testDnsDomainRecordCreatedAt,
+		ID:        &testDnsDomainRecordId,
+		Name:      &testDnsDomainRecordName,
+		Priority:  &testDnsDomainRecordPriority,
+		Ttl:       &testDnsDomainRecordTtl,
+		Type:      &testDnsDomainRecordType,
+		UpdatedAt: &testDnsDomainRecordUpdatedAt,
+	}
+
+	actual, err := ts.client.CreateDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{
+		Content:  &testDnsDomainRecordContent,
+		Name:     &testDnsDomainRecordName,
+		Priority: &testDnsDomainRecordPriority,
+		Ttl:      &testDnsDomainRecordTtl,
+		Type:     &testDnsDomainRecordType,
+	})
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *testSuite) TestClient_DeleteDnsDomainRecord() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+	)
+
+	ts.mock().
+		On(
+			"DeleteDnsDomainRecordWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			mock.Anything,                 // recordId
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+			ts.Require().Equal(
+				testDnsDomainRecordId,
+				args.Get(2),
+			)
+		}).
+		Return(
+			&oapi.DeleteDnsDomainRecordResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		State:     &testOperationState,
+	})
+
+	err := ts.client.DeleteDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{ID: &testDnsDomainRecordId})
+	ts.Require().NoError(err)
+}
+
+func (ts *testSuite) TestClient_UpdateDnsDomainRecord() {
+	var (
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+	)
+
+	ts.mock().
+		On(
+			"UpdateDnsDomainRecordWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // domainId
+			mock.Anything,                 // recordId
+			mock.Anything,                 // body
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(
+				testDnsDomainId,
+				args.Get(1),
+			)
+			ts.Require().Equal(
+				testDnsDomainRecordId,
+				args.Get(2),
+			)
+			ts.Require().Equal(
+				oapi.UpdateDnsDomainRecordJSONRequestBody{
+					Content:  &testDnsDomainRecordContent,
+					Name:     &testDnsDomainRecordName,
+					Priority: &testDnsDomainRecordPriority,
+					Ttl:      &testDnsDomainRecordTtl,
+				},
+				args.Get(3),
+			)
+		}).
+		Return(
+			&oapi.UpdateDnsDomainRecordResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDnsDomainRecordId, nil),
+		State:     &testOperationState,
+	})
+
+	err := ts.client.UpdateDnsDomainRecord(context.Background(), testZone, testDnsDomainId, &DnsDomainRecord{
+		ID:       &testDnsDomainRecordId,
+		Content:  &testDnsDomainRecordContent,
+		Name:     &testDnsDomainRecordName,
+		Priority: &testDnsDomainRecordPriority,
+		Ttl:      &testDnsDomainRecordTtl,
+		Type:     &testDnsDomainRecordType,
+	})
+	ts.Require().NoError(err)
+}


### PR DESCRIPTION
This PR allows management of DNS with egoscale v2, as available in Public API:
https://openapi-v2.exoscale.com/#endpoint-dns