### PR TITLE
automate the release with a GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    env:
+      GOLANGCI_LINT_CONFIG: ".golangci.yml"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - run: git submodule update --init --recursive go.mk
+
+      - uses: ./go.mk/.github/actions/setup
+
+      - uses: ./go.mk/.github/actions/pre-check
+
+      - uses: ./go.mk/.github/actions/release
+        with:
+          release_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,5 +3,5 @@ builds:
 
 release:
   github:
-    owner: exoscale
+    owner: sauterp
     name: egoscale

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,5 +3,5 @@ builds:
 
 release:
   github:
-    owner: sauterp
+    owner: exoscale
     name: egoscale


### PR DESCRIPTION
Pushing a tag in semver format(v0.123.4) triggers the release action.

The needed go.mk change needs to be merged first and synced in this PR: https://github.com/exoscale/go.mk/pull/33