### PR TITLE
deprecate v1 and v2 and remove alpha notice for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased
 - go.mk: lint with staticcheck #633 
 - v3: update generated code #637
 - v3: separate v3 into its own go module #638 
+- deprecate v1 and v2 and remove alpha notice for v3 #640 
 
 0.102.3
 -------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Deprecated use v3
+
+v1 and v2 of `egoscale` are deprecated, please use [v3](https://pkg.go.dev/github.com/sauterp/egoscale/v3)
+
 ---
 title: Egoscale
 description: the Go library for Exoscale

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Deprecated use v3
 
-v1 and v2 of `egoscale` are deprecated, please use [v3](https://pkg.go.dev/github.com/sauterp/egoscale/v3)
+v1 and v2 of `egoscale` are deprecated, please use [v3](https://pkg.go.dev/github.com/exoscale/egoscale/v3)
 
 ---
 title: Egoscale

--- a/README.md
+++ b/README.md
@@ -10,17 +10,15 @@ description: the Go library for Exoscale
 <a href="https://gopherize.me/gopher/9c1bc7cfe1d84cf43e477dbfc4aa86332065f1fd"><img src="gopher.png" align="right" alt=""></a>
 
 [![Actions Status](https://github.com/exoscale/egoscale/workflows/CI/badge.svg?branch=master)](https://github.com/exoscale/egoscale/actions?query=workflow%3ACI+branch%3Amaster)
-[![GoDoc](https://godoc.org/github.com/exoscale/egoscale?status.svg)](https://godoc.org/github.com/exoscale/egoscale/v2) [![Go Report Card](https://goreportcard.com/badge/github.com/exoscale/egoscale)](https://goreportcard.com/report/github.com/exoscale/egoscale)
+[![GoDoc](https://godoc.org/github.com/exoscale/egoscale?status.svg)](https://godoc.org/github.com/exoscale/egoscale/v3) [![Go Report Card](https://goreportcard.com/badge/github.com/exoscale/egoscale)](https://goreportcard.com/report/github.com/exoscale/egoscale)
 
 A wrapper for the [Exoscale public cloud](https://www.exoscale.com) API.
 
-Actively maintained version is **v2**, it can be imported as:
+**v2** can be imported as:
 
 ```
 	import "github.com/exoscale/egoscale/v2"
 ```
-
-**Version v3 is in alpha state and breaking changes are expected.**
 
 ## Known users
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: this version is no longer maintained, please use github.com/exoscale/egoscale/v3 instead
 module github.com/exoscale/egoscale
 
 require (

--- a/v3/README.md
+++ b/v3/README.md
@@ -1,4 +1,4 @@
-# Egoscale v3 (Alpha)
+# Egoscale v3
 
 Exoscale API Golang wrapper
 


### PR DESCRIPTION
# Description
After merging this change and pushing the release tag `v3.0.0`, users will see the following when opening `https://pkg.go.dev/github.com/exoscale/egoscale@v3.0.0` <- (note that the v3 suffix is missing, thus they will be redirected to v3)
![image](https://github.com/exoscale/egoscale/assets/46172817/8acb330f-0f78-4dd2-8672-859270cd895e)

If users open `https://pkg.go.dev/github.com/exoscale/egoscale` they will not be automatically redirected, but they will see:
![image](https://github.com/exoscale/egoscale/assets/46172817/624d4d05-bf34-4289-99d0-358118f25124)

This was tested on [a fork](https://pkg.go.dev/github.com/sauterp/egoscale).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
