### PR TITLE
Makefile: fix targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - go.mk: remove submodule and initialize through make #618 
+- Makefile: fix targets #619 
 
 0.102.3
 -------

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,10 @@ oapigen: install-oapi-codegen
 .PHONY: generate
 generate:
 	@wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
-	@echo
-	@cd v3/generator/; go generate
-	@go mod tidy && go mod vendor
-	@rm v3/generator/source.yaml
-	@ls -l v3/*.go
+	@cd v3/generator/
+	@go generate
+	@go mod tidy
+	@go mod vendor
+	@rm source.yaml
+	@cd ..
+	@ls -l *.go

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ install-oapi-codegen:
 # OpenAPI specifications (JSON)
 .PHONY: oapigen
 oapigen: install-oapi-codegen
-	wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.json -O- > v2/oapi/source.json
-	@echo
-	cd v2/oapi/; go generate
-	@rm v2/oapi/source.json
-	ls -l v2/oapi/oapi.gen.go
+	@wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.json -O- > v2/oapi/source.json
+	@cd v2/oapi/
+	@go generate
+	@rm source.json
+	@ls -l oapi.gen.go
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
# Description
Due to the introduction of `.ONESHELL` to `Makefile` in #618  the shell commands in each target are now executed in one shell session. This improves performance but also means that changing the directory in one line also changes the directory for the following lines(doesn't happen across targets). Unfortunately it broke the targets `oapigen` and `generate`.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
