### PR TITLE
v3: make maps nullable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,9 @@ oapigen: install-oapi-codegen
 
 .PHONY: generate
 generate:
-	@wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
 	@cd v3/generator/
 	@go generate
 	@go mod tidy
 	@go mod vendor
-	@rm source.yaml
 	@cd ..
 	@ls -l *.go

--- a/v3/generator/main.go
+++ b/v3/generator/main.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pb33f/libopenapi"
+
 	"github.com/exoscale/egoscale/v3/generator/client"
 	"github.com/exoscale/egoscale/v3/generator/helpers"
 	"github.com/exoscale/egoscale/v3/generator/operations"
 	"github.com/exoscale/egoscale/v3/generator/schemas"
-	"github.com/pb33f/libopenapi"
 )
 
 //go:generate go run main.go ./source.yaml ../ v3

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -9,10 +9,11 @@ import (
 
 	"fmt"
 
-	"github.com/exoscale/egoscale/v3/generator/helpers"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	"github.com/pb33f/libopenapi/datamodel/low"
+
+	"github.com/exoscale/egoscale/v3/generator/helpers"
 )
 
 // TODO fix the OpenApi spec (duplicated resources)
@@ -124,6 +125,7 @@ func RenderSimpleType(s *base.Schema) string {
 		)
 		return "any"
 	}
+
 	if s.Type[0] == "boolean" {
 		return "bool"
 	}
@@ -194,7 +196,12 @@ func renderSchemaInternal(schemaName string, s *base.Schema, output *bytes.Buffe
 		if err != nil {
 			return err
 		}
-		output.WriteString("type " + schemaName + " " + Map + "\n")
+		typeString := "type " + schemaName + " "
+		if s.Nullable != nil && *s.Nullable {
+			typeString += "*"
+		}
+		typeString += Map + "\n"
+		output.WriteString(typeString)
 		return nil
 	default:
 		slog.Error("type not implemented", slog.String("type", typ))

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -2017,7 +2017,7 @@ type KubeletImageGC struct {
 	MinAge        string `json:"min-age,omitempty"`
 }
 
-type Labels map[string]string
+type Labels *map[string]string
 
 type LoadBalancerState string
 


### PR DESCRIPTION
# Description
```diff
❯ diff -C 3 v3/generator/source.old.yaml v3/generator/source.yaml
*** v3/generator/source.old.yaml	2024-04-22 13:26:16.271603306 +0200
--- v3/generator/source.yaml	2024-04-22 14:10:03.906145240 +0200
***************
*** 3479,3484 ****
--- 3479,3485 ----
        description: DBaaS plan
      labels:
        type: object
+       nullable: true
        additionalProperties:
          type: string
      dbaas-mysql-database-name:
```

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
