### PR TITLE
v3: ForEachZone helper and logging

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -3,6 +3,7 @@ package v3
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -64,8 +65,10 @@ func NewClient(endpoint string, opts ...ClientOpt) (*Client, error) {
 	// Use retryablehttp client by default
 	if config.httpClient == nil {
 		rc := retryablehttp.NewClient()
-		// TODO: attach to global logger when implemented
-		rc.Logger = log.New(os.Stderr, "", 0)
+		rc.Logger = log.New(io.Discard, "", 0)
+		if config.logger != nil {
+			rc.Logger = config.logger
+		}
 		config.httpClient = rc.StandardClient()
 	}
 

--- a/v3/clientopts.go
+++ b/v3/clientopts.go
@@ -17,6 +17,7 @@ const (
 type ClientConfig struct {
 	creds      *Credentials
 	httpClient *http.Client
+	logger     Logger
 
 	requestEditors []oapi.RequestEditorFn
 	// TODO: implement response editors (not available in oapi, should be embeded in consumer API.
@@ -85,6 +86,15 @@ func ClientOptWithRequestEditor(e oapi.RequestEditorFn) ClientOpt {
 func ClientOptWithUserAgent(ua string) ClientOpt {
 	return func(c *ClientConfig) error {
 		c.uaPrefix = ua
+
+		return nil
+	}
+}
+
+// ClientOptWithLogger returns ClientOpt that configures logging with provided Logger.
+func ClientOptWithLogger(logger Logger) ClientOpt {
+	return func(c *ClientConfig) error {
+		c.logger = logger
 
 		return nil
 	}

--- a/v3/logger.go
+++ b/v3/logger.go
@@ -28,27 +28,27 @@ func NewStandardLogger(writer io.Writer, debug bool) *StandardLogger {
 }
 
 func (l *StandardLogger) Error(msg string, keysAndValues ...interface{}) {
-	fmt.Fprintf(l.writer, "[ERROR] %s %v\n", msg, toMap(keysAndValues))
+	fmt.Fprintf(l.writer, "[ERROR] %s %v\n", msg, l.toMap(keysAndValues))
 }
 
 func (l *StandardLogger) Info(msg string, keysAndValues ...interface{}) {
-	fmt.Fprintf(l.writer, "[INFO] %s %v\n", msg, toMap(keysAndValues))
+	fmt.Fprintf(l.writer, "[INFO] %s %v\n", msg, l.toMap(keysAndValues))
 }
 
 func (l *StandardLogger) Debug(msg string, keysAndValues ...interface{}) {
 	if l.debug {
-		fmt.Fprintf(l.writer, "[DEBUG] %s %v\n", msg, toMap(keysAndValues))
+		fmt.Fprintf(l.writer, "[DEBUG] %s %v\n", msg, l.toMap(keysAndValues))
 	}
 }
 
 func (l *StandardLogger) Warn(msg string, keysAndValues ...interface{}) {
-	fmt.Fprintf(l.writer, "[WARN] %s %v\n", msg, toMap(keysAndValues))
+	fmt.Fprintf(l.writer, "[WARN] %s %v\n", msg, l.toMap(keysAndValues))
 }
 
 // Convert keysAndValues to map.
 // Every odd element (key) must be a string.
 // If slice has odd number of elements, last item with value nil is added.
-func toMap(keysAndValues []interface{}) map[string]interface{} {
+func (l *StandardLogger) toMap(keysAndValues []interface{}) map[string]interface{} {
 	if len(keysAndValues) == 0 {
 		return nil
 	}
@@ -61,6 +61,8 @@ func toMap(keysAndValues []interface{}) map[string]interface{} {
 	for i := 0; i < len(keysAndValues); i = i + 2 {
 		if k, ok := keysAndValues[i].(string); ok {
 			m[k] = keysAndValues[i+1]
+		} else {
+			l.Warn("standard_logger: key is not a string", "key", keysAndValues[i], "val", keysAndValues[i+1])
 		}
 	}
 

--- a/v3/logger.go
+++ b/v3/logger.go
@@ -1,0 +1,68 @@
+package v3
+
+import (
+	"fmt"
+	"io"
+)
+
+// Logger is an interface that can be implemented by to provide logging for Client.
+// Interface is the same as LeveledLogger from hashicorp/go-retryablehttp (default http client).
+// Argument keysAndValues expects even number of values and each odd item a string.
+type Logger interface {
+	Error(msg string, keysAndValues ...interface{})
+	Info(msg string, keysAndValues ...interface{})
+	Debug(msg string, keysAndValues ...interface{})
+	Warn(msg string, keysAndValues ...interface{})
+}
+
+// StandardLogger is a simple logger that implements Logger interface.
+// It supports any output that implements Writer interface.
+// Set Debug to true to print debug messages.
+type StandardLogger struct {
+	debug  bool
+	writer io.Writer
+}
+
+func NewStandardLogger(writer io.Writer, debug bool) *StandardLogger {
+	return &StandardLogger{debug: debug, writer: writer}
+}
+
+func (l *StandardLogger) Error(msg string, keysAndValues ...interface{}) {
+	fmt.Fprintf(l.writer, "[ERROR] %s %v\n", msg, toMap(keysAndValues))
+}
+
+func (l *StandardLogger) Info(msg string, keysAndValues ...interface{}) {
+	fmt.Fprintf(l.writer, "[INFO] %s %v\n", msg, toMap(keysAndValues))
+}
+
+func (l *StandardLogger) Debug(msg string, keysAndValues ...interface{}) {
+	if l.debug {
+		fmt.Fprintf(l.writer, "[DEBUG] %s %v\n", msg, toMap(keysAndValues))
+	}
+}
+
+func (l *StandardLogger) Warn(msg string, keysAndValues ...interface{}) {
+	fmt.Fprintf(l.writer, "[WARN] %s %v\n", msg, toMap(keysAndValues))
+}
+
+// Convert keysAndValues to map.
+// Every odd element (key) must be a string.
+// If slice has odd number of elements, last item with value nil is added.
+func toMap(keysAndValues []interface{}) map[string]interface{} {
+	if len(keysAndValues) == 0 {
+		return nil
+	}
+
+	if len(keysAndValues)%2 > 0 {
+		keysAndValues = append(keysAndValues, nil)
+	}
+
+	m := map[string]interface{}{}
+	for i := 0; i < len(keysAndValues); i = i + 2 {
+		if k, ok := keysAndValues[i].(string); ok {
+			m[k] = keysAndValues[i+1]
+		}
+	}
+
+	return m
+}

--- a/v3/zoned_client.go
+++ b/v3/zoned_client.go
@@ -117,9 +117,6 @@ func (c *ZonedClient) SetZone(z oapi.ZoneName) {
 //
 //	zonedClient.InZone(oapi.ChGva2).OAPIClient()...
 func (c *ZonedClient) InZone(z oapi.ZoneName) *Client {
-	c.mx.Lock()
-	defer c.mx.Unlock()
-
 	return &Client{
 		creds:      c.creds,
 		oapiClient: c.zones[z],
@@ -132,4 +129,12 @@ func (c *ZonedClient) OAPIClient() *oapi.ClientWithResponses {
 	defer c.mx.RUnlock()
 
 	return c.Client.OAPIClient()
+}
+
+// ForEachZone runs function f in each configured zone.
+// Argument of function f is configured Client for the zone.
+func (c *ZonedClient) ForEachZone(f func(c *Client, zone string)) {
+	for zone, oapiClient := range c.zones {
+		f(&Client{creds: c.creds, oapiClient: oapiClient}, zone)
+	}
 }

--- a/v3/zoned_client.go
+++ b/v3/zoned_client.go
@@ -133,7 +133,7 @@ func (c *ZonedClient) OAPIClient() *oapi.ClientWithResponses {
 
 // ForEachZone runs function f in each configured zone.
 // Argument of function f is configured Client for the zone.
-func (c *ZonedClient) ForEachZone(f func(c *Client, zone string)) {
+func (c *ZonedClient) ForEachZone(f func(c *Client, zone oapi.ZoneName)) {
 	for zone, oapiClient := range c.zones {
 		f(&Client{creds: c.creds, oapiClient: oapiClient}, zone)
 	}


### PR DESCRIPTION
Example usage of `ForEachZone` and logging  with builtin `Logger` implementation (`StandardLogger`):

```go
func main() {
	client, err := exoscale.DefaultClient(
		exoscale.ClientOptWithCredentialsFromEnv(),
		exoscale.ClientOptWithLogger(exoscale.NewStandardLogger(os.Stdout, true)),
	)
	if err != nil {
		panic(err)
	}

	client.ForEachZone(func(c *exoscale.Client, zone oapi.ZoneName) {
		l, err := c.Compute().LoadBalancers().Get(context.Background(), <id>)
		if err != nil {
			fmt.Println(err)
		} else {
			fmt.Println(l)
		}
	})
}
```
