### PR TITLE
v3: Add a metadata package to interact with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- v3: Add a metadata package to interact with #632
 - v3: Remove omitempty on nullable complex types #628
 - v3: Add the Authorization header value in the dump request #624
 - v3: Add the User-Agent header value #623

--- a/v3/metadata/metadata.go
+++ b/v3/metadata/metadata.go
@@ -1,0 +1,61 @@
+package metadata
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type Endpoint string
+
+const (
+	AvailabilityZone Endpoint = "availability-zone"
+	CloudIdentifier  Endpoint = "cloud-identifier"
+	InstanceID       Endpoint = "instance-id"
+	LocalHostname    Endpoint = "local-hostname"
+	LocalIpv4        Endpoint = "local-ipv4"
+	PublicHostname   Endpoint = "public-hostname"
+	PublicIpv4       Endpoint = "public-ipv4"
+	ServiceOffering  Endpoint = "service-offering"
+	VmID             Endpoint = "vm-id"
+)
+
+const (
+	URL         = "http://metadata.exoscale.com/latest/"
+	MetaDataURL = URL + "meta-data"
+	UserDataURL = URL + "user-data"
+)
+
+func UserData(ctx context.Context) (string, error) {
+	return httpGet(ctx, UserDataURL)
+}
+
+func Get(ctx context.Context, endpoint Endpoint) (string, error) {
+	url, err := url.JoinPath(MetaDataURL, string(endpoint))
+	if err != nil {
+		return "", err
+	}
+
+	return httpGet(ctx, url)
+}
+
+func httpGet(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/v3/metadata/metadata.go
+++ b/v3/metadata/metadata.go
@@ -18,7 +18,7 @@ const (
 	PublicHostname   Endpoint = "public-hostname"
 	PublicIpv4       Endpoint = "public-ipv4"
 	ServiceOffering  Endpoint = "service-offering"
-	VmID             Endpoint = "vm-id"
+	VMID             Endpoint = "vm-id"
 )
 
 const (

--- a/v3/metadata/metadata.go
+++ b/v3/metadata/metadata.go
@@ -1,3 +1,5 @@
+// This package provides functions to interact with the Exoscale metadata server
+// and retrieve user-data (Cloudinit or Ignition data).
 package metadata
 
 import (
@@ -7,8 +9,13 @@ import (
 	"net/url"
 )
 
+// Endpoint represents different types of metadata
+// available on the Exoscale server.
 type Endpoint string
 
+// These constants define the various types of
+// Exoscale metadata you can retrieve.
+// Use the Get function to access specific metadata.
 const (
 	AvailabilityZone Endpoint = "availability-zone"
 	CloudIdentifier  Endpoint = "cloud-identifier"
@@ -27,10 +34,14 @@ const (
 	UserDataURL = URL + "user-data"
 )
 
+// UserData retrieves the user-data associated with the current instance from the Exoscale server.
+// This data is typically used for Cloudinit/Ignition configuration.
 func UserData(ctx context.Context) (string, error) {
 	return httpGet(ctx, UserDataURL)
 }
 
+// Get retrieves the value for a specific type of Exoscale metadata.
+// Provide the desired Endpoint constant as an argument.
 func Get(ctx context.Context, endpoint Endpoint) (string, error) {
 	url, err := url.JoinPath(MetaDataURL, string(endpoint))
 	if err != nil {


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Metadata package to interact with exoscale metadata server from an exoscale Instance

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] For a new resource or new attributes: test added/updated

test from Instance

```Golang
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/exoscale/egoscale/v3/metadata"
)

func main() {
	endpoints := []metadata.Endpoint{
		metadata.AvailabilityZone,
		metadata.CloudIdentifier,
		metadata.InstanceID,
		metadata.LocalHostname,
		metadata.LocalIpv4,
		metadata.PublicHostname,
		metadata.PublicIpv4,
		metadata.ServiceOffering,
		metadata.VMID,
	}

	for _, endpoint := range endpoints {
		resp, err := metadata.Get(context.Background(), endpoint)
		if err != nil {
			log.Fatal(err)
		}

		fmt.Printf("Response for %s: %s\n", endpoint, resp)
	}

	resp, err := metadata.UserData(context.Background())
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Response for user-data: %s\n", resp)
}
```

Output
```Bash
Response for availability-zone: ch-gva-2
Response for cloud-identifier: Exoscale Compute Platform
Response for instance-id: 905xxxxxx8efd0
Response for local-hostname: test
Response for local-ipv4: 85.x.x.x
Response for public-hostname: test
Response for public-ipv4: 85.x.x.x
Response for service-offering: Cpu-huge 32gb 16cpu
Response for vm-id: 905xxxxxxx8efd0
Response for user-data: #cloud-init....
```