### PR TITLE
v2: add database migration stop

### DIFF
--- a/v2/client_mock.go
+++ b/v2/client_mock.go
@@ -1157,3 +1157,30 @@ func (m *oapiClientMock) UpdateReverseDnsElasticIpWithResponse(
 	args := m.Called(ctx, id, body, reqEditors)
 	return args.Get(0).(*oapi.UpdateReverseDnsElasticIpResponse), args.Error(1)
 }
+
+func (m *oapiClientMock) StopDbaasRedisMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasRedisMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasRedisMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasPgMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasPgMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasPgMigrationResponse), args.Error(1)
+}
+
+func (m *oapiClientMock) StopDbaasMysqlMigrationWithResponse(
+	ctx context.Context,
+	name oapi.DbaasServiceName,
+	reqEditors ...oapi.RequestEditorFn,
+) (*oapi.StopDbaasMysqlMigrationResponse, error) {
+	args := m.Called(ctx, name, reqEditors)
+	return args.Get(0).(*oapi.StopDbaasMysqlMigrationResponse), args.Error(1)
+}

--- a/v2/database_mysql.go
+++ b/v2/database_mysql.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopMysqlDatabaseMigration stops running Database migration.
+func (c *Client) StopMysqlDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasMysqlMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/database_mysql_test.go
+++ b/v2/database_mysql_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/stretchr/testify/mock"
+)
+
+func (ts *testSuite) TestClient_StopMysqlDatabaseMigration() {
+	var (
+		testDatabaseName   = "testdb"
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+		stopped            = false
+	)
+
+	ts.mock().
+		On(
+			"StopDbaasMysqlMigrationWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // name
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(oapi.DbaasServiceName(testDatabaseName), args.Get(1))
+			stopped = true
+		}).
+		Return(
+			&oapi.StopDbaasMysqlMigrationResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+		State:     &testOperationState,
+	})
+
+	ts.Require().NoError(ts.client.StopMysqlDatabaseMigration(
+		context.Background(),
+		testZone,
+		testDatabaseName,
+	))
+	ts.Require().True(stopped)
+}

--- a/v2/database_pg.go
+++ b/v2/database_pg.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopPgDatabaseMigration stops running Database migration.
+func (c *Client) StopPgDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasPgMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/database_pg_test.go
+++ b/v2/database_pg_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/stretchr/testify/mock"
+)
+
+func (ts *testSuite) TestClient_StopPgDatabaseMigration() {
+	var (
+		testDatabaseName   = "testdb"
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+		stopped            = false
+	)
+
+	ts.mock().
+		On(
+			"StopDbaasPgMigrationWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // name
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(oapi.DbaasServiceName(testDatabaseName), args.Get(1))
+			stopped = true
+		}).
+		Return(
+			&oapi.StopDbaasPgMigrationResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+		State:     &testOperationState,
+	})
+
+	ts.Require().NoError(ts.client.StopPgDatabaseMigration(
+		context.Background(),
+		testZone,
+		testDatabaseName,
+	))
+	ts.Require().True(stopped)
+}

--- a/v2/database_redis.go
+++ b/v2/database_redis.go
@@ -1,0 +1,26 @@
+package v2
+
+import (
+	"context"
+
+	apiv2 "github.com/exoscale/egoscale/v2/api"
+	"github.com/exoscale/egoscale/v2/oapi"
+)
+
+// StopRedisDatabaseMigration stops running Database migration.
+func (c *Client) StopRedisDatabaseMigration(ctx context.Context, zone string, name string) error {
+	resp, err := c.StopDbaasRedisMigrationWithResponse(apiv2.WithZone(ctx, zone), oapi.DbaasServiceName(name))
+	if err != nil {
+		return err
+	}
+
+	_, err = oapi.NewPoller().
+		WithTimeout(c.timeout).
+		WithInterval(c.pollInterval).
+		Poll(ctx, oapi.OperationPoller(c, zone, *resp.JSON200.Id))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/database_redis_test.go
+++ b/v2/database_redis_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/exoscale/egoscale/v2/oapi"
+	"github.com/stretchr/testify/mock"
+)
+
+func (ts *testSuite) TestClient_StopRedisDatabaseMigration() {
+	var (
+		testDatabaseName   = "testdb"
+		testOperationID    = ts.randomID()
+		testOperationState = oapi.OperationStateSuccess
+		stopped            = false
+	)
+
+	ts.mock().
+		On(
+			"StopDbaasRedisMigrationWithResponse",
+			mock.Anything,                 // ctx
+			mock.Anything,                 // name
+			([]oapi.RequestEditorFn)(nil), // reqEditors
+		).
+		Run(func(args mock.Arguments) {
+			ts.Require().Equal(oapi.DbaasServiceName(testDatabaseName), args.Get(1))
+			stopped = true
+		}).
+		Return(
+			&oapi.StopDbaasRedisMigrationResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
+				JSON200: &oapi.Operation{
+					Id:        &testOperationID,
+					Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+					State:     &testOperationState,
+				},
+			},
+			nil,
+		)
+
+	ts.mockGetOperation(&oapi.Operation{
+		Id:        &testOperationID,
+		Reference: oapi.NewReference(nil, &testDatabaseName, nil),
+		State:     &testOperationState,
+	})
+
+	ts.Require().NoError(ts.client.StopRedisDatabaseMigration(
+		context.Background(),
+		testZone,
+		testDatabaseName,
+	))
+	ts.Require().True(stopped)
+}


### PR DESCRIPTION
Implements database migration stop calls for databases supporting it: Redis, PostgreSQL, MySQL.