### PR TITLE
Fix SetHTTPClient (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-0.102.1
-=======
-
 Unreleased
 ----------
+
+- v2: Fixed `SetHTTPClient` #605
+
+0.102.1
+=======
 
 - v2: IAMv3 Policy Resources field now noop #604
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -213,6 +213,14 @@ func (c *Client) SetHTTPClient(client *http.Client) {
 		return
 	}
 
+	// Tracing must be performed before API error handling in the middleware chain,
+	// otherwise the response won't be dumped in case of an API error.
+	if c.trace {
+		c.httpClient.Transport = api.NewTraceMiddleware(c.httpClient.Transport)
+	}
+
+	c.httpClient.Transport = api.NewAPIErrorHandlerMiddleware(c.httpClient.Transport)
+
 	oapiOpts := []oapi.ClientOption{
 		oapi.WithHTTPClient(c.httpClient),
 		oapi.WithRequestEditorFn(

--- a/v2/client.go
+++ b/v2/client.go
@@ -198,8 +198,35 @@ func NewClient(apiKey, apiSecret string, opts ...ClientOpt) (*Client, error) {
 }
 
 // SetHTTPClient overrides the current HTTP client.
+// As we don't return error, any error during intialization of client will make SetHTTPClient NOOP.
 func (c *Client) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+
+	apiURL, err := url.Parse(c.apiEndpoint)
+	if err != nil {
+		return
+	}
+	apiURL = apiURL.ResolveReference(&url.URL{Path: api.Prefix})
+
+	apiSecurityProvider, err := api.NewSecurityProvider(c.apiKey, c.apiSecret)
+	if err != nil {
+		return
+	}
+
+	oapiOpts := []oapi.ClientOption{
+		oapi.WithHTTPClient(c.httpClient),
+		oapi.WithRequestEditorFn(
+			oapi.MultiRequestsEditor(
+				setUserAgent,
+				apiSecurityProvider.Intercept,
+				setEndpointFromContext,
+			),
+		),
+	}
+
+	if c.oapiClient, err = oapi.NewClientWithResponses(apiURL.String(), oapiOpts...); err != nil {
+		return
+	}
 }
 
 // SetTimeout overrides the current client timeout value.


### PR DESCRIPTION
# Description
This PR fixes #573 .
As stated in the issue, `SetHTTPClient` did not actually replace the HTTP client used by underlying `oapi` client.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] For a new resource or new attributes: test added/updated
