### PR TITLE
Make IAMv3 policy Resources field NOOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- v2: IAMv3 Policy Resources field now noop #604
+
 0.102.0
 -------
 

--- a/v2/iam.go
+++ b/v2/iam.go
@@ -29,15 +29,9 @@ func iamPolicyFromAPI(r *oapi.IamPolicy) *IAMPolicy {
 		rules := []IAMPolicyServiceRule{}
 		if service.Rules != nil && len(*service.Rules) > 0 {
 			for _, rule := range *service.Rules {
-				resources := []string{}
-				if rule.Resources != nil && len(*rule.Resources) > 0 {
-					resources = *rule.Resources
-				}
-
 				rules = append(rules, IAMPolicyServiceRule{
 					Action:     (*string)(rule.Action),
 					Expression: rule.Expression,
-					Resources:  resources,
 				})
 			}
 		}

--- a/v2/iam_org_policy.go
+++ b/v2/iam_org_policy.go
@@ -42,10 +42,6 @@ func (c *Client) UpdateIAMOrgPolicy(ctx context.Context, zone string, policy *IA
 						Expression: rule.Expression,
 					}
 
-					if rule.Resources != nil {
-						r.Resources = &rule.Resources
-					}
-
 					rules = append(rules, r)
 				}
 

--- a/v2/iam_org_policy_test.go
+++ b/v2/iam_org_policy_test.go
@@ -13,7 +13,6 @@ var (
 	testIAMPolicyServiceType           = new(testSuite).randomString(10)
 	testIAMPolicyServiceRuleAction     = "allow"
 	testIAMPolicyServiceRuleExpression = new(testSuite).randomString(10)
-	testIAMPolicyServiceRuleResources  = []string{"foo", "bar"}
 )
 
 func (ts *testSuite) TestClient_GetIAMOrgPolicy() {
@@ -34,7 +33,6 @@ func (ts *testSuite) TestClient_GetIAMOrgPolicy() {
 								{
 									Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 									Expression: &testIAMPolicyServiceRuleExpression,
-									Resources:  &testIAMPolicyServiceRuleResources,
 								},
 							},
 						},
@@ -52,7 +50,6 @@ func (ts *testSuite) TestClient_GetIAMOrgPolicy() {
 					IAMPolicyServiceRule{
 						Action:     (*string)(&testIAMPolicyServiceRuleAction),
 						Expression: &testIAMPolicyServiceRuleExpression,
-						Resources:  testIAMPolicyServiceRuleResources,
 					},
 				},
 			},
@@ -89,7 +86,6 @@ func (ts *testSuite) TestClient_UpdateIAMOrgPolicy() {
 									{
 										Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 										Expression: &testIAMPolicyServiceRuleExpression,
-										Resources:  &testIAMPolicyServiceRuleResources,
 									},
 								},
 							},
@@ -126,7 +122,6 @@ func (ts *testSuite) TestClient_UpdateIAMOrgPolicy() {
 					IAMPolicyServiceRule{
 						Action:     (*string)(&testIAMPolicyServiceRuleAction),
 						Expression: &testIAMPolicyServiceRuleExpression,
-						Resources:  testIAMPolicyServiceRuleResources,
 					},
 				},
 			},

--- a/v2/iam_role.go
+++ b/v2/iam_role.go
@@ -125,10 +125,6 @@ func (c *Client) CreateIAMRole(
 							Expression: rule.Expression,
 						}
 
-						if rule.Resources != nil {
-							r.Resources = &rule.Resources
-						}
-
 						rules = append(rules, r)
 					}
 
@@ -259,10 +255,6 @@ func (c *Client) UpdateIAMRolePolicy(ctx context.Context, zone string, role *IAM
 					r := oapi.IamServicePolicyRule{
 						Action:     (*oapi.IamServicePolicyRuleAction)(rule.Action),
 						Expression: rule.Expression,
-					}
-
-					if rule.Resources != nil {
-						r.Resources = &rule.Resources
 					}
 
 					rules = append(rules, r)

--- a/v2/iam_role_test.go
+++ b/v2/iam_role_test.go
@@ -47,7 +47,6 @@ func (ts *testSuite) TestClient_GetIAMRole() {
 									{
 										Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 										Expression: &testIAMPolicyServiceRuleExpression,
-										Resources:  &testIAMPolicyServiceRuleResources,
 									},
 								},
 							},
@@ -77,7 +76,6 @@ func (ts *testSuite) TestClient_GetIAMRole() {
 						IAMPolicyServiceRule{
 							Action:     (*string)(&testIAMPolicyServiceRuleAction),
 							Expression: &testIAMPolicyServiceRuleExpression,
-							Resources:  testIAMPolicyServiceRuleResources,
 						},
 					},
 				},
@@ -125,7 +123,6 @@ func (ts *testSuite) TestClient_ListIAMRoles() {
 											{
 												Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 												Expression: &testIAMPolicyServiceRuleExpression,
-												Resources:  &testIAMPolicyServiceRuleResources,
 											},
 										},
 									},
@@ -158,7 +155,6 @@ func (ts *testSuite) TestClient_ListIAMRoles() {
 							IAMPolicyServiceRule{
 								Action:     (*string)(&testIAMPolicyServiceRuleAction),
 								Expression: &testIAMPolicyServiceRuleExpression,
-								Resources:  testIAMPolicyServiceRuleResources,
 							},
 						},
 					},
@@ -209,7 +205,6 @@ func (ts *testSuite) TestClient_CreateIAMRole() {
 										{
 											Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 											Expression: &testIAMPolicyServiceRuleExpression,
-											Resources:  &testIAMPolicyServiceRuleResources,
 										},
 									},
 								},
@@ -269,7 +264,6 @@ func (ts *testSuite) TestClient_CreateIAMRole() {
 									{
 										Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 										Expression: &testIAMPolicyServiceRuleExpression,
-										Resources:  &testIAMPolicyServiceRuleResources,
 									},
 								},
 							},
@@ -299,7 +293,6 @@ func (ts *testSuite) TestClient_CreateIAMRole() {
 						IAMPolicyServiceRule{
 							Action:     (*string)(&testIAMPolicyServiceRuleAction),
 							Expression: &testIAMPolicyServiceRuleExpression,
-							Resources:  testIAMPolicyServiceRuleResources,
 						},
 					},
 				},
@@ -326,7 +319,6 @@ func (ts *testSuite) TestClient_CreateIAMRole() {
 						IAMPolicyServiceRule{
 							Action:     (*string)(&testIAMPolicyServiceRuleAction),
 							Expression: &testIAMPolicyServiceRuleExpression,
-							Resources:  testIAMPolicyServiceRuleResources,
 						},
 					},
 				},
@@ -476,7 +468,6 @@ func (ts *testSuite) TestClient_UpdateIAMRolePolicy() {
 									{
 										Action:     (*oapi.IamServicePolicyRuleAction)(&testIAMPolicyServiceRuleAction),
 										Expression: &testIAMPolicyServiceRuleExpression,
-										Resources:  &testIAMPolicyServiceRuleResources,
 									},
 								},
 							},
@@ -515,7 +506,6 @@ func (ts *testSuite) TestClient_UpdateIAMRolePolicy() {
 						IAMPolicyServiceRule{
 							Action:     (*string)(&testIAMPolicyServiceRuleAction),
 							Expression: &testIAMPolicyServiceRuleExpression,
-							Resources:  testIAMPolicyServiceRuleResources,
 						},
 					},
 				},


### PR DESCRIPTION
# Description
Makes IAMv3 Policy Resources field noop. More details in the attached story.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] For a new resource or new attributes: test added/updated
