### PR TITLE
v2: use hashicorp/go-retryablehttp as default http client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.45
+        version: v1.47
     - name: Tests
       run: |
         git submodule update --init --recursive go.mk

--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -127,7 +127,7 @@ func NewClient(endpoint, apiKey, apiSecret string, opts ...ClientOpt) *Client {
 		Timeout:       DefaultTimeout,
 		Expiration:    10 * time.Minute,
 		RetryStrategy: MonotonicRetryStrategyFunc(2),
-		Logger:        log.New(ioutil.Discard, "", 0),
+		Logger:        log.New(io.Discard, "", 0),
 	}
 
 	for _, opt := range opts {
@@ -175,7 +175,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 			Message string `json:"message"`
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading response body: %s", err)
 		}

--- a/dns.go
+++ b/dns.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -347,7 +347,7 @@ func (client *Client) dnsRequest(ctx context.Context, uri string, urlValues url.
 		return nil, fmt.Errorf(`response content-type expected to be "application/json", got %q`, contentType)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/exoscale/egoscale
 require (
 	github.com/deepmap/oapi-codegen v1.9.1
 	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,12 @@ github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGS
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -73,6 +79,7 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/request.go
+++ b/request.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
@@ -46,7 +45,7 @@ func responseKey(key string) (string, bool) {
 }
 
 func (client *Client) parseResponse(resp *http.Response, apiName string) (json.RawMessage, error) {
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/runstatus.go
+++ b/runstatus.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -108,7 +108,7 @@ func (client *Client) runstatusRequest(ctx context.Context, uri string, structPa
 		return nil, fmt.Errorf(`response %d content-type expected to be "application/json", got %q`, resp.StatusCode, contentType)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/api/middleware.go
+++ b/v2/api/middleware.go
@@ -3,7 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -40,7 +40,7 @@ func (m *ErrorHandlerMiddleware) RoundTrip(req *http.Request) (*http.Response, e
 			Message string `json:"message"`
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error reading response body: %s", err)
 		}

--- a/v2/api/middleware_test.go
+++ b/v2/api/middleware_test.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,7 +54,7 @@ func TestErrorHandlerMiddleware_RoundTrip(t *testing.T) {
 			handler: &testHandler{resStatus: http.StatusOK, resText: "test"},
 			testFunc: func(t *testing.T, res *http.Response, err error) {
 				require.NoError(t, err)
-				actual, _ := ioutil.ReadAll(res.Body)
+				actual, _ := io.ReadAll(res.Body)
 				require.Equal(t, []byte("test"), actual)
 			},
 		},

--- a/v2/api/security.go
+++ b/v2/api/security.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -62,7 +62,7 @@ func (s *SecurityProviderExoscale) signRequest(req *http.Request, expiration tim
 	// Request body if present
 	body := ""
 	if req.Body != nil {
-		data, err := ioutil.ReadAll(req.Body)
+		data, err := io.ReadAll(req.Body)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,7 @@ func (s *SecurityProviderExoscale) signRequest(req *http.Request, expiration tim
 			return err
 		}
 		body = string(data)
-		req.Body = ioutil.NopCloser(bytes.NewReader(data))
+		req.Body = io.NopCloser(bytes.NewReader(data))
 	}
 	sigParts = append(sigParts, body)
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -30,6 +30,7 @@ var UserAgent = fmt.Sprintf("egoscale/%s (%s; %s/%s)",
 	runtime.GOARCH)
 
 // defaultHTTPClient is HTTP client with retry logic.
+// Default retry configuration can be found in go-retryablehttp repo.
 var defaultHTTPClient = retryablehttp.NewClient().StandardClient()
 
 // ClientOpt represents a function setting Exoscale API client option.
@@ -127,6 +128,10 @@ type Client struct {
 }
 
 // NewClient returns a new Exoscale API client, or an error if one couldn't be initialized.
+// Default HTTP client is [go-retryablehttp] with static retry configuration.
+// To change retry configuration, build new HTTP client and pass it using ClientOptWithHTTPClient.
+//
+// [go-retryablehttp]: https://github.com/hashicorp/go-retryablehttp
 func NewClient(apiKey, apiSecret string, opts ...ClientOpt) (*Client, error) {
 	client := Client{
 		apiKey:       apiKey,
@@ -199,6 +204,7 @@ func (c *Client) SetTrace(enabled bool) {
 	c.trace = enabled
 }
 
+// setUserAgent is an HTTP client request interceptor that adds the "User-Agent" header
 func setUserAgent(ctx context.Context, req *http.Request) error {
 	req.Header.Add("User-Agent", UserAgent)
 

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/url"
 )
@@ -252,7 +252,7 @@ func (userdata VirtualMachineUserData) Decode() (string, error) {
 	}
 	defer gr.Close() // nolint: errcheck
 
-	str, err := ioutil.ReadAll(gr)
+	str, err := io.ReadAll(gr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR changes default v2 HTTP client to [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp).
This new library provides retry logic for HTTP server errors and network errors.

Debug logs for retries can be seen when running unit tests:
```
=== RUN   TestDefaultClient_Retry                                                                                      
2022/09/05 14:03:38 [DEBUG] GET http://127.0.0.1:42175                                                                 
2022/09/05 14:03:38 [DEBUG] GET http://127.0.0.1:42175 (status: 500): retrying in 1s (4 left)                          
2022/09/05 14:03:39 [DEBUG] GET http://127.0.0.1:42175 (status: 500): retrying in 2s (3 left)                          
--- PASS: TestDefaultClient_Retry (3.00s)
```

Because user-agent setter was implemented as http Transport (and would overwrite the new library logic), user-agent setter now works as oapi request editor.