### PR TITLE
v2: fix issue with iam role labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- v2: fix issue with iam role labels #614
+
 0.102.2
 -------
 

--- a/v2/iam_role.go
+++ b/v2/iam_role.go
@@ -20,7 +20,7 @@ type IAMRole struct {
 
 func iamRoleFromAPI(r *oapi.IamRole) *IAMRole {
 	labels := map[string]string{}
-	if r.Labels != nil {
+	if r.Labels != nil && r.Labels.AdditionalProperties != nil {
 		labels = r.Labels.AdditionalProperties
 	}
 


### PR DESCRIPTION
# Description

Fixes the bug with iam role labels where API returns no labels field (equivalent to nil) but egoscale translates it to empty slice.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] For a new resource or new attributes: test added/updated
