### PR TITLE
fix: incomplete package retraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,4 +50,7 @@ require (
 
 go 1.20
 
-retract v1.19.0 // Published accidentally.
+retract (
+	v1.19.1 // Retracts the previous version
+	v1.19.0 // Published accidentally.
+)


### PR DESCRIPTION
# Description

Fixes #586

After the merge of this PR, you should create a tag `v1.19.1` as explained [here](https://go.dev/ref/mod#go-mod-file-retract).

> To retract a version, a module author should add a retract directive to `go.mod`, then publish a new version containing that directive. **The new version must be higher than other release or pre-release versions**; that is, the `@latest` [version query](https://go.dev/ref/mod#version-queries) should resolve to the new version before retractions are considered.


Related to https://github.com/exoscale/egoscale/issues/482
Related to https://github.com/exoscale/egoscale/issues/483
