### PR TITLE
v2: don't overwrite Host header if host is IP address

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -207,7 +207,7 @@ func (c *Client) SetTrace(enabled bool) {
 
 // setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
 // with information from a request endpoint optionally set in the context instance. If none is
-// found or host is IP address, the request is left untouched.
+// found or host is an IP address, the request is left untouched.
 func setEndpointFromContext(ctx context.Context, req *http.Request) error {
 	h, _, err := net.SplitHostPort(req.Host)
 	if err != nil {

--- a/v2/client.go
+++ b/v2/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -206,11 +207,18 @@ func (c *Client) SetTrace(enabled bool) {
 
 // setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
 // with information from a request endpoint optionally set in the context instance. If none is
-// found, the request is left untouched.
+// found or host is IP address, the request is left untouched.
 func setEndpointFromContext(ctx context.Context, req *http.Request) error {
-	if v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint); ok {
-		req.Host = v.Host()
-		req.URL.Host = v.Host()
+	h, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		h = req.Host
+	}
+	if net.ParseIP(h) == nil {
+		v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint)
+		if ok {
+			req.Host = v.Host()
+			req.URL.Host = v.Host()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR prevents endpoint override if endpoint is IP address. This means `environment` and `zone` will be ignored in the case of IP address.

Motivation for this PR is to allow running a mock public API server using [httptest](https://pkg.go.dev/net/http/httptest@go1.19).

Relevant tests:
```
$ go test ./... -count=1 -run TestSetEndpointFromContext 
ok      github.com/exoscale/egoscale    0.003s [no tests to run]
?       github.com/exoscale/egoscale/admin      [no test files]
?       github.com/exoscale/egoscale/generate   [no test files]
ok      github.com/exoscale/egoscale/v2 0.003s
ok      github.com/exoscale/egoscale/v2/api     0.002s [no tests to run]
ok      github.com/exoscale/egoscale/v2/oapi    0.003s [no tests to run]
?       github.com/exoscale/egoscale/version    [no test files
```