### PR TITLE
v3: automate regeneration when spec changes

### DIFF
--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,4 +1,4 @@
-name: Check whether the exoscale API has been updated and regenerate egoscale v3.
+name: check_and_regenerate_v3
 
 # TODO run on a regular basis
 on:
@@ -29,6 +29,7 @@ jobs:
       uses: peter-evans/create-pull-request@v6
       with:
         title: "v3: regenerate from new API spec"
-        body: New changes have appeared in the API spec and egoscale v3 has been regenerated.
-        branch: generate-v3/${{ github.run_id }}
-        draft: true
+        body: "New changes have appeared in the API spec and egoscale v3 has been regenerated."
+        branch: generate-v3
+        delete-branch: true
+        base: master

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,10 +1,8 @@
 name: check_and_regenerate_v3
 
-# TODO run on a regular basis
 on:
-  push:
-    branches:
-      - philippsauter/sc-100400/automate-v3-generation
+  schedule:
+    - cron: "0 7 * * *" # everyday at 7 AM
 
 jobs:
   check_changes_and_create_pr:

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,0 +1,34 @@
+name: Check whether the exoscale API has been updated and regenerate egoscale v3.
+
+# TODO run on a regular basis
+on:
+  push:
+    branches:
+      - philippsauter/sc-100400/automate-v3-generation
+
+jobs:
+  check_changes_and_create_pr:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Check for changes
+      id: check_changes
+      run: |
+        make generate
+        git diff --quiet || echo "::set-output name=changes_detected::true"
+
+    - name: Create PR
+      if: steps.check_changes.outputs.changes_detected
+      uses: peter-evans/create-pull-request@v6
+      with:
+        title: "v3: regenerate from new API spec"
+        body: New changes have appeared in the API spec and egoscale v3 has been regenerated.
+        branch: generate-v3/${{ github.run_id }}
+        draft: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ test/
 listApis.json
 public-api.json
 release
-v3/generator/source.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- v3: automate regeneration when spec changes #643 
+
 3.1.0
 ----------
 

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,14 @@ oapigen: install-oapi-codegen
 	@rm source.json
 	@ls -l oapi.gen.go
 
+# TODO renenable download
+# @wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
 .PHONY: generate
 generate:
-	@wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
 	@echo
 	@cd v3/generator/
 	@go generate
 	@go mod tidy
 	@go mod vendor
-	@rm source.yaml
 	@cd ..
 	@ls -l *.go 1>&2

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,9 @@ oapigen: install-oapi-codegen
 	@rm source.json
 	@ls -l oapi.gen.go
 
-# TODO renenable download
-# @wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
 .PHONY: generate
 generate:
+	@wget -q --show-progress --progress=dot https://openapi-v2.exoscale.com/source.yaml -O- > v3/generator/source.yaml
 	@echo
 	@cd v3/generator/
 	@go generate

--- a/v3/generator/source.yaml
+++ b/v3/generator/source.yaml
@@ -1,0 +1,15943 @@
+---
+openapi: 3.0.0
+info:
+  version: 2.0.0
+  termsOfService: https://exoscale.com/terms
+  contact:
+    email: api@exoscale.com
+    name: API support
+    url: https://portal.exoscale.com/tickets
+  title: Exoscale Public API
+  description: |2-
+
+    Infrastructure automation API, allowing programmatic access to all Exoscale products and services.
+
+    The [OpenAPI Specification](http://spec.openapis.org/oas/v3.0.3.html) source of this documentation can be obtained here:
+
+    * [JSON format](https://openapi-v2.exoscale.com/source.json)
+    * [YAML format](https://openapi-v2.exoscale.com/source.yaml)
+tags:
+- description: |2-
+
+    Security Groups are groups of firewall rules that regulate network traffic to and from your Compute instances.
+
+    [Read more](https://community.exoscale.com/documentation/compute/security-groups/)
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/security-groups/
+  name: security-groups
+- description: |2-
+
+    An Instance Type is a resource describing the amount of CPU, RAM and eventually GPUs your Compute instance will run on.
+
+    [Read more](https://www.exoscale.com/pricing/)
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/pricing/
+  name: instance-types
+- description: |2
+
+    A Network Load Balancer (NLB) is a Layer 4 (TCP/UDP) load balancer that distributes incoming traffic to Compute instances managed by an Instance Pool.
+
+    [Read more](https://community.exoscale.com/documentation/compute/network-load-balancer/)
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/network-load-balancer/
+  name: network-load-balancer
+- description: |2-
+
+    Instance Pools is an Exoscale service allowing users to provision managed groups of identical Compute instances automatically.
+
+    [Read more](https://community.exoscale.com/documentation/compute/instance-pools/)
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/instance-pools/
+  name: instance-pools
+- description: |2-
+
+    Events form the basis of the Exoscale audit-trail, a mechanism to query past events
+    performing mutations on resources which happened on an organization
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/support/
+  name: event
+- description: |2-
+
+    Instances are the virtual machines at the core of the Exoscale Compute service.
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/compute/
+  name: instances
+- description: |2-
+
+    Exoscale's Block Storage offers persistent
+    externally attached volumes for your workloads.
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/
+  name: block-storage
+- description: |2-
+
+    Snapshots provide a way to get point-in-time recovery for your Compute instance.
+
+    [Read more](https://community.exoscale.com/documentation/compute/snapshots/)
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/snapshots/
+  name: snapshots
+- description: |2-
+
+    A Zone represents an independent datacenter in which Exoscale infrastructure is deployed into.
+
+    [Read more](https://www.exoscale.com/datacenters/)
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/datacenters/
+  name: zones
+- description: |2-
+
+    SSH Keypairs
+
+    [Read more](https://community.exoscale.com/documentation/compute/ssh-keypairs/)
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/documentation/compute/ssh-keypairs/
+  name: ssh-keypair
+- description: |2-
+
+    Operations describe the current state of an asynchronous operation.
+  externalDocs:
+    description: Read more
+    url: https://community.exoscale.com/
+  name: operations
+- description: |2-
+
+    Templates contain the OS and the initial setup of a Compute instance.
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/templates/
+  name: templates
+- description: |2-
+
+    SKS is Exoscale's scalable Kubernetes service which provides managed Kubernetes
+    control planes with integrated support for Exoscale instance pools ands network load
+    balancers.
+    [Read more](https://www.exoscale.com/scalable-kubernetes-service/)
+  externalDocs:
+    description: Read more
+    url: https://www.exoscale.com/scalable-kubernetes-service/
+  name: sks
+components:
+  schemas:
+    dbaas-node-state:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the service node
+        progress-updates:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state-progress-update"
+          description: Extra information regarding the progress for current state
+        role:
+          type: string
+          enum:
+          - standby
+          - master
+          - read-replica
+          description: Role of this node. Only returned for a subset of service types
+        state:
+          type: string
+          enum:
+          - leaving
+          - running
+          - syncing_data
+          - setting_up_vm
+          - unknown
+          description: Current state of the service node
+      required:
+      - name
+      - state
+      description: Automatic maintenance settings
+    json-schema-schema-registry:
+      additionalProperties: false
+      properties:
+        leader_eligibility:
+          description: If true, Karapace / Schema Registry on the service nodes can
+            participate in leader election. It might be needed to disable this when
+            the schemas topic is replicated to a secondary cluster and Karapace /
+            Schema Registry there must not participate in leader election. Defaults
+            to `true`.
+          example: true
+          title: leader_eligibility
+          type: boolean
+        topic_name:
+          description: The durable single partition topic that acts as the durable
+            log for the data. This topic must be compacted to avoid losing data due
+            to retention policy. Please note that changing this configuration in an
+            existing Schema Registry / Karapace setup leads to previous schemas being
+            inaccessible, data encoded with them potentially unreadable and schema
+            ID sequence put out of order. It's only possible to do the switch while
+            Schema Registry / Karapace is disabled. Defaults to `_schemas`.
+          example: _schemas
+          maxLength: 249
+          minLength: 1
+          pattern: "^(?!\\.$|\\.\\.$)[-_.A-Za-z0-9]+$"
+          title: topic_name
+          type: string
+      title: Schema Registry configuration
+      type: object
+    resource:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Resource ID
+        name:
+          type: string
+          description: Resource name
+      description: Resource
+    dbaas-kafka-topic-acl-entry:
+      type: object
+      properties:
+        id:
+          "$ref": "#/components/schemas/dbaas-kafka-acl-id"
+          description: Kafka ACL ID
+        username:
+          type: string
+          maxLength: 64
+          minLength: 1
+          description: Kafka username or username pattern
+        topic:
+          type: string
+          maxLength: 249
+          minLength: 1
+          description: Kafka topic name or pattern
+        permission:
+          type: string
+          enum:
+          - admin
+          - read
+          - readwrite
+          - write
+          description: Kafka permission
+      required:
+      - username
+      - topic
+      - permission
+    instance-state:
+      type: string
+      enum:
+      - expunging
+      - starting
+      - destroying
+      - running
+      - stopping
+      - stopped
+      - migrating
+      - error
+      - destroyed
+    dbaas-pg-pool-size:
+      type: integer
+      format: int64
+      minimum: 1
+      maximum: 10000
+      exclusiveMinimum: false
+      exclusiveMaximum: false
+    security-group-rule:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 255
+          description: Security Group rule description
+        start-port:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 65535
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Start port of the range
+        protocol:
+          type: string
+          enum:
+          - tcp
+          - esp
+          - icmp
+          - udp
+          - gre
+          - ah
+          - ipip
+          - icmpv6
+          description: Network protocol
+        icmp:
+          type: object
+          properties:
+            code:
+              type: integer
+              format: int64
+              minimum: -1
+              maximum: 254
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+            type:
+              type: integer
+              format: int64
+              minimum: -1
+              maximum: 254
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+          description: ICMP details
+        end-port:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 65535
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: End port of the range
+        security-group:
+          "$ref": "#/components/schemas/security-group-resource"
+          description: Security Group allowed
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Security Group rule ID
+        network:
+          type: string
+          description: CIDR-formatted network allowed
+        flow-direction:
+          type: string
+          enum:
+          - ingress
+          - egress
+          description: Network flow direction to match
+      description: Security Group rule
+    enum-component-route:
+      type: string
+      enum:
+      - dynamic
+      - private
+      - public
+      - privatelink
+    json-schema-grafana:
+      properties:
+        allow_embedding:
+          example: false
+          title: Allow embedding Grafana dashboards with iframe/frame/object/embed
+            tags. Disabled by default to limit impact of clickjacking
+          type: boolean
+        cookie_samesite:
+          enum:
+          - lax
+          - strict
+          - none
+          example: lax
+          title: 'Cookie SameSite attribute: ''strict'' prevents sending cookie for
+            cross-site requests, effectively disabling direct linking from other sites
+            to Grafana. ''lax'' is the default value.'
+          type: string
+        dashboard_previews_enabled:
+          description: This feature is new in Grafana 9 and is quite resource intensive.
+            It may cause low-end plans to work more slowly while the dashboard previews
+            are rendering.
+          example: false
+          title: Enable browsing of dashboards in grid (pictures) mode
+          type: boolean
+        metrics_enabled:
+          example: true
+          title: Enable Grafana /metrics endpoint
+          type: boolean
+        auth_azuread:
+          additionalProperties: false
+          properties:
+            allow_sign_up:
+              example: false
+              title: Automatically sign-up users on successful sign-in
+              type: boolean
+            allowed_domains:
+              items:
+                example: mycompany.com
+                maxLength: 255
+                title: Allowed domain
+                type: string
+              maxItems: 50
+              title: Allowed domains
+              type: array
+            allowed_groups:
+              items:
+                example: c0ffee15-c01d-0000-1111-012345abcdef
+                maxLength: 36
+                pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                title: Group Object ID from Azure AD
+                type: string
+              maxItems: 50
+              title: Require users to belong to one of given groups
+              type: array
+            auth_url:
+              example: https://login.microsoftonline.com/<AZURE_TENANT_ID>/oauth2/v2.0/authorize
+              maxLength: 2048
+              title: Authorization URL
+              type: string
+            client_id:
+              example: b1ba0bf54a4c2c0a1c29
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client ID from provider
+              type: string
+            client_secret:
+              example: bfa6gea4f129076761dcba8ce5e1e406bd83af7b
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client secret from provider
+              type: string
+            token_url:
+              example: https://login.microsoftonline.com/<AZURE_TENANT_ID>/oauth2/v2.0/token
+              maxLength: 2048
+              title: Token URL
+              type: string
+          required:
+          - client_id
+          - client_secret
+          - auth_url
+          - token_url
+          title: Azure AD OAuth integration
+          type: object
+        alerting_enabled:
+          example: true
+          title: Enable or disable Grafana legacy alerting functionality. This should
+            not be enabled with unified_alerting_enabled.
+          type: boolean
+        unified_alerting_enabled:
+          example: true
+          title: Enable or disable Grafana unified alerting functionality. By default
+            this is enabled and any legacy alerts will be migrated on upgrade to Grafana
+            9+. To stay on legacy alerting, set unified_alerting_enabled to false
+            and alerting_enabled to true. See https://grafana.com/docs/grafana/latest/alerting/set-up/migrating-alerts/
+            for more details.
+          type: boolean
+        auth_github:
+          additionalProperties: false
+          properties:
+            allow_sign_up:
+              example: false
+              title: Automatically sign-up users on successful sign-in
+              type: boolean
+            allowed_organizations:
+              items:
+                example: aiven
+                maxLength: 256
+                pattern: "^[A-Za-z0-9-]+$"
+                title: Organization name
+                type: string
+              maxItems: 50
+              title: Require users to belong to one of given organizations
+              type: array
+            auto_login:
+              example: false
+              title: Allow users to bypass the login screen and automatically log
+                in
+              type: boolean
+            client_id:
+              example: b1ba0bf54a4c2c0a1c29
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client ID from provider
+              type: string
+            client_secret:
+              example: bfa6gea4f129076761dcba8ce5e1e406bd83af7b
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client secret from provider
+              type: string
+            skip_org_role_sync:
+              example: false
+              title: Stop automatically syncing user roles
+              type: boolean
+            team_ids:
+              items:
+                example: 150
+                maximum: 9223372036854775807
+                minimum: 1
+                title: Team ID
+                type: integer
+              maxItems: 50
+              title: Require users to belong to one of given team IDs
+              type: array
+          required:
+          - client_id
+          - client_secret
+          title: Github Auth integration
+          type: object
+        user_auto_assign_org:
+          example: false
+          title: Auto-assign new users on signup to main organization. Defaults to
+            false
+          type: boolean
+        dataproxy_send_user_header:
+          example: false
+          title: Send 'X-Grafana-User' header to data source
+          type: boolean
+        google_analytics_ua_id:
+          example: UA-123456-4
+          maxLength: 64
+          pattern: "^(G|UA|YT|MO)-[a-zA-Z0-9-]+$"
+          title: Google Analytics ID
+          type: string
+        dashboards_versions_to_keep:
+          example: 20
+          maximum: 100
+          minimum: 1
+          title: Dashboard versions to keep per dashboard
+          type: integer
+        editors_can_admin:
+          example: false
+          title: Editors can manage folders, teams and dashboards created by them
+          type: boolean
+        smtp_server:
+          additionalProperties: false
+          properties:
+            from_address:
+              example: yourgrafanauser@yourdomain.example.com
+              maxLength: 319
+              pattern: "^[A-Za-z0-9_\\-\\.+'&]+@(([\\da-zA-Z])([_\\w-]{0,62})\\.){0,127}(([\\da-zA-Z])[_\\w-]{0,61})?([\\da-zA-Z]\\.((xn\\-\\-[a-zA-Z\\d]+)|([a-zA-Z\\d]{2,})))$"
+              title: Address used for sending emails
+              type: string
+            from_name:
+              example: Company Grafana
+              maxLength: 128
+              nullable: true
+              pattern: "^[^\\x00-\\x1F]+$"
+              title: Name used in outgoing emails, defaults to Grafana
+              type: string
+            host:
+              example: smtp.example.com
+              maxLength: 255
+              title: Server hostname or IP
+              type: string
+            password:
+              example: ein0eemeev5eeth3Ahfu
+              maxLength: 255
+              nullable: true
+              pattern: "^[^\\x00-\\x1F]+$"
+              title: Password for SMTP authentication
+              type: string
+            port:
+              example: 25
+              maximum: 65535
+              minimum: 1
+              title: SMTP server port
+              type: integer
+            skip_verify:
+              example: 'false'
+              title: Skip verifying server certificate. Defaults to false
+              type: boolean
+            starttls_policy:
+              enum:
+              - OpportunisticStartTLS
+              - MandatoryStartTLS
+              - NoStartTLS
+              example: NoStartTLS
+              title: Either OpportunisticStartTLS, MandatoryStartTLS or NoStartTLS.
+                Default is OpportunisticStartTLS.
+              type: string
+            username:
+              example: smtpuser
+              maxLength: 255
+              nullable: true
+              pattern: "^[^\\x00-\\x1F]+$"
+              title: Username for SMTP authentication
+              type: string
+          required:
+          - host
+          - port
+          - from_address
+          title: SMTP server settings
+          type: object
+        auth_gitlab:
+          additionalProperties: false
+          properties:
+            allow_sign_up:
+              example: false
+              title: Automatically sign-up users on successful sign-in
+              type: boolean
+            allowed_groups:
+              items:
+                example: aiven/developers
+                maxLength: 256
+                pattern: "^[a-z0-9-_/]+$"
+                title: Group or subgroup name
+                type: string
+              maxItems: 50
+              title: Require users to belong to one of given groups
+              type: array
+            api_url:
+              example: https://gitlab.com/api/v4
+              maxLength: 2048
+              title: API URL. This only needs to be set when using self hosted GitLab
+              type: string
+            auth_url:
+              example: https://gitlab.com/oauth/authorize
+              maxLength: 2048
+              title: Authorization URL. This only needs to be set when using self
+                hosted GitLab
+              type: string
+            client_id:
+              example: b1ba0bf54a4c2c0a1c29
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client ID from provider
+              type: string
+            client_secret:
+              example: bfa6gea4f129076761dcba8ce5e1e406bd83af7b
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client secret from provider
+              type: string
+            token_url:
+              example: https://gitlab.com/oauth/token
+              maxLength: 2048
+              title: Token URL. This only needs to be set when using self hosted GitLab
+              type: string
+          required:
+          - client_id
+          - client_secret
+          - allowed_groups
+          title: GitLab Auth integration
+          type: object
+        alerting_nodata_or_nullvalues:
+          enum:
+          - alerting
+          - no_data
+          - keep_state
+          - ok
+          example: ok
+          title: Default value for 'no data or null values' for new alerting rules
+          type: string
+        auth_basic_enabled:
+          example: true
+          title: Enable or disable basic authentication form, used by Grafana built-in
+            login
+          type: boolean
+        date_formats:
+          additionalProperties: false
+          properties:
+            default_timezone:
+              example: Europe/Helsinki
+              maxLength: 64
+              pattern: "^([a-zA-Z_]+/){1,2}[a-zA-Z_-]+$|^(Etc/)?([Uu][Tt][Cc]|[Gg][Mm][Tt])([+-](\\d){1,2})?$|^([Ff][Aa][Cc][Tt][Oo][Rr][Yy])$|^([Bb][Rr][Oo][Ww][Ss][Ee][Rr])$"
+              title: Default time zone for user preferences. Value 'browser' uses
+                browser local time zone.
+              type: string
+            full_date:
+              example: YYYY MM DD
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string for cases where full date is shown
+              type: string
+            interval_day:
+              example: MM/DD
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring day
+                accuracy is shown
+              type: string
+            interval_hour:
+              example: MM/DD HH:mm
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring hour
+                accuracy is shown
+              type: string
+            interval_minute:
+              example: HH:mm
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring minute
+                accuracy is shown
+              type: string
+            interval_month:
+              example: YYYY-MM
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring month
+                accuracy is shown
+              type: string
+            interval_second:
+              example: HH:mm:ss
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring second
+                accuracy is shown
+              type: string
+            interval_year:
+              example: YYYY
+              maxLength: 128
+              pattern: "^(([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|N{1,5}|YYYYYY|YYYYY|YYYY|YY|y{2,4}|yo?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|LTS|LT|LL?L?L?|l{1,4}|[-+/T,;.:
+                ]?)*)$"
+              title: Moment.js style format string used when a time requiring year
+                accuracy is shown
+              type: string
+          title: Grafana date format specifications
+          type: object
+        service_log:
+          description: Store logs for the service so that they are available in the
+            HTTP API and console.
+          example: true
+          nullable: true
+          title: Service logging
+          type: boolean
+        disable_gravatar:
+          example: false
+          title: Set to true to disable gravatar. Defaults to false (gravatar is enabled)
+          type: boolean
+        user_auto_assign_org_role:
+          enum:
+          - Viewer
+          - Admin
+          - Editor
+          example: Viewer
+          title: Set role for new signups. Defaults to Viewer
+          type: string
+        dataproxy_timeout:
+          example: 30
+          maximum: 90
+          minimum: 15
+          title: Timeout for data proxy requests in seconds
+          type: integer
+        viewers_can_edit:
+          example: false
+          title: Users with view-only permission can edit but not save dashboards
+          type: boolean
+        dashboards_min_refresh_interval:
+          description: Signed sequence of decimal numbers, followed by a unit suffix
+            (ms, s, m, h, d), e.g. 30s, 1h
+          example: 5s
+          maxLength: 16
+          pattern: "^[0-9]+(ms|s|m|h|d)$"
+          title: Minimum refresh interval
+          type: string
+        auth_google:
+          additionalProperties: false
+          properties:
+            allow_sign_up:
+              example: false
+              title: Automatically sign-up users on successful sign-in
+              type: boolean
+            allowed_domains:
+              items:
+                example: example.com
+                maxLength: 255
+                title: Domain
+                type: string
+              maxItems: 64
+              title: Domains allowed to sign-in to this Grafana
+              type: array
+            client_id:
+              example: b1ba0bf54a4c2c0a1c29
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client ID from provider
+              type: string
+            client_secret:
+              example: bfa6gea4f129076761dcba8ce5e1e406bd83af7b
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client secret from provider
+              type: string
+          required:
+          - client_id
+          - client_secret
+          - allowed_domains
+          title: Google Auth integration
+          type: object
+        oauth_allow_insecure_email_lookup:
+          example: false
+          title: Enforce user lookup based on email instead of the unique ID provided
+            by the IdP
+          type: boolean
+        alerting_max_annotations_to_keep:
+          example: 0
+          maximum: 1000000
+          minimum: 0
+          title: Max number of alert annotations that Grafana stores. 0 (default)
+            keeps all alert annotations.
+          type: integer
+        auth_generic_oauth:
+          additionalProperties: false
+          properties:
+            scopes:
+              items:
+                example: email
+                maxLength: 256
+                pattern: "^[\\S]+$"
+                title: OAuth scope
+                type: string
+              maxItems: 50
+              title: OAuth scopes
+              type: array
+            allowed_domains:
+              items:
+                example: mycompany.com
+                maxLength: 255
+                title: Allowed domain
+                type: string
+              maxItems: 50
+              title: Allowed domains
+              type: array
+            allowed_organizations:
+              items:
+                example: myorg
+                maxLength: 256
+                pattern: "^[\\S]+$"
+                title: Allowed organization
+                type: string
+              maxItems: 50
+              title: Require user to be member of one of the listed organizations
+              type: array
+            token_url:
+              example: https://yourprovider.com/oauth/token
+              maxLength: 2048
+              title: Token URL
+              type: string
+            name:
+              example: My authentication
+              maxLength: 128
+              pattern: "^[a-zA-Z0-9_\\- ]+$"
+              title: Name of the OAuth integration
+              type: string
+            auth_url:
+              example: https://yourprovider.com/oauth/authorize
+              maxLength: 2048
+              title: Authorization URL
+              type: string
+            api_url:
+              example: https://yourprovider.com/api
+              maxLength: 2048
+              title: API URL
+              type: string
+            auto_login:
+              example: false
+              title: Allow users to bypass the login screen and automatically log
+                in
+              type: boolean
+            client_id:
+              example: b1ba0bf54a4c2c0a1c29
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client ID from provider
+              type: string
+            client_secret:
+              example: bfa6gea4f129076761dcba8ce5e1e406bd83af7b
+              maxLength: 1024
+              pattern: "^[ -~]+$"
+              title: Client secret from provider
+              type: string
+            allow_sign_up:
+              example: false
+              title: Automatically sign-up users on successful sign-in
+              type: boolean
+          required:
+          - api_url
+          - auth_url
+          - client_id
+          - client_secret
+          - token_url
+          title: Generic OAuth integration
+          type: object
+        alerting_error_or_timeout:
+          enum:
+          - alerting
+          - keep_state
+          example: alerting
+          title: Default error or timeout setting for new alerting rules
+          type: string
+      title: Grafana settings
+      type: object
+    dbaas-service-type:
+      type: object
+      properties:
+        name:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          readOnly: true
+          description: DbaaS service name
+        available-versions:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          description: DbaaS service available versions
+        default-version:
+          type: string
+          readOnly: true
+          description: DbaaS service default version
+        description:
+          type: string
+          readOnly: true
+          description: DbaaS service description
+        plans:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-plan"
+          readOnly: true
+          description: DbaaS service plans
+      description: DBaaS service
+    json-schema-kafka-connect:
+      additionalProperties: false
+      properties:
+        producer_buffer_memory:
+          description: The total bytes of memory the producer can use to buffer records
+            waiting to be sent to the broker (defaults to 33554432).
+          example: 8388608
+          maximum: 134217728
+          minimum: 5242880
+          title: The total bytes of memory the producer can use to buffer records
+            waiting to be sent to the broker
+          type: integer
+        consumer_max_poll_interval_ms:
+          description: The maximum delay in milliseconds between invocations of poll()
+            when using consumer group management (defaults to 300000).
+          example: 300000
+          maximum: 2147483647
+          minimum: 1
+          title: The maximum delay between polls when using consumer group management
+          type: integer
+        producer_compression_type:
+          description: Specify the default compression type for producers. This configuration
+            accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd').
+            It additionally accepts 'none' which is the default and equivalent to
+            no compression.
+          enum:
+          - gzip
+          - snappy
+          - lz4
+          - zstd
+          - none
+          title: The default compression type for producers
+          type: string
+        connector_client_config_override_policy:
+          description: Defines what client configurations can be overridden by the
+            connector. Default is None
+          enum:
+          - None
+          - All
+          title: Client config override policy
+          type: string
+        offset_flush_interval_ms:
+          description: The interval at which to try committing offsets for tasks (defaults
+            to 60000).
+          example: 60000
+          maximum: 100000000
+          minimum: 1
+          title: The interval at which to try committing offsets for tasks
+          type: integer
+        scheduled_rebalance_max_delay_ms:
+          description: The maximum delay that is scheduled in order to wait for the
+            return of one or more departed workers before rebalancing and reassigning
+            their connectors and tasks to the group. During this period the connectors
+            and tasks of the departed workers remain unassigned. Defaults to 5 minutes.
+          example: 300000
+          maximum: 600000
+          minimum: 0
+          title: The maximum delay of rebalancing connector workers
+          type: integer
+        consumer_fetch_max_bytes:
+          description: Records are fetched in batches by the consumer, and if the
+            first record batch in the first non-empty partition of the fetch is larger
+            than this value, the record batch will still be returned to ensure that
+            the consumer can make progress. As such, this is not a absolute maximum.
+          example: 52428800
+          maximum: 104857600
+          minimum: 1048576
+          title: The maximum amount of data the server should return for a fetch request
+          type: integer
+        consumer_max_partition_fetch_bytes:
+          description: 'Records are fetched in batches by the consumer.If the first
+            record batch in the first non-empty partition of the fetch is larger than
+            this limit, the batch will still be returned to ensure that the consumer
+            can make progress. '
+          example: 1048576
+          maximum: 104857600
+          minimum: 1048576
+          title: The maximum amount of data per-partition the server will return.
+          type: integer
+        offset_flush_timeout_ms:
+          description: Maximum number of milliseconds to wait for records to flush
+            and partition offset data to be committed to offset storage before cancelling
+            the process and restoring the offset data to be committed in a future
+            attempt (defaults to 5000).
+          example: 5000
+          maximum: 2147483647
+          minimum: 1
+          title: Offset flush timeout
+          type: integer
+        consumer_auto_offset_reset:
+          description: What to do when there is no initial offset in Kafka or if the
+            current offset does not exist any more on the server. Default is earliest
+          enum:
+          - earliest
+          - latest
+          title: Consumer auto offset reset
+          type: string
+        producer_max_request_size:
+          description: This setting will limit the number of record batches the producer
+            will send in a single request to avoid sending huge requests.
+          example: 1048576
+          maximum: 67108864
+          minimum: 131072
+          title: The maximum size of a request in bytes
+          type: integer
+        producer_batch_size:
+          description: This setting gives the upper bound of the batch size to be
+            sent. If there are fewer than this many bytes accumulated for this partition,
+            the producer will 'linger' for the linger.ms time waiting for more records
+            to show up. A batch size of zero will disable batching entirely (defaults
+            to 16384).
+          example: 1024
+          maximum: 5242880
+          minimum: 0
+          title: The batch size in bytes the producer will attempt to collect for
+            the same partition before publishing to broker
+          type: integer
+        session_timeout_ms:
+          description: The timeout in milliseconds used to detect failures when using
+            Kafka’s group management facilities (defaults to 10000).
+          example: 10000
+          maximum: 2147483647
+          minimum: 1
+          title: The timeout used to detect failures when using Kafka’s group management
+            facilities
+          type: integer
+        producer_linger_ms:
+          description: 'This setting gives the upper bound on the delay for batching:
+            once there is batch.size worth of records for a partition it will be sent
+            immediately regardless of this setting, however if there are fewer than
+            this many bytes accumulated for this partition the producer will ''linger''
+            for the specified time waiting for more records to show up. Defaults to
+            0.'
+          example: 100
+          maximum: 5000
+          minimum: 0
+          title: Wait for up to the given delay to allow batching records together
+          type: integer
+        consumer_isolation_level:
+          description: Transaction read isolation level. read_uncommitted is the default,
+            but read_committed can be used if consume-exactly-once behavior is desired.
+          enum:
+          - read_uncommitted
+          - read_committed
+          title: Consumer isolation level
+          type: string
+        consumer_max_poll_records:
+          description: The maximum number of records returned in a single call to
+            poll() (defaults to 500).
+          example: 500
+          maximum: 10000
+          minimum: 1
+          title: The maximum number of records returned by a single poll
+          type: integer
+      title: Kafka Connect configuration values
+      type: object
+    private-network:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 255
+          description: Private Network description
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Resource labels
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Private Network name
+        start-ip:
+          type: string
+          format: ipv4
+          description: Private Network start IP address
+        leases:
+          type: array
+          items:
+            "$ref": "#/components/schemas/private-network-lease"
+          readOnly: true
+          description: Private Network leased IP addresses
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Private Network ID
+        vni:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Private Network VXLAN ID
+        netmask:
+          type: string
+          format: ipv4
+          description: Private Network netmask
+        end-ip:
+          type: string
+          format: ipv4
+          description: Private Network end IP address
+      description: Private Network
+    enum-component-usage:
+      type: string
+      enum:
+      - primary
+      - replica
+    dbaas-service-logs:
+      type: object
+      properties:
+        offset:
+          type: string
+        first-log-offset:
+          type: string
+        logs:
+          type: array
+          items:
+            type: object
+            properties:
+              unit:
+                type: string
+              time:
+                type: string
+              message:
+                type: string
+              node:
+                type: string
+    instance-password:
+      type: object
+      properties:
+        password:
+          type: string
+          readOnly: true
+          description: Password
+      description: Instance password
+    load-balancer:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Load Balancer ID
+        description:
+          type: string
+          maxLength: 255
+          description: Load Balancer description
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Load Balancer name
+        state:
+          type: string
+          enum:
+          - creating
+          - migrated
+          - deleting
+          - running
+          - migrating
+          - error
+          readOnly: true
+          description: Load Balancer state
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Load Balancer creation date
+        ip:
+          type: string
+          format: ipv4
+          readOnly: true
+          description: Load Balancer public IP
+        services:
+          type: array
+          items:
+            "$ref": "#/components/schemas/load-balancer-service"
+          description: Load Balancer Services
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Load Balancer Labels
+      description: Load Balancer
+    sks-cluster-deprecated-resource:
+      type: object
+      additionalProperties:
+        type: string
+    elastic-ip:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Elastic IP ID
+        ip:
+          type: string
+          readOnly: true
+          description: Elastic IP address
+        addressfamily:
+          type: string
+          enum:
+          - inet4
+          - inet6
+          readOnly: true
+          description: Elastic IP address family
+        cidr:
+          type: string
+          readOnly: true
+          description: Elastic IP cidr
+        description:
+          type: string
+          maxLength: 255
+          description: Elastic IP description
+        healthcheck:
+          "$ref": "#/components/schemas/elastic-ip-healthcheck"
+          description: Elastic IP healthcheck
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Resource labels
+      description: Elastic IP
+    domain-name:
+      type: string
+      maxLength: 253
+      minLength: 1
+    dbaas-user-opensearch-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Opensearch username
+        password:
+          type: string
+          description: Opensearch password
+      description: Opensearch User secrets
+    access-key-resource:
+      type: object
+      properties:
+        domain:
+          type: string
+          enum:
+          - partner
+          - sos
+          description: Resource domain
+        resource-type:
+          type: string
+          enum:
+          - product
+          - bucket
+          description: Resource type
+        resource-name:
+          type: string
+          description: Resource name
+      description: Access key resource
+    json-schema-kafka:
+      additionalProperties: false
+      properties:
+        sasl_oauthbearer_expected_audience:
+          description: The (optional) comma-delimited setting for the broker to use
+            to verify that the JWT was issued for one of the expected audiences.
+          maxLength: 128
+          pattern: "^[^\\r\\n]*$"
+          title: sasl.oauthbearer.expected.audience
+          type: string
+        group_max_session_timeout_ms:
+          description: The maximum allowed session timeout for registered consumers.
+            Longer timeouts give consumers more time to process messages in between
+            heartbeats at the cost of a longer time to detect failures.
+          example: 1800000
+          maximum: 1800000
+          minimum: 0
+          title: group.max.session.timeout.ms
+          type: integer
+        log_flush_interval_messages:
+          description: The number of messages accumulated on a log partition before
+            messages are flushed to disk
+          example: 9223372036854775807
+          maximum: 9223372036854775807
+          minimum: 1
+          title: log.flush.interval.messages
+          type: integer
+        sasl_oauthbearer_jwks_endpoint_url:
+          description: 'OIDC JWKS endpoint URL. By setting this the SASL SSL OAuth2/OIDC
+            authentication is enabled. See also other options for SASL OAuth2/OIDC. '
+          maxLength: 2048
+          title: sasl.oauthbearer.jwks.endpoint.url
+          type: string
+        max_connections_per_ip:
+          description: The maximum number of connections allowed from each ip address
+            (defaults to 2147483647).
+          maximum: 2147483647
+          minimum: 256
+          title: max.connections.per.ip
+          type: integer
+        sasl_oauthbearer_expected_issuer:
+          description: Optional setting for the broker to use to verify that the JWT
+            was created by the expected issuer.
+          maxLength: 128
+          pattern: "^[^\\r\\n]*$"
+          title: sasl.oauthbearer.expected.issuer
+          type: string
+        log_index_size_max_bytes:
+          description: The maximum size in bytes of the offset index
+          example: 10485760
+          maximum: 104857600
+          minimum: 1048576
+          title: log.index.size.max.bytes
+          type: integer
+        auto_create_topics_enable:
+          description: Enable auto creation of topics
+          example: true
+          title: auto.create.topics.enable
+          type: boolean
+        log_index_interval_bytes:
+          description: The interval with which Kafka adds an entry to the offset index
+          example: 4096
+          maximum: 104857600
+          minimum: 0
+          title: log.index.interval.bytes
+          type: integer
+        replica_fetch_max_bytes:
+          description: The number of bytes of messages to attempt to fetch for each
+            partition (defaults to 1048576). This is not an absolute maximum, if the
+            first record batch in the first non-empty partition of the fetch is larger
+            than this value, the record batch will still be returned to ensure that
+            progress can be made.
+          maximum: 104857600
+          minimum: 1048576
+          title: replica.fetch.max.bytes
+          type: integer
+        num_partitions:
+          description: Number of partitions for autocreated topics
+          maximum: 1000
+          minimum: 1
+          title: num.partitions
+          type: integer
+        transaction_state_log_segment_bytes:
+          description: The transaction topic segment bytes should be kept relatively
+            small in order to facilitate faster log compaction and cache loads (defaults
+            to 104857600 (100 mebibytes)).
+          example: 104857600
+          maximum: 2147483647
+          minimum: 1048576
+          title: transaction.state.log.segment.bytes
+          type: integer
+        replica_fetch_response_max_bytes:
+          description: Maximum bytes expected for the entire fetch response (defaults
+            to 10485760). Records are fetched in batches, and if the first record
+            batch in the first non-empty partition of the fetch is larger than this
+            value, the record batch will still be returned to ensure that progress
+            can be made. As such, this is not an absolute maximum.
+          maximum: 1048576000
+          minimum: 10485760
+          title: replica.fetch.response.max.bytes
+          type: integer
+        log_message_timestamp_type:
+          description: Define whether the timestamp in the message is message create
+            time or log append time.
+          enum:
+          - CreateTime
+          - LogAppendTime
+          title: log.message.timestamp.type
+          type: string
+        connections_max_idle_ms:
+          description: 'Idle connections timeout: the server socket processor threads
+            close the connections that idle for longer than this.'
+          example: 540000
+          maximum: 3600000
+          minimum: 1000
+          title: connections.max.idle.ms
+          type: integer
+        log_flush_interval_ms:
+          description: The maximum time in ms that a message in any topic is kept
+            in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms
+            is used
+          maximum: 9223372036854775807
+          minimum: 0
+          title: log.flush.interval.ms
+          type: integer
+        log_preallocate:
+          description: Should pre allocate file when create new segment?
+          example: false
+          title: log.preallocate
+          type: boolean
+        log_segment_delete_delay_ms:
+          description: The amount of time to wait before deleting a file from the
+            filesystem
+          example: 60000
+          maximum: 3600000
+          minimum: 0
+          title: log.segment.delete.delay.ms
+          type: integer
+        message_max_bytes:
+          description: The maximum size of message that the server can receive.
+          example: 1048588
+          maximum: 100001200
+          minimum: 0
+          title: message.max.bytes
+          type: integer
+        group_initial_rebalance_delay_ms:
+          description: The amount of time, in milliseconds, the group coordinator
+            will wait for more consumers to join a new group before performing the
+            first rebalance. A longer delay means potentially fewer rebalances, but
+            increases the time until processing begins. The default value for this
+            is 3 seconds. During development and testing it might be desirable to
+            set this to 0 in order to not delay test execution time.
+          example: 3000
+          maximum: 300000
+          minimum: 0
+          title: group.initial.rebalance.delay.ms
+          type: integer
+        log_local_retention_bytes:
+          description: The maximum size of local log segments that can grow for a
+            partition before it gets eligible for deletion. If set to -2, the value
+            of log.retention.bytes is used. The effective value should always be less
+            than or equal to log.retention.bytes value.
+          maximum: 9223372036854775807
+          minimum: -2
+          title: log.local.retention.bytes
+          type: integer
+        log_roll_jitter_ms:
+          description: The maximum jitter to subtract from logRollTimeMillis (in milliseconds).
+            If not set, the value in log.roll.jitter.hours is used
+          maximum: 9223372036854775807
+          minimum: 0
+          title: log.roll.jitter.ms
+          type: integer
+        transaction_remove_expired_transaction_cleanup_interval_ms:
+          description: The interval at which to remove transactions that have expired
+            due to transactional.id.expiration.ms passing (defaults to 3600000 (1
+            hour)).
+          example: 3600000
+          maximum: 3600000
+          minimum: 600000
+          title: transaction.remove.expired.transaction.cleanup.interval.ms
+          type: integer
+        transaction_partition_verification_enable:
+          description: Enable verification that checks that the partition has been
+            added to the transaction before writing transactional records to the partition
+          example: true
+          title: transaction.partition.verification.enable
+          type: boolean
+        default_replication_factor:
+          description: Replication factor for autocreated topics
+          maximum: 10
+          minimum: 1
+          title: default.replication.factor
+          type: integer
+        log_roll_ms:
+          description: The maximum time before a new log segment is rolled out (in
+            milliseconds).
+          maximum: 9223372036854775807
+          minimum: 1
+          title: log.roll.ms
+          type: integer
+        producer_purgatory_purge_interval_requests:
+          description: The purge interval (in number of requests) of the producer
+            request purgatory(defaults to 1000).
+          maximum: 10000
+          minimum: 10
+          title: producer.purgatory.purge.interval.requests
+          type: integer
+        log_retention_bytes:
+          description: The maximum size of the log before deleting messages
+          maximum: 9223372036854775807
+          minimum: -1
+          title: log.retention.bytes
+          type: integer
+        min_insync_replicas:
+          description: When a producer sets acks to 'all' (or '-1'), min.insync.replicas
+            specifies the minimum number of replicas that must acknowledge a write
+            for the write to be considered successful.
+          example: 1
+          maximum: 7
+          minimum: 1
+          title: min.insync.replicas
+          type: integer
+        compression_type:
+          description: Specify the final compression type for a given topic. This
+            configuration accepts the standard compression codecs ('gzip', 'snappy',
+            'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent
+            to no compression; and 'producer' which means retain the original compression
+            codec set by the producer.
+          enum:
+          - gzip
+          - snappy
+          - lz4
+          - zstd
+          - uncompressed
+          - producer
+          title: compression.type
+          type: string
+        log_message_timestamp_difference_max_ms:
+          description: The maximum difference allowed between the timestamp when a
+            broker receives a message and the timestamp specified in the message
+          maximum: 9223372036854775807
+          minimum: 0
+          title: log.message.timestamp.difference.max.ms
+          type: integer
+        log_local_retention_ms:
+          description: The number of milliseconds to keep the local log segments before
+            it gets eligible for deletion. If set to -2, the value of log.retention.ms
+            is used. The effective value should always be less than or equal to log.retention.ms
+            value.
+          maximum: 9223372036854775807
+          minimum: -2
+          title: log.local.retention.ms
+          type: integer
+        log_message_downconversion_enable:
+          description: 'This configuration controls whether down-conversion of message
+            formats is enabled to satisfy consume requests. '
+          example: true
+          title: log.message.downconversion.enable
+          type: boolean
+        sasl_oauthbearer_sub_claim_name:
+          description: Name of the scope from which to extract the subject claim from
+            the JWT. Defaults to sub.
+          maxLength: 128
+          pattern: "^[^\\r\\n]*$"
+          title: sasl.oauthbearer.sub.claim.name
+          type: string
+        max_incremental_fetch_session_cache_slots:
+          description: The maximum number of incremental fetch sessions that the broker
+            will maintain.
+          example: 1000
+          maximum: 10000
+          minimum: 1000
+          title: max.incremental.fetch.session.cache.slots
+          type: integer
+        log_retention_hours:
+          description: The number of hours to keep a log file before deleting it
+          maximum: 2147483647
+          minimum: -1
+          title: log.retention.hours
+          type: integer
+        group_min_session_timeout_ms:
+          description: The minimum allowed session timeout for registered consumers.
+            Longer timeouts give consumers more time to process messages in between
+            heartbeats at the cost of a longer time to detect failures.
+          example: 6000
+          maximum: 60000
+          minimum: 0
+          title: group.min.session.timeout.ms
+          type: integer
+        socket_request_max_bytes:
+          description: The maximum number of bytes in a socket request (defaults to
+            104857600).
+          maximum: 209715200
+          minimum: 10485760
+          title: socket.request.max.bytes
+          type: integer
+        log_segment_bytes:
+          description: The maximum size of a single log file
+          maximum: 1073741824
+          minimum: 10485760
+          title: log.segment.bytes
+          type: integer
+        log-cleanup-and-compaction:
+          properties:
+            log_cleaner_delete_retention_ms:
+              description: How long are delete records retained?
+              example: 86400000
+              maximum: 315569260000
+              minimum: 0
+              title: log.cleaner.delete.retention.ms
+              type: integer
+            log_cleaner_max_compaction_lag_ms:
+              description: The maximum amount of time message will remain uncompacted.
+                Only applicable for logs that are being compacted
+              maximum: 9223372036854775807
+              minimum: 30000
+              title: log.cleaner.max.compaction.lag.ms
+              type: integer
+            log_cleaner_min_cleanable_ratio:
+              description: Controls log compactor frequency. Larger value means more
+                frequent compactions but also more space wasted for logs. Consider
+                setting log.cleaner.max.compaction.lag.ms to enforce compactions sooner,
+                instead of setting a very high value for this option.
+              example: 0.5
+              maximum: 0.9
+              minimum: 0.2
+              title: log.cleaner.min.cleanable.ratio
+              type: number
+            log_cleaner_min_compaction_lag_ms:
+              description: The minimum time a message will remain uncompacted in the
+                log. Only applicable for logs that are being compacted.
+              maximum: 9223372036854775807
+              minimum: 0
+              title: log.cleaner.min.compaction.lag.ms
+              type: integer
+            log_cleanup_policy:
+              description: The default cleanup policy for segments beyond the retention
+                window
+              enum:
+              - delete
+              - compact
+              - compact,delete
+              example: delete
+              title: log.cleanup.policy
+              type: string
+          title: Configure log cleaner for topic compaction
+          type: object
+        offsets_retention_minutes:
+          description: Log retention window in minutes for offsets topic
+          example: 10080
+          maximum: 2147483647
+          minimum: 1
+          title: offsets.retention.minutes
+          type: integer
+        log_retention_ms:
+          description: The number of milliseconds to keep a log file before deleting
+            it (in milliseconds), If not set, the value in log.retention.minutes is
+            used. If set to -1, no time limit is applied.
+          maximum: 9223372036854775807
+          minimum: -1
+          title: log.retention.ms
+          type: integer
+      title: Kafka broker configuration values
+      type: object
+    instance-target:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Instance ID
+      description: Target Instance
+    json-schema-pg:
+      additionalProperties: false
+      properties:
+        track_activity_query_size:
+          description: Specifies the number of bytes reserved to track the currently
+            executing command for each active session.
+          example: 1024
+          maximum: 10240
+          minimum: 1024
+          title: track_activity_query_size
+          type: integer
+        timezone:
+          description: PostgreSQL service timezone
+          example: Europe/Helsinki
+          maxLength: 64
+          pattern: "^[\\w/]*$"
+          title: timezone
+          type: string
+        track_io_timing:
+          description: Enables timing of database I/O calls. This parameter is off
+            by default, because it will repeatedly query the operating system for
+            the current time, which may cause significant overhead on some platforms.
+          enum:
+          - 'off'
+          - 'on'
+          example: 'off'
+          title: track_io_timing
+          type: string
+        pg_stat_monitor.pgsm_enable_query_plan:
+          description: Enables or disables query plan monitoring
+          example: false
+          title: pg_stat_monitor.pgsm_enable_query_plan
+          type: boolean
+        max_files_per_process:
+          description: PostgreSQL maximum number of files that can be open per process
+          maximum: 4096
+          minimum: 1000
+          title: max_files_per_process
+          type: integer
+        pg_stat_monitor.pgsm_max_buckets:
+          description: 'Sets the maximum number of buckets '
+          example: 10
+          maximum: 10
+          minimum: 1
+          title: pg_stat_monitor.pgsm_max_buckets
+          type: integer
+        wal:
+          properties:
+            max_slot_wal_keep_size:
+              description: PostgreSQL maximum WAL size (MB) reserved for replication
+                slots. Default is -1 (unlimited). wal_keep_size minimum WAL size setting
+                takes precedence over this.
+              maximum: 2147483647
+              minimum: -1
+              title: max_slot_wal_keep_size
+              type: integer
+            max_wal_senders:
+              description: PostgreSQL maximum WAL senders
+              maximum: 64
+              minimum: 20
+              title: max_wal_senders
+              type: integer
+            wal_sender_timeout:
+              description: Terminate replication connections that are inactive for
+                longer than this amount of time, in milliseconds.
+              maximum: 10800000
+              minimum: 0
+              title: A value of 0 disables the timeout. Otherwise between 5000 and
+                10800000 millis
+              type: integer
+            wal_writer_delay:
+              description: WAL flush interval in milliseconds. Note that setting this
+                value to lower than the default 200ms may negatively impact performance
+              example: 50
+              maximum: 200
+              minimum: 10
+              title: wal_writer_delay
+              type: integer
+          title: Write-ahead log (WAL) settings
+          type: object
+        default_toast_compression:
+          description: Specifies the default TOAST compression method for values of
+            compressible columns (the default is lz4).
+          enum:
+          - lz4
+          - pglz
+          example: lz4
+          title: default_toast_compression
+          type: string
+        deadlock_timeout:
+          description: This is the amount of time, in milliseconds, to wait on a lock
+            before checking to see if there is a deadlock condition.
+          example: 1000
+          maximum: 1800000
+          minimum: 500
+          title: deadlock_timeout
+          type: integer
+        idle_in_transaction_session_timeout:
+          description: Time out sessions with open transactions after this number
+            of milliseconds
+          maximum: 604800000
+          minimum: 0
+          title: idle_in_transaction_session_timeout
+          type: integer
+        max_pred_locks_per_transaction:
+          description: PostgreSQL maximum predicate locks per transaction
+          maximum: 5120
+          minimum: 64
+          title: max_pred_locks_per_transaction
+          type: integer
+        max_replication_slots:
+          description: PostgreSQL maximum replication slots
+          maximum: 64
+          minimum: 8
+          title: max_replication_slots
+          type: integer
+        autovacuum:
+          properties:
+            log_autovacuum_min_duration:
+              description: Causes each action executed by autovacuum to be logged
+                if it ran for at least the specified number of milliseconds. Setting
+                this to zero logs all autovacuum actions. Minus-one (the default)
+                disables logging autovacuum actions.
+              maximum: 2147483647
+              minimum: -1
+              title: log_autovacuum_min_duration
+              type: integer
+            autovacuum_vacuum_cost_limit:
+              description: Specifies the cost limit value that will be used in automatic
+                VACUUM operations. If -1 is specified (which is the default), the
+                regular vacuum_cost_limit value will be used.
+              maximum: 10000
+              minimum: -1
+              title: autovacuum_vacuum_cost_limit
+              type: integer
+            autovacuum_max_workers:
+              description: Specifies the maximum number of autovacuum processes (other
+                than the autovacuum launcher) that may be running at any one time.
+                The default is three. This parameter can only be set at server start.
+              maximum: 20
+              minimum: 1
+              title: autovacuum_max_workers
+              type: integer
+            autovacuum_vacuum_threshold:
+              description: Specifies the minimum number of updated or deleted tuples
+                needed to trigger a VACUUM in any one table. The default is 50 tuples
+              maximum: 2147483647
+              minimum: 0
+              title: autovacuum_vacuum_threshold
+              type: integer
+            autovacuum_naptime:
+              description: Specifies the minimum delay between autovacuum runs on
+                any given database. The delay is measured in seconds, and the default
+                is one minute
+              maximum: 86400
+              minimum: 1
+              title: autovacuum_naptime
+              type: integer
+            autovacuum_vacuum_scale_factor:
+              description: Specifies a fraction of the table size to add to autovacuum_vacuum_threshold
+                when deciding whether to trigger a VACUUM. The default is 0.2 (20%
+                of table size)
+              maximum: 1.0
+              minimum: 0.0
+              title: autovacuum_vacuum_scale_factor
+              type: number
+            autovacuum_vacuum_cost_delay:
+              description: Specifies the cost delay value that will be used in automatic
+                VACUUM operations. If -1 is specified, the regular vacuum_cost_delay
+                value will be used. The default value is 20 milliseconds
+              maximum: 100
+              minimum: -1
+              title: autovacuum_vacuum_cost_delay
+              type: integer
+            autovacuum_analyze_scale_factor:
+              description: Specifies a fraction of the table size to add to autovacuum_analyze_threshold
+                when deciding whether to trigger an ANALYZE. The default is 0.2 (20%
+                of table size)
+              maximum: 1.0
+              minimum: 0.0
+              title: autovacuum_analyze_scale_factor
+              type: number
+            autovacuum_analyze_threshold:
+              description: Specifies the minimum number of inserted, updated or deleted
+                tuples needed to trigger an ANALYZE in any one table. The default
+                is 50 tuples.
+              maximum: 2147483647
+              minimum: 0
+              title: autovacuum_analyze_threshold
+              type: integer
+            autovacuum_freeze_max_age:
+              description: Specifies the maximum age (in transactions) that a table's
+                pg_class.relfrozenxid field can attain before a VACUUM operation is
+                forced to prevent transaction ID wraparound within the table. Note
+                that the system will launch autovacuum processes to prevent wraparound
+                even when autovacuum is otherwise disabled. This parameter will cause
+                the server to be restarted.
+              example: 200000000
+              maximum: 1500000000
+              minimum: 200000000
+              title: autovacuum_freeze_max_age
+              type: integer
+          title: Autovacuum settings
+          type: object
+        max_parallel_workers_per_gather:
+          description: Sets the maximum number of workers that can be started by a
+            single Gather or Gather Merge node
+          maximum: 96
+          minimum: 0
+          title: max_parallel_workers_per_gather
+          type: integer
+        pg_partman_bgw.interval:
+          description: Sets the time interval to run pg_partman's scheduled tasks
+          example: 3600
+          maximum: 604800
+          minimum: 3600
+          title: pg_partman_bgw.interval
+          type: integer
+        log_line_prefix:
+          description: Choose from one of the available log-formats. These can support
+            popular log analyzers like pgbadger, pganalyze etc.
+          enum:
+          - "'pid=%p,user=%u,db=%d,app=%a,client=%h '"
+          - "'%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '"
+          - "'%m [%p] %q[user=%u,db=%d,app=%a] '"
+          title: log_line_prefix
+          type: string
+        log_temp_files:
+          description: Log statements for each temporary file created larger than
+            this number of kilobytes, -1 disables
+          maximum: 2147483647
+          minimum: -1
+          title: log_temp_files
+          type: integer
+        max_locks_per_transaction:
+          description: PostgreSQL maximum locks per transaction
+          maximum: 6400
+          minimum: 64
+          title: max_locks_per_transaction
+          type: integer
+        track_commit_timestamp:
+          description: Record commit time of transactions.
+          enum:
+          - 'off'
+          - 'on'
+          example: 'off'
+          title: track_commit_timestamp
+          type: string
+        track_functions:
+          description: Enables tracking of function call counts and time used.
+          enum:
+          - all
+          - pl
+          - none
+          title: track_functions
+          type: string
+        max_stack_depth:
+          description: Maximum depth of the stack in bytes
+          maximum: 6291456
+          minimum: 2097152
+          title: max_stack_depth
+          type: integer
+        max_parallel_workers:
+          description: Sets the maximum number of workers that the system can support
+            for parallel queries
+          maximum: 96
+          minimum: 0
+          title: max_parallel_workers
+          type: integer
+        pg_partman_bgw.role:
+          description: Controls which role to use for pg_partman's scheduled background
+            tasks.
+          example: myrolename
+          maxLength: 64
+          pattern: "^[_A-Za-z0-9][-._A-Za-z0-9]{0,63}$"
+          title: pg_partman_bgw.role
+          type: string
+        max_logical_replication_workers:
+          description: PostgreSQL maximum logical replication workers (taken from
+            the pool of max_parallel_workers)
+          maximum: 64
+          minimum: 4
+          title: max_logical_replication_workers
+          type: integer
+        max_prepared_transactions:
+          description: PostgreSQL maximum prepared transactions
+          maximum: 10000
+          minimum: 0
+          title: max_prepared_transactions
+          type: integer
+        max_worker_processes:
+          description: Sets the maximum number of background processes that the system
+            can support
+          maximum: 96
+          minimum: 8
+          title: max_worker_processes
+          type: integer
+        pg_stat_statements.track:
+          description: Controls which statements are counted. Specify top to track
+            top-level statements (those issued directly by clients), all to also track
+            nested statements (such as statements invoked within functions), or none
+            to disable statement statistics collection. The default value is top.
+          enum:
+          - all
+          - top
+          - none
+          title: pg_stat_statements.track
+          type: string
+        temp_file_limit:
+          description: PostgreSQL temporary file limit in KiB, -1 for unlimited
+          example: 5000000
+          maximum: 2147483647
+          minimum: -1
+          title: temp_file_limit
+          type: integer
+        log_error_verbosity:
+          description: Controls the amount of detail written in the server log for
+            each message that is logged.
+          enum:
+          - TERSE
+          - DEFAULT
+          - VERBOSE
+          title: log_error_verbosity
+          type: string
+        log_min_duration_statement:
+          description: Log statements that take more than this number of milliseconds
+            to run, -1 disables
+          maximum: 86400000
+          minimum: -1
+          title: log_min_duration_statement
+          type: integer
+        max_standby_streaming_delay:
+          description: Max standby streaming delay in milliseconds
+          maximum: 43200000
+          minimum: 1
+          title: max_standby_streaming_delay
+          type: integer
+        jit:
+          description: Controls system-wide use of Just-in-Time Compilation (JIT).
+          example: true
+          title: jit
+          type: boolean
+        max_standby_archive_delay:
+          description: Max standby archive delay in milliseconds
+          maximum: 43200000
+          minimum: 1
+          title: max_standby_archive_delay
+          type: integer
+        bg-writer:
+          properties:
+            bgwriter_delay:
+              description: Specifies the delay between activity rounds for the background
+                writer in milliseconds. Default is 200.
+              example: 200
+              maximum: 10000
+              minimum: 10
+              title: bgwriter_delay
+              type: integer
+            bgwriter_flush_after:
+              description: Whenever more than bgwriter_flush_after bytes have been
+                written by the background writer, attempt to force the OS to issue
+                these writes to the underlying storage. Specified in kilobytes, default
+                is 512. Setting of 0 disables forced writeback.
+              example: 512
+              maximum: 2048
+              minimum: 0
+              title: bgwriter_flush_after
+              type: integer
+            bgwriter_lru_maxpages:
+              description: In each round, no more than this many buffers will be written
+                by the background writer. Setting this to zero disables background
+                writing. Default is 100.
+              example: 100
+              maximum: 1073741823
+              minimum: 0
+              title: bgwriter_lru_maxpages
+              type: integer
+            bgwriter_lru_multiplier:
+              description: The average recent need for new buffers is multiplied by
+                bgwriter_lru_multiplier to arrive at an estimate of the number that
+                will be needed during the next round, (up to bgwriter_lru_maxpages).
+                1.0 represents a “just in time” policy of writing exactly the number
+                of buffers predicted to be needed. Larger values provide some cushion
+                against spikes in demand, while smaller values intentionally leave
+                writes to be done by server processes. The default is 2.0.
+              example: 2.0
+              maximum: 10
+              minimum: 0
+              title: bgwriter_lru_multiplier
+              type: number
+          title: Background (BG) writer settings
+          type: object
+      title: postgresql.conf configuration values
+      type: object
+    dns-domain:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: DNS domain ID
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: DNS domain creation date
+        unicode-name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: DNS domain unicode name
+      description: DNS domain
+    sks-kubeconfig-request:
+      type: object
+      properties:
+        ttl:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: 'Validity in seconds of the Kubeconfig user certificate (default:
+            30 days)'
+        user:
+          type: string
+          description: User name in the generated Kubeconfig. The certificate present
+            in the Kubeconfig will also have this name set for the CN field.
+        groups:
+          type: array
+          items:
+            type: string
+          description: List of roles. The certificate present in the Kubeconfig will
+            have these roles set in the Org field.
+      description: Kubeconfig request for a SKS cluster
+    dbaas-service-notification:
+      type: object
+      properties:
+        level:
+          type: string
+          enum:
+          - warning
+          - notice
+          description: Notification level
+        message:
+          type: string
+          maxLength: 1024
+          minLength: 1
+          description: Human notification message
+        type:
+          type: string
+          enum:
+          - service_powered_off_removal
+          - service_end_of_life
+          description: Notification type
+        metadata:
+          type: object
+          description: Notification type
+      required:
+      - level
+      - message
+      - type
+      - metadata
+      description: Service notifications
+    json-schema-mysql:
+      additionalProperties: false
+      properties:
+        net_write_timeout:
+          description: The number of seconds to wait for a block to be written to
+            a connection before aborting the write.
+          example: 30
+          maximum: 3600
+          minimum: 1
+          title: net_write_timeout
+          type: integer
+        internal_tmp_mem_storage_engine:
+          description: The storage engine for in-memory internal temporary tables.
+          enum:
+          - TempTable
+          - MEMORY
+          example: TempTable
+          title: internal_tmp_mem_storage_engine
+          type: string
+        sql_mode:
+          description: Global SQL mode. Set to empty to use MySQL server defaults.
+            When creating a new service and not setting this field Aiven default SQL
+            mode (strict, SQL standard compliant) will be assigned.
+          example: ANSI,TRADITIONAL
+          maxLength: 1024
+          pattern: "^[A-Z_]*(,[A-Z_]+)*$"
+          title: sql_mode
+          type: string
+        information_schema_stats_expiry:
+          description: The time, in seconds, before cached statistics expire
+          example: 86400
+          maximum: 31536000
+          minimum: 900
+          title: information_schema_stats_expiry
+          type: integer
+        sort_buffer_size:
+          description: Sort buffer size in bytes for ORDER BY optimization. Default
+            is 262144 (256K)
+          example: 262144
+          maximum: 1073741824
+          minimum: 32768
+          title: sort_buffer_size
+          type: integer
+        innodb_thread_concurrency:
+          description: Defines the maximum number of threads permitted inside of InnoDB.
+            Default is 0 (infinite concurrency - no limit)
+          example: 10
+          maximum: 1000
+          minimum: 0
+          title: innodb_thread_concurrency
+          type: integer
+        innodb_write_io_threads:
+          description: The number of I/O threads for write operations in InnoDB. Default
+            is 4. Changing this parameter will lead to a restart of the MySQL service.
+          example: 10
+          maximum: 64
+          minimum: 1
+          title: innodb_write_io_threads
+          type: integer
+        innodb_ft_min_token_size:
+          description: Minimum length of words that are stored in an InnoDB FULLTEXT
+            index. Changing this parameter will lead to a restart of the MySQL service.
+          example: 3
+          maximum: 16
+          minimum: 0
+          title: innodb_ft_min_token_size
+          type: integer
+        innodb_change_buffer_max_size:
+          description: Maximum size for the InnoDB change buffer, as a percentage
+            of the total size of the buffer pool. Default is 25
+          example: 30
+          maximum: 50
+          minimum: 0
+          title: innodb_change_buffer_max_size
+          type: integer
+        innodb_flush_neighbors:
+          description: 'Specifies whether flushing a page from the InnoDB buffer pool
+            also flushes other dirty pages in the same extent (default is 1): 0 -
+            dirty pages in the same extent are not flushed, 1 - flush contiguous dirty
+            pages in the same extent, 2 - flush dirty pages in the same extent'
+          example: 0
+          maximum: 2
+          minimum: 0
+          title: innodb_flush_neighbors
+          type: integer
+        tmp_table_size:
+          description: Limits the size of internal in-memory tables. Also set max_heap_table_size.
+            Default is 16777216 (16M)
+          example: 16777216
+          maximum: 1073741824
+          minimum: 1048576
+          title: tmp_table_size
+          type: integer
+        slow_query_log:
+          description: Slow query log enables capturing of slow queries. Setting slow_query_log
+            to false also truncates the mysql.slow_log table. Default is off
+          example: true
+          title: slow_query_log
+          type: boolean
+        connect_timeout:
+          description: The number of seconds that the mysqld server waits for a connect
+            packet before responding with Bad handshake
+          example: 10
+          maximum: 3600
+          minimum: 2
+          title: connect_timeout
+          type: integer
+        net_read_timeout:
+          description: The number of seconds to wait for more data from a connection
+            before aborting the read.
+          example: 30
+          maximum: 3600
+          minimum: 1
+          title: net_read_timeout
+          type: integer
+        innodb_lock_wait_timeout:
+          description: The length of time in seconds an InnoDB transaction waits for
+            a row lock before giving up. Default is 120.
+          example: 50
+          maximum: 3600
+          minimum: 1
+          title: innodb_lock_wait_timeout
+          type: integer
+        wait_timeout:
+          description: The number of seconds the server waits for activity on a noninteractive
+            connection before closing it.
+          example: 28800
+          maximum: 2147483
+          minimum: 1
+          title: wait_timeout
+          type: integer
+        innodb_rollback_on_timeout:
+          description: When enabled a transaction timeout causes InnoDB to abort and
+            roll back the entire transaction. Changing this parameter will lead to
+            a restart of the MySQL service.
+          example: true
+          title: innodb_rollback_on_timeout
+          type: boolean
+        group_concat_max_len:
+          description: The maximum permitted result length in bytes for the GROUP_CONCAT()
+            function.
+          example: 1024
+          maximum: 18446744073709551615
+          minimum: 4
+          title: group_concat_max_len
+          type: integer
+        net_buffer_length:
+          description: Start sizes of connection buffer and result buffer. Default
+            is 16384 (16K). Changing this parameter will lead to a restart of the
+            MySQL service.
+          example: 16384
+          maximum: 1048576
+          minimum: 1024
+          title: net_buffer_length
+          type: integer
+        innodb_print_all_deadlocks:
+          description: When enabled, information about all deadlocks in InnoDB user
+            transactions is recorded in the error log. Disabled by default.
+          example: true
+          title: innodb_print_all_deadlocks
+          type: boolean
+        innodb_online_alter_log_max_size:
+          description: The upper limit in bytes on the size of the temporary log files
+            used during online DDL operations for InnoDB tables.
+          example: 134217728
+          maximum: 1099511627776
+          minimum: 65536
+          title: innodb_online_alter_log_max_size
+          type: integer
+        interactive_timeout:
+          description: The number of seconds the server waits for activity on an interactive
+            connection before closing it.
+          example: 3600
+          maximum: 604800
+          minimum: 30
+          title: interactive_timeout
+          type: integer
+        innodb_log_buffer_size:
+          description: The size in bytes of the buffer that InnoDB uses to write to
+            the log files on disk.
+          example: 16777216
+          maximum: 4294967295
+          minimum: 1048576
+          title: innodb_log_buffer_size
+          type: integer
+        max_allowed_packet:
+          description: Size of the largest message in bytes that can be received by
+            the server. Default is 67108864 (64M)
+          example: 67108864
+          maximum: 1073741824
+          minimum: 102400
+          title: max_allowed_packet
+          type: integer
+        max_heap_table_size:
+          description: Limits the size of internal in-memory tables. Also set tmp_table_size.
+            Default is 16777216 (16M)
+          example: 16777216
+          maximum: 1073741824
+          minimum: 1048576
+          title: max_heap_table_size
+          type: integer
+        innodb_ft_server_stopword_table:
+          description: This option is used to specify your own InnoDB FULLTEXT index
+            stopword list for all InnoDB tables.
+          example: db_name/table_name
+          maxLength: 1024
+          nullable: true
+          pattern: "^.+/.+$"
+          title: innodb_ft_server_stopword_table
+          type: string
+        innodb_read_io_threads:
+          description: The number of I/O threads for read operations in InnoDB. Default
+            is 4. Changing this parameter will lead to a restart of the MySQL service.
+          example: 10
+          maximum: 64
+          minimum: 1
+          title: innodb_read_io_threads
+          type: integer
+        sql_require_primary_key:
+          description: Require primary key to be defined for new tables or old tables
+            modified with ALTER TABLE and fail if missing. It is recommended to always
+            have primary keys because various functionality may break if any large
+            table is missing them.
+          example: true
+          title: sql_require_primary_key
+          type: boolean
+        default_time_zone:
+          description: Default server time zone as an offset from UTC (from -12:00
+            to +12:00), a time zone name, or 'SYSTEM' to use the MySQL server default.
+          example: "+03:00"
+          maxLength: 100
+          minLength: 2
+          pattern: "^([-+][\\d:]*|[\\w/]*)$"
+          title: default_time_zone
+          type: string
+        long_query_time:
+          description: The slow_query_logs work as SQL statements that take more than
+            long_query_time seconds to execute. Default is 10s
+          example: 10
+          maximum: 3600
+          minimum: 0.0
+          title: long_query_time
+          type: number
+      title: mysql.conf configuration values
+      type: object
+    dbaas-pg-database-name:
+      type: string
+      maxLength: 63
+      minLength: 1
+    dbaas-pg-target-versions:
+      type: string
+      enum:
+      - '14'
+      - '15'
+      - '12'
+      - '13'
+      - '16'
+    instance-type:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Instance type ID
+        size:
+          type: string
+          enum:
+          - large
+          - huge
+          - jumbo
+          - medium
+          - mega
+          - small
+          - extra-large
+          - titan
+          - micro
+          - colossus
+          - tiny
+          readOnly: true
+          description: Instance type size
+        family:
+          type: string
+          enum:
+          - gpu3
+          - gpu2
+          - gpu
+          - memory
+          - storage
+          - standard
+          - colossus
+          - cpu
+          readOnly: true
+          description: Instance type family
+        cpus:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: CPU count
+        gpus:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: GPU count
+        authorized:
+          type: boolean
+          readOnly: true
+          description: Requires authorization or publicly available
+        memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: Available memory
+        zones:
+          type: array
+          items:
+            "$ref": "#/components/schemas/zone-name"
+          readOnly: true
+          description: Instance Type available zones
+      description: Compute instance type
+    json-schema-pgbouncer:
+      description: System-wide settings for pgbouncer.
+      properties:
+        min_pool_size:
+          default: 0
+          example: 0
+          maximum: 10000
+          minimum: 0
+          title: Add more server connections to pool if below this number. Improves
+            behavior when usual load comes suddenly back after period of total inactivity.
+            The value is effectively capped at the pool size.
+          type: integer
+        ignore_startup_parameters:
+          example:
+          - extra_float_digits
+          - search_path
+          items:
+            enum:
+            - extra_float_digits
+            - search_path
+            type: string
+          maxItems: 32
+          title: List of parameters to ignore when given in startup packet
+          type: array
+        server_lifetime:
+          default: 3600
+          example: 3600
+          maximum: 86400
+          minimum: 60
+          title: The pooler will close an unused server connection that has been connected
+            longer than this. [seconds]
+          type: integer
+        autodb_pool_mode:
+          default: transaction
+          enum:
+          - transaction
+          - session
+          - statement
+          example: session
+          title: PGBouncer pool mode
+          type: string
+        server_idle_timeout:
+          default: 600
+          example: 600
+          maximum: 86400
+          minimum: 0
+          title: If a server connection has been idle more than this many seconds
+            it will be dropped. If 0 then timeout is disabled. [seconds]
+          type: integer
+        autodb_max_db_connections:
+          example: 0
+          maximum: 2147483647
+          minimum: 0
+          title: Do not allow more than this many server connections per database
+            (regardless of user). Setting it to 0 means unlimited.
+          type: integer
+        server_reset_query_always:
+          default: false
+          example: false
+          title: Run server_reset_query (DISCARD ALL) in all pooling modes
+          type: boolean
+        autodb_pool_size:
+          default: 0
+          example: 0
+          maximum: 10000
+          minimum: 0
+          title: If non-zero then create automatically a pool of that size per user
+            when a pool doesn't exist.
+          type: integer
+        autodb_idle_timeout:
+          default: 3600
+          example: 3600
+          maximum: 86400
+          minimum: 0
+          title: If the automatically created database pools have been unused this
+            many seconds, they are freed. If 0 then timeout is disabled. [seconds]
+          type: integer
+      title: PGBouncer connection pooling settings
+      type: object
+    load-balancer-server-status:
+      type: object
+      properties:
+        public-ip:
+          type: string
+          format: ipv4
+          description: Backend server public IP
+        status:
+          type: string
+          enum:
+          - failure
+          - success
+          description: Status of the instance's healthcheck
+      description: Load Balancer Service status
+    user:
+      type: object
+      properties:
+        sso:
+          type: boolean
+          description: SSO enabled
+        two-factor-authentication:
+          type: boolean
+          description: Two Factor Authentication enabled
+        email:
+          type: string
+          readOnly: true
+          description: User Email
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: User ID
+        role:
+          "$ref": "#/components/schemas/iam-role"
+          description: IAM Role
+        pending:
+          type: boolean
+          readOnly: true
+          description: True if the user has not yet created an Exoscale account
+      required:
+      - email
+      - role
+      description: User
+    dbaas-service-mysql:
+      type: object
+      properties:
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            uri:
+              type: array
+              items:
+                type: string
+            params:
+              type: array
+              items:
+                type: object
+                additionalProperties:
+                  type: string
+            standby:
+              type: array
+              items:
+                type: string
+          description: MySQL connection information properties
+        backup-schedule:
+          type: object
+          properties:
+            backup-hour:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 23
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The hour of day (in UTC) when backup for the service is
+                started. New backup is only started if previous backup has already
+                completed.
+            backup-minute:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 59
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The minute of an hour when backup for the service is started.
+                New backup is only started if previous backup has already completed.
+          description: Backup schedule
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        databases:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-mysql-database-name"
+          description: List of MySQL databases
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allowed CIDR address blocks for incoming connections
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        mysql-settings:
+          "$ref": "#/components/schemas/json-schema-mysql"
+          description: MySQL-specific settings
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        version:
+          type: string
+          description: MySQL version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              username:
+                type: string
+              password:
+                type: string
+              authentication:
+                type: string
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    dbaas-service-kafka:
+      type: object
+      properties:
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        authentication-methods:
+          type: object
+          properties:
+            certificate:
+              type: boolean
+              description: Whether certificate/SSL authentication is enabled
+            sasl:
+              type: boolean
+              description: Whether SASL authentication is enabled
+          description: Kafka authentication methods
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            nodes:
+              type: array
+              items:
+                type: string
+            access-cert:
+              type: string
+            access-key:
+              type: string
+            connect-uri:
+              type: string
+            rest-uri:
+              type: string
+            registry-uri:
+              type: string
+          description: Kafka connection information properties
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        kafka-rest-enabled:
+          type: boolean
+          description: Whether Kafka REST is enabled
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        kafka-connect-enabled:
+          type: boolean
+          description: Whether Kafka Connect is enabled
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allow incoming connections from CIDR address block, e.g. '10.20.0.0/16'
+        schema-registry-settings:
+          "$ref": "#/components/schemas/json-schema-schema-registry"
+          description: Schema Registry configuration
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        kafka-rest-settings:
+          "$ref": "#/components/schemas/json-schema-kafka-rest"
+          description: Kafka REST configuration
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        kafka-connect-settings:
+          "$ref": "#/components/schemas/json-schema-kafka-connect"
+          description: Kafka Connect configuration values
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              kafka-authentication-method:
+                "$ref": "#/components/schemas/enum-kafka-auth-method"
+                description: Kafka authentication method. This is a value specific
+                  to the 'kafka' service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        kafka-settings:
+          "$ref": "#/components/schemas/json-schema-kafka"
+          description: Kafka-specific settings
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        schema-registry-enabled:
+          type: boolean
+          description: Whether Schema-Registry is enabled
+        version:
+          type: string
+          description: Kafka version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              username:
+                type: string
+              password:
+                type: string
+              access-cert:
+                type: string
+              access-cert-expiry:
+                type: string
+                format: date-time
+              access-key:
+                type: string
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    dbaas-user-password:
+      type: string
+      maxLength: 256
+      minLength: 8
+    quota:
+      type: object
+      properties:
+        resource:
+          type: string
+          description: Resource Name
+        usage:
+          type: integer
+          format: int64
+          description: Resource Usage
+        limit:
+          type: integer
+          format: int64
+          description: Resource Limit. -1 for Unlimited
+      description: Organization Quota
+    dbaas-pg-pool-name:
+      type: string
+      maxLength: 63
+      minLength: 1
+    private-network-lease:
+      type: object
+      properties:
+        ip:
+          type: string
+          format: ipv4
+          readOnly: true
+          description: Private Network IP address
+        instance-id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Attached instance ID
+      description: Private Network leased IP address
+    sks-nodepool-taint:
+      type: object
+      properties:
+        value:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Nodepool taint value
+        effect:
+          type: string
+          enum:
+          - NoExecute
+          - NoSchedule
+          - PreferNoSchedule
+          description: Nodepool taint effect
+      required:
+      - value
+      - effect
+      description: Nodepool taint
+    deploy-target:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Deploy Target ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Deploy Target name
+        type:
+          type: string
+          enum:
+          - edge
+          - dedicated
+          description: Deploy Target type
+        description:
+          type: string
+          maxLength: 255
+          description: Deploy Target description
+      required:
+      - id
+      description: Deploy target
+    snapshot:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Snapshot ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Snapshot name
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Snapshot creation date
+        state:
+          type: string
+          enum:
+          - snapshotting
+          - deleted
+          - exporting
+          - ready
+          - deleting
+          - error
+          - exported
+          description: Snapshot state
+        size:
+          type: integer
+          format: int64
+          minimum: 10
+          maximum: 51200
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          readOnly: true
+          description: Snapshot size in GiB
+        export:
+          type: object
+          properties:
+            presigned-url:
+              type: string
+              description: Exported snapshot disk file pre-signed URL
+            md5sum:
+              type: string
+              description: Exported snapshot disk file MD5 checksum
+          description: Exported snapshot information
+        instance:
+          "$ref": "#/components/schemas/instance"
+          description: Compute Instance snapshotted
+      description: Snapshot
+    dbaas-user-kafka-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Kafka username
+        password:
+          type: string
+          description: Kafka password
+        access-cert:
+          type: string
+          description: Kafka certificate
+        access-cert-expiry:
+          type: string
+          format: date-time
+        access-key:
+          type: string
+          description: Kafka access key
+      description: Kafka User secrets
+    event:
+      type: object
+      properties:
+        iam-user:
+          "$ref": "#/components/schemas/user"
+          description: Details about the IAM User
+        request-id:
+          type: string
+          description: Operation unique identifier
+        iam-role:
+          "$ref": "#/components/schemas/iam-role"
+          description: Details about the IAM Role
+        zone:
+          type: string
+          description: Operation targeted zone
+        get-params:
+          type: object
+          description: Query string parameters (free form map)
+        body-params:
+          type: object
+          description: Body parameters (free form map)
+        status:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Operation HTTP status
+        source-ip:
+          type: string
+          description: Client IP address
+        iam-api-key:
+          "$ref": "#/components/schemas/iam-api-key"
+          description: Details about the IAM API Key
+        uri:
+          type: string
+          description: Operation request URI
+        elapsed-ms:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Operation processing time
+        timestamp:
+          type: string
+          format: date-time
+          description: Time at which the event happened, millisecond resolution
+        path-params:
+          type: object
+          description: URI path parameters (free form map)
+        handler:
+          type: string
+          description: Operation handler name
+        message:
+          type: string
+          description: Operation message
+      description: A notable Mutation Event which happened on the infrastructure
+    iam-api-key:
+      type: object
+      properties:
+        name:
+          type: string
+          description: IAM API Key name
+        key:
+          type: string
+          description: IAM API Key
+        role-id:
+          type: string
+          format: uuid
+          description: IAM API Key Role ID
+      description: IAM API Key
+    public-ip-assignment:
+      type: string
+      enum:
+      - inet4
+      - dual
+      - none
+    elastic-ip-healthcheck:
+      type: object
+      properties:
+        strikes-ok:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 20
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Number of attempts before considering the target healthy (default:
+            2)'
+        tls-skip-verify:
+          type: boolean
+          description: Skip TLS verification
+        tls-sni:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: An optional domain or subdomain to check TLS against
+        strikes-fail:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 20
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Number of attempts before considering the target unhealthy
+            (default: 3)'
+        mode:
+          type: string
+          enum:
+          - tcp
+          - http
+          - https
+          description: Health check mode
+        port:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 65535
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Health check port
+        uri:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: An endpoint to use for the health check, for example '/status'
+        interval:
+          type: integer
+          format: int64
+          minimum: 5
+          maximum: 300
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Interval between the checks in seconds (default: 10)'
+        timeout:
+          type: integer
+          format: int64
+          minimum: 2
+          maximum: 60
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Health check timeout value in seconds (default: 2)'
+      required:
+      - mode
+      - port
+      description: Elastic IP address healthcheck
+    dbaas-user-redis-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Redis username
+        password:
+          type: string
+          description: Redis password
+      description: Redis User secrets
+    dbaas-kafka-schema-registry-acl-entry:
+      type: object
+      properties:
+        id:
+          "$ref": "#/components/schemas/dbaas-kafka-acl-id"
+          description: Kafka ACL ID
+        username:
+          type: string
+          maxLength: 64
+          minLength: 1
+          description: Kafka username or username pattern
+        resource:
+          type: string
+          maxLength: 249
+          minLength: 1
+          description: Kafka Schema Registry name or pattern
+        permission:
+          type: string
+          enum:
+          - schema_registry_read
+          - schema_registry_write
+          description: Kafka Schema Registry permission
+      required:
+      - username
+      - resource
+      - permission
+    enum-mysql-authentication-plugin:
+      type: string
+      enum:
+      - caching_sha2_password
+      - mysql_native_password
+    load-balancer-service-healthcheck:
+      type: object
+      properties:
+        mode:
+          type: string
+          enum:
+          - tcp
+          - http
+          - https
+          description: Healthcheck mode
+        interval:
+          type: integer
+          format: int64
+          minimum: 5
+          maximum: 300
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Healthcheck interval (default: 10). Must be greater than or
+            equal to Timeout'
+        uri:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: An endpoint to use for the HTTP healthcheck, e.g. '/status'
+        port:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 65535
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Healthcheck port
+        timeout:
+          type: integer
+          format: int64
+          minimum: 2
+          maximum: 60
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: 'Healthcheck timeout value (default: 2). Must be lower than
+            or equal to Interval'
+        retries:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 20
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Number of retries before considering a Service failed
+        tls-sni:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: SNI domain for HTTPS healthchecks
+      description: Load Balancer Service healthcheck
+    access-key-operation:
+      type: object
+      properties:
+        operation:
+          type: string
+          description: Name of the operation
+        tags:
+          type: array
+          items:
+            type: string
+          description: Tags associated with the operation
+      description: Access key operation
+    ssh-key:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: SSH key name
+        fingerprint:
+          type: string
+          readOnly: true
+          description: SSH key fingerprint
+      description: SSH key
+    load-balancer-service:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 255
+          description: Load Balancer Service description
+        protocol:
+          type: string
+          enum:
+          - tcp
+          - udp
+          description: Network traffic protocol
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Load Balancer Service name
+        state:
+          type: string
+          enum:
+          - creating
+          - deleting
+          - running
+          - updating
+          - error
+          readOnly: true
+          description: Load Balancer Service state
+        target-port:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Port on which the network traffic will be forwarded to on the
+            receiving instance
+        port:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Port exposed on the Load Balancer's public IP
+        instance-pool:
+          "$ref": "#/components/schemas/instance-pool"
+          description: Instance Pool to forward network traffic to
+        strategy:
+          type: string
+          enum:
+          - round-robin
+          - maglev-hash
+          - source-hash
+          description: Load balancing strategy
+        healthcheck:
+          "$ref": "#/components/schemas/load-balancer-service-healthcheck"
+          description: Healthcheck configuration
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Load Balancer Service ID
+        healthcheck-status:
+          type: array
+          items:
+            "$ref": "#/components/schemas/load-balancer-server-status"
+          readOnly: true
+          description: Healthcheck status per backend server
+      description: Load Balancer Service
+    access-key:
+      type: object
+      properties:
+        name:
+          type: string
+          description: IAM Access Key name
+        key:
+          type: string
+          description: IAM Access Key
+        secret:
+          type: string
+          readOnly: true
+          description: IAM Access Key Secret
+        type:
+          type: string
+          enum:
+          - restricted
+          - unrestricted
+          readOnly: true
+          description: IAM Access Key type
+        version:
+          type: string
+          enum:
+          - v2
+          - v1
+          description: IAM Access Key version
+        tags:
+          type: array
+          items:
+            type: string
+          description: IAM Access Key tags
+        operations:
+          type: array
+          items:
+            type: string
+          description: IAM Access Key operations
+        resources:
+          type: array
+          items:
+            "$ref": "#/components/schemas/access-key-resource"
+          description: IAM Access Key Resources
+      description: IAM Access Key
+    dbaas-service-update:
+      type: object
+      properties:
+        description:
+          type: string
+          description: Description of the update
+        deadline:
+          type: string
+          format: date-time
+          description: Deadline for installing the update
+        start-after:
+          type: string
+          format: date-time
+          description: The earliest time the update will be automatically applied
+        start-at:
+          type: string
+          format: date-time
+          description: The time when the update will be automatically applied
+      description: Update waiting to be installed
+    enum-kafka-auth-method:
+      type: string
+      enum:
+      - certificate
+      - sasl
+    json-schema-pglookout:
+      description: System-wide settings for pglookout.
+      properties:
+        max_failover_replication_time_lag:
+          default: 60
+          description: Number of seconds of master unavailability before triggering
+            database failover to standby
+          maximum: 9223372036854775807
+          minimum: 10
+          title: max_failover_replication_time_lag
+          type: integer
+      title: PGLookout settings
+      type: object
+    dbaas-plan:
+      type: object
+      properties:
+        name:
+          type: string
+          readOnly: true
+          description: DBaaS plan name
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: DBaaS plan node count
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: DBaaS plan CPU count per node
+        disk-space:
+          type: integer
+          format: int64
+          readOnly: true
+          description: DBaaS plan disk space
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: DBaaS plan memory count per node
+        max-memory-percent:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: DBaaS plan max memory allocated percentage
+        backup-config:
+          "$ref": "#/components/schemas/dbaas-backup-config"
+          readOnly: true
+          description: DBaaS plan backup config
+        authorized:
+          type: boolean
+          readOnly: true
+          description: Requires authorization or publicly available
+      description: DBaaS plan
+    labels:
+      type: object
+      additionalProperties:
+        type: string
+    dbaas-mysql-database-name:
+      type: string
+      maxLength: 64
+      minLength: 1
+    dbaas-service-maintenance:
+      type: object
+      properties:
+        dow:
+          type: string
+          enum:
+          - saturday
+          - tuesday
+          - never
+          - wednesday
+          - sunday
+          - friday
+          - monday
+          - thursday
+          description: Day of week for installing updates
+        time:
+          type: string
+          maxLength: 8
+          minLength: 8
+          description: Time for installing updates, UTC
+        updates:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-update"
+          description: List of updates waiting to be installed
+      required:
+      - dow
+      - time
+      - updates
+      description: Automatic maintenance settings
+    enum-service-state:
+      type: string
+      enum:
+      - running
+      - rebuilding
+      - rebalancing
+      - poweroff
+    dbaas-kafka-acls:
+      type: object
+      properties:
+        topic-acl:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-kafka-topic-acl-entry"
+        schema-registry-acl:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-kafka-schema-registry-acl-entry"
+    dbaas-service-pg:
+      type: object
+      properties:
+        pgbouncer-settings:
+          "$ref": "#/components/schemas/json-schema-pgbouncer"
+          description: PGBouncer connection pooling settings
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            uri:
+              type: array
+              items:
+                type: string
+            params:
+              type: array
+              items:
+                type: object
+                additionalProperties:
+                  type: string
+            standby:
+              type: array
+              items:
+                type: string
+            syncing:
+              type: array
+              items:
+                type: string
+          description: PG connection information properties
+        backup-schedule:
+          type: object
+          properties:
+            backup-hour:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 23
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The hour of day (in UTC) when backup for the service is
+                started. New backup is only started if previous backup has already
+                completed.
+            backup-minute:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 59
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The minute of an hour when backup for the service is started.
+                New backup is only started if previous backup has already completed.
+          description: Backup schedule
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        connection-pools:
+          type: array
+          items:
+            type: object
+            properties:
+              connection-uri:
+                type: string
+                description: Connection URI for the DB pool
+              database:
+                "$ref": "#/components/schemas/dbaas-database-name"
+                description: Service database name
+              mode:
+                "$ref": "#/components/schemas/enum-pg-pool-mode"
+                description: PGBouncer pool mode
+              name:
+                "$ref": "#/components/schemas/dbaas-pg-pool-name"
+                description: Connection pool name
+              size:
+                "$ref": "#/components/schemas/dbaas-pg-pool-size"
+                description: Size of PGBouncer's PostgreSQL side connection pool
+              username:
+                "$ref": "#/components/schemas/dbaas-pg-pool-username"
+                description: Pool username
+            required:
+            - connection-uri
+            - database
+            - mode
+            - name
+            - size
+            - username
+          description: PostgreSQL PGBouncer connection pools
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        timescaledb-settings:
+          "$ref": "#/components/schemas/json-schema-timescaledb"
+          description: TimescaleDB extension configuration values
+        databases:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-database-name"
+          description: List of PostgreSQL databases
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allowed CIDR address blocks for incoming connections
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        synchronous-replication:
+          "$ref": "#/components/schemas/enum-pg-synchronous-replication"
+          description: Synchronous replication type. Note that the service plan also
+            needs to support synchronous replication.
+        pglookout-settings:
+          "$ref": "#/components/schemas/json-schema-pglookout"
+          description: PGLookout settings
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        version:
+          type: string
+          description: PostgreSQL version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        work-mem:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 1024
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Sets the maximum amount of memory to be used by a query operation
+            (such as a sort or hash table) before writing to temporary disk files,
+            in MB. Default is 1MB + 0.075% of total RAM (up to 32MB).
+        shared-buffers-percentage:
+          type: integer
+          format: int64
+          minimum: 20
+          maximum: 60
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Percentage of total RAM that the database server uses for shared
+            memory buffers. Valid range is 20-60 (float), which corresponds to 20%
+            - 60%. This setting adjusts the shared_buffers configuration value.
+        pg-settings:
+          "$ref": "#/components/schemas/json-schema-pg"
+          description: PostgreSQL-specific settings
+        max-connections:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Maximum number of connections allowed to an instance
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: Account type
+              username:
+                type: string
+                description: Account username
+              password:
+                type: string
+                description: Account password. A missing field indicates a user overridden
+                  password.
+              allow-replication:
+                type: boolean
+            required:
+            - type
+            - username
+            description: List of service users
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    dbaas-integration:
+      type: object
+      properties:
+        description:
+          type: string
+          description: Description of the integration
+        settings:
+          type: object
+          description: Integration settings
+        type:
+          type: string
+          description: Integration type
+        is-enabled:
+          type: boolean
+          description: Whether the integration is enabled or not
+        source:
+          type: string
+          description: Source service name
+        is-active:
+          type: boolean
+          description: Whether the integration is active or not
+        status:
+          type: string
+          description: Integration status
+        id:
+          type: string
+          format: uuid
+          description: Integration id
+        dest:
+          type: string
+          description: Destination service name
+    sks-oidc:
+      type: object
+      properties:
+        client-id:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: OpenID client ID
+        issuer-url:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: OpenID provider URL
+        username-claim:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: JWT claim to use as the user name
+        username-prefix:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Prefix prepended to username claims
+        groups-claim:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: JWT claim to use as the user's group
+        groups-prefix:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Prefix prepended to group claims
+        required-claim:
+          type: object
+          additionalProperties:
+            type: string
+          description: A key value map that describes a required claim in the ID Token
+      required:
+      - client-id
+      - issuer-url
+      description: SKS Cluster OpenID config map
+    dbaas-task:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        create-time:
+          type: string
+          format: date-time
+        result:
+          type: string
+        result-codes:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+              dbname:
+                type: string
+        success:
+          type: boolean
+        task-type:
+          type: string
+    operation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Operation ID
+        reason:
+          type: string
+          enum:
+          - incorrect
+          - unknown
+          - unavailable
+          - forbidden
+          - busy
+          - fault
+          - partial
+          - not-found
+          - interrupted
+          - unsupported
+          - conflict
+          readOnly: true
+          description: Operation failure reason
+        reference:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+              description: Reference ID
+            link:
+              type: string
+              readOnly: true
+              description: Link to the referenced resource
+            command:
+              type: string
+              description: Command name
+          description: Related resource reference
+          readOnly: true
+        message:
+          type: string
+          readOnly: true
+          description: Operation message
+        state:
+          type: string
+          enum:
+          - failure
+          - pending
+          - success
+          - timeout
+          readOnly: true
+          description: Operation status
+      description: Operation
+    iam-api-key-created:
+      type: object
+      properties:
+        name:
+          type: string
+          description: IAM API Key name
+        key:
+          type: string
+          description: IAM API Key
+        secret:
+          type: string
+          readOnly: true
+          description: IAM API Key Secret
+        role-id:
+          type: string
+          format: uuid
+          description: IAM API Key Role ID
+      description: IAM API Key
+    iam-policy:
+      type: object
+      properties:
+        default-service-strategy:
+          type: string
+          enum:
+          - allow
+          - deny
+          description: IAM default service strategy
+        services:
+          type: object
+          additionalProperties:
+            "$ref": "#/components/schemas/iam-service-policy"
+          description: IAM services
+      required:
+      - default-service-strategy
+      - services
+      description: Policy
+    reverse-dns-record:
+      type: object
+      properties:
+        domain-name:
+          "$ref": "#/components/schemas/domain-name"
+    security-group-resource:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Security Group ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Security Group name
+        visibility:
+          type: string
+          enum:
+          - private
+          - public
+          description: |-
+            Whether this points to a public security group. This is only valid when in the context of
+                               a rule addition which uses a public security group as a source or destination.
+      description: Security Group
+    dbaas-migration-status:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message in case that migration has failed
+        master-last-io-seconds-ago:
+          type: integer
+          format: int64
+          description: 'Redis only: how many seconds since last I/O with redis master'
+        master-link-status:
+          "$ref": "#/components/schemas/enum-master-link-status"
+          description: 'Redis only: replication master link status'
+        method:
+          type: string
+          description: Migration method. Empty in case of multiple methods or error
+        status:
+          type: string
+          description: Migration status
+        details:
+          type: array
+          items:
+            type: object
+            properties:
+              dbname:
+                type: string
+                description: Migrated db name (PG) or number (Redis)
+              error:
+                type: string
+                description: Error message in case that migration has failed
+              method:
+                type: string
+                description: Migration method
+              status:
+                "$ref": "#/components/schemas/enum-migration-status"
+                description: Migration status
+          description: Migration status per database
+    enum-pg-pool-mode:
+      type: string
+      enum:
+      - transaction
+      - statement
+      - session
+    sos-bucket-usage:
+      type: object
+      properties:
+        name:
+          type: string
+          description: SOS Bucket name
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: SOS Bucket creation date
+        zone-name:
+          "$ref": "#/components/schemas/zone-name"
+          readOnly: true
+          description: SOS Bucket zone
+        size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: SOS Bucket size in B
+      description: SOS Bucket usage
+    instance:
+      type: object
+      properties:
+        anti-affinity-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/anti-affinity-group"
+          description: Instance Anti-affinity Groups
+        public-ip-assignment:
+          "$ref": "#/components/schemas/public-ip-assignment"
+          description: Instance public IP assignment
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Resource labels
+        security-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/security-group"
+          description: Instance Security Groups
+        elastic-ips:
+          type: array
+          items:
+            "$ref": "#/components/schemas/elastic-ip"
+          description: Instance Elastic IPs
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Instance name
+        instance-type:
+          "$ref": "#/components/schemas/instance-type"
+          description: Instance Type
+        private-networks:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+                description: Private Network ID
+              mac-address:
+                type: string
+                description: Private Network MAC address
+            description: Private Network
+          description: Instance Private Networks
+        template:
+          "$ref": "#/components/schemas/template"
+          description: Instance Template
+        state:
+          "$ref": "#/components/schemas/instance-state"
+          readOnly: true
+          description: Instance state
+        ssh-key:
+          "$ref": "#/components/schemas/ssh-key"
+          description: Instance SSH Key
+        user-data:
+          type: string
+          minLength: 1
+          description: Instance Cloud-init user-data (base64 encoded)
+        mac-address:
+          type: string
+          readOnly: true
+          description: Instance MAC address
+        manager:
+          "$ref": "#/components/schemas/manager"
+          readOnly: true
+          description: Instance manager
+        deploy-target:
+          "$ref": "#/components/schemas/deploy-target"
+          description: Instance Deploy Target
+        ipv6-address:
+          type: string
+          readOnly: true
+          description: Instance IPv6 address
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Instance ID
+        snapshots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/snapshot"
+          description: Instance Snapshots
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 10
+          maximum: 51200
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Instance disk size in GiB
+        ssh-keys:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ssh-key"
+          description: Instance SSH Keys
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Instance creation date
+        public-ip:
+          type: string
+          format: ipv4
+          readOnly: true
+          description: Instance public IPv4 address
+      description: Instance
+    kubelet-image-gc:
+      type: object
+      properties:
+        high-threshold:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+        low-threshold:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+        min-age:
+          type: string
+      description: Kubelet image GC options
+    dbaas-service-integration:
+      type: object
+      properties:
+        integration-status:
+          type: object
+          description: Integration status
+        description:
+          type: string
+          description: Description of the integration
+        source-service-type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        source-endpoint:
+          type: string
+          description: Source endpoint name
+        dest-service-type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        integration-type:
+          type: string
+          description: Type of the integration
+        dest-endpoint:
+          type: string
+          description: Destination endpoint name
+        user-config:
+          type: object
+          description: Service integration settings
+        dest-endpoint-id:
+          type: string
+          description: Destination endpoint id
+        service-integration-id:
+          type: string
+          description: Integration ID
+        dest-service:
+          type: string
+          description: Destination service name
+        active:
+          type: boolean
+          description: True when integration is active
+        source-endpoint-id:
+          type: string
+          description: Source endpoint ID
+        source-service:
+          type: string
+          description: Source service name
+        enabled:
+          type: boolean
+          description: True when integration is enabled
+      required:
+      - active
+      - description
+      - dest-service
+      - dest-service-type
+      - enabled
+      - integration-type
+      - service-integration-id
+      - source-service
+      - source-service-type
+      description: Integrations with other services
+    dbaas-pg-pool-username:
+      type: string
+      maxLength: 64
+      minLength: 1
+    dbaas-user-mysql-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: MySQL username
+        password:
+          type: string
+          description: MySQL password
+      description: MySQL User secrets
+    json-schema-kafka-rest:
+      additionalProperties: false
+      properties:
+        producer_compression_type:
+          description: Specify the default compression type for producers. This configuration
+            accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd').
+            It additionally accepts 'none' which is the default and equivalent to
+            no compression.
+          enum:
+          - gzip
+          - snappy
+          - lz4
+          - zstd
+          - none
+          title: producer.compression.type
+          type: string
+        name_strategy_validation:
+          default: true
+          description: If true, validate that given schema is registered under expected
+            subject name by the used name strategy when producing messages.
+          title: name.strategy.validation
+          type: boolean
+        name_strategy:
+          default: topic_name
+          description: Name strategy to use when selecting subject for storing schemas
+          enum:
+          - topic_name
+          - record_name
+          - topic_record_name
+          title: name.strategy
+          type: string
+        consumer_enable_auto_commit:
+          default: true
+          description: If true the consumer's offset will be periodically committed
+            to Kafka in the background
+          title: consumer.enable.auto.commit
+          type: boolean
+        producer_acks:
+          default: '1'
+          description: The number of acknowledgments the producer requires the leader
+            to have received before considering a request complete. If set to 'all'
+            or '-1', the leader will wait for the full set of in-sync replicas to
+            acknowledge the record.
+          enum:
+          - all
+          - "-1"
+          - '0'
+          - '1'
+          title: producer.acks
+          type: string
+        consumer_request_max_bytes:
+          default: 67108864
+          description: Maximum number of bytes in unencoded message keys and values
+            by a single request
+          maximum: 671088640
+          minimum: 0
+          title: consumer.request.max.bytes
+          type: integer
+        producer_max_request_size:
+          default: 1048576
+          description: The maximum size of a request in bytes. Note that Kafka broker
+            can also cap the record batch size.
+          maximum: 2147483647
+          minimum: 0
+          title: producer.max.request.size
+          type: integer
+        simpleconsumer_pool_size_max:
+          default: 25
+          description: Maximum number of SimpleConsumers that can be instantiated
+            per broker
+          maximum: 250
+          minimum: 10
+          title: simpleconsumer.pool.size.max
+          type: integer
+        producer_linger_ms:
+          default: 0
+          description: Wait for up to the given delay to allow batching records together
+          maximum: 5000
+          minimum: 0
+          title: producer.linger.ms
+          type: integer
+        consumer_request_timeout_ms:
+          default: 1000
+          description: The maximum total time to wait for messages for a request if
+            the maximum number of messages has not yet been reached
+          enum:
+          - 1000
+          - 15000
+          - 30000
+          maximum: 30000
+          minimum: 1000
+          title: consumer.request.timeout.ms
+          type: integer
+      title: Kafka REST configuration
+      type: object
+    dbaas-service-name:
+      type: string
+      maxLength: 63
+      minLength: 0
+    dbaas-user-grafana-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Grafana username
+        password:
+          type: string
+          description: Grafana password
+      description: Grafana User secrets
+    sks-cluster:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 255
+          description: Cluster description
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Cluster labels
+        cni:
+          type: string
+          enum:
+          - calico
+          - cilium
+          description: Cluster CNI
+        auto-upgrade:
+          type: boolean
+          description: Enable auto upgrade of the control plane to the latest patch
+            version available
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Cluster name
+        state:
+          type: string
+          enum:
+          - rotating-ccm-credentials
+          - creating
+          - upgrading
+          - deleting
+          - running
+          - suspending
+          - updating
+          - error
+          readOnly: true
+          description: Cluster state
+        nodepools:
+          type: array
+          items:
+            "$ref": "#/components/schemas/sks-nodepool"
+          readOnly: true
+          description: Cluster Nodepools
+        level:
+          type: string
+          enum:
+          - starter
+          - pro
+          description: Cluster level
+        addons:
+          type: array
+          items:
+            type: string
+            enum:
+            - exoscale-cloud-controller
+            - exoscale-container-storage-interface
+            - metrics-server
+          uniqueItems: true
+          description: Cluster addons
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Cluster ID
+        version:
+          type: string
+          description: Control plane Kubernetes version
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Cluster creation date
+        endpoint:
+          type: string
+          readOnly: true
+          description: Cluster endpoint
+      description: SKS Cluster
+    instance-pool:
+      type: object
+      properties:
+        anti-affinity-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/anti-affinity-group"
+          description: Instance Pool Anti-affinity Groups
+        description:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Instance Pool description
+        public-ip-assignment:
+          "$ref": "#/components/schemas/public-ip-assignment"
+          description: Instance Pool public IP assignment
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Instance Pool Labels
+        security-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/security-group"
+          description: Instance Pool Security Groups
+        elastic-ips:
+          type: array
+          items:
+            "$ref": "#/components/schemas/elastic-ip"
+          description: Instances Elastic IPs
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Instance Pool name
+        instance-type:
+          "$ref": "#/components/schemas/instance-type"
+          description: Instances type
+        min-available:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Minimum number of running instances
+        private-networks:
+          type: array
+          items:
+            "$ref": "#/components/schemas/private-network"
+          description: Instance Pool Private Networks
+        template:
+          "$ref": "#/components/schemas/template"
+          description: Instances template
+        state:
+          type: string
+          enum:
+          - scaling-up
+          - scaling-down
+          - destroying
+          - creating
+          - suspended
+          - running
+          - updating
+          readOnly: true
+          description: Instance Pool state
+        size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Number of instances
+        ssh-key:
+          "$ref": "#/components/schemas/ssh-key"
+          description: Instances SSH key
+        instance-prefix:
+          type: string
+          maxLength: 30
+          minLength: 1
+          description: 'The instances created by the Instance Pool will be prefixed
+            with this value (default: pool)'
+        user-data:
+          type: string
+          minLength: 1
+          description: Instances Cloud-init user-data
+        manager:
+          "$ref": "#/components/schemas/manager"
+          readOnly: true
+          description: Instance Pool manager
+        instances:
+          type: array
+          items:
+            "$ref": "#/components/schemas/instance"
+          readOnly: true
+          description: Instances
+        deploy-target:
+          "$ref": "#/components/schemas/deploy-target"
+          description: Instance Pool Deploy Target
+        ipv6-enabled:
+          type: boolean
+          description: Enable IPv6 for instances
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Instance Pool ID
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 10
+          maximum: 51200
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Instances disk size in GiB
+        ssh-keys:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ssh-key"
+          description: Instances SSH keys
+      description: Instance Pool
+    dbaas-integration-type:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of the integration.
+        source-description:
+          type: string
+          description: The description of the source service types.
+        source-service-types:
+          type: array
+          items:
+            type: string
+          description: A list of the source service types the integration supports.
+        dest-description:
+          type: string
+          description: The description of the destination service types.
+        dest-service-types:
+          type: array
+          items:
+            type: string
+          description: A list of the destination service types the integration supports.
+        settings:
+          type: object
+          properties:
+            properties:
+              type: object
+            additionalProperties:
+              type: boolean
+            type:
+              type: string
+            title:
+              type: string
+          description: A JSON schema of additional settings of the integration.
+    sks-nodepool:
+      type: object
+      properties:
+        anti-affinity-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/anti-affinity-group"
+          description: Nodepool Anti-affinity Groups
+        description:
+          type: string
+          maxLength: 255
+          description: Nodepool description
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Nodepool labels
+        taints:
+          "$ref": "#/components/schemas/sks-nodepool-taints"
+          description: Nodepool taints
+        security-groups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/security-group"
+          description: Nodepool Security Groups
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Nodepool name
+        instance-type:
+          "$ref": "#/components/schemas/instance-type"
+          description: Nodepool Instances type
+        private-networks:
+          type: array
+          items:
+            "$ref": "#/components/schemas/private-network"
+          description: Nodepool Private Networks
+        template:
+          "$ref": "#/components/schemas/template"
+          readOnly: true
+          description: Nodepool Instance template
+        state:
+          type: string
+          enum:
+          - renewing-token
+          - creating
+          - deleting
+          - running
+          - scaling
+          - updating
+          - error
+          readOnly: true
+          description: Nodepool state
+        size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Number of instances
+        kubelet-image-gc:
+          "$ref": "#/components/schemas/kubelet-image-gc"
+          description: Kubelet image GC options
+        instance-pool:
+          "$ref": "#/components/schemas/instance-pool"
+          readOnly: true
+          description: Instance Pool managed by the Nodepool
+        instance-prefix:
+          type: string
+          maxLength: 30
+          minLength: 1
+          description: 'The instances created by the Nodepool will be prefixed with
+            this value (default: pool)'
+        deploy-target:
+          "$ref": "#/components/schemas/deploy-target"
+          description: Instance Pool Deploy Target
+        addons:
+          type: array
+          items:
+            type: string
+            enum:
+            - storage-lvm
+          uniqueItems: true
+          description: Nodepool addons
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Nodepool ID
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 20
+          maximum: 51200
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Nodepool instances disk size in GiB
+        version:
+          type: string
+          readOnly: true
+          description: Nodepool version
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Nodepool creation date
+      description: SKS Nodepool
+    enum-integration-types:
+      type: string
+      enum:
+      - datasource
+      - logs
+      - metrics
+    template:
+      type: object
+      properties:
+        maintainer:
+          type: string
+          readOnly: true
+          description: Template maintainer
+        description:
+          type: string
+          maxLength: 255
+          description: Template description
+        ssh-key-enabled:
+          type: boolean
+          description: Enable SSH key-based login
+        family:
+          type: string
+          readOnly: true
+          description: Template family
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Template name
+        default-user:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Template default user
+        size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          description: Template size
+        password-enabled:
+          type: boolean
+          description: Enable password-based login
+        build:
+          type: string
+          readOnly: true
+          description: Template build
+        checksum:
+          type: string
+          description: Template MD5 checksum
+        boot-mode:
+          type: string
+          enum:
+          - legacy
+          - uefi
+          description: 'Boot mode (default: legacy)'
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Template ID
+        zones:
+          type: array
+          items:
+            "$ref": "#/components/schemas/zone-name"
+          description: Zones availability
+        url:
+          type: string
+          description: Template source URL
+        version:
+          type: string
+          readOnly: true
+          description: Template version
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Template creation date
+        visibility:
+          type: string
+          enum:
+          - private
+          - public
+          readOnly: true
+          description: Template visibility
+      description: Instance template
+    dbaas-service-grafana:
+      type: object
+      properties:
+        description:
+          type: string
+          description: DbaaS service description
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            uri:
+              type: string
+            username:
+              type: string
+            password:
+              type: string
+          description: Grafana connection information properties
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        grafana-settings:
+          "$ref": "#/components/schemas/json-schema-grafana"
+          description: Grafana specific settings
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allowed CIDR address blocks for incoming connections
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        version:
+          type: string
+          description: Grafana version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              username:
+                type: string
+              password:
+                type: string
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    enum-migration-status:
+      type: string
+      enum:
+      - running
+      - syncing
+      - failed
+      - done
+    enum-opensearch-rule-permission:
+      type: string
+      enum:
+      - admin
+      - read
+      - deny
+      - readwrite
+      - write
+    security-group:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Security Group ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Security Group name
+        description:
+          type: string
+          maxLength: 255
+          description: Security Group description
+        external-sources:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+          description: Security Group external sources
+        rules:
+          type: array
+          items:
+            "$ref": "#/components/schemas/security-group-rule"
+          uniqueItems: true
+          writeOnly: true
+          description: Security Group rules
+      description: Security Group
+    zone:
+      type: object
+      properties:
+        name:
+          "$ref": "#/components/schemas/zone-name"
+          readOnly: true
+          description: Zone short name
+        api-endpoint:
+          type: string
+          readOnly: true
+          x-go-type: Endpoint
+          description: Zone API endpoint
+        sos-endpoint:
+          type: string
+          readOnly: true
+          x-go-type: Endpoint
+          description: Zone SOS endpoint
+      description: Zone
+    dbaas-opensearch-acl-config:
+      type: object
+      properties:
+        acls:
+          type: array
+          items:
+            type: object
+            properties:
+              rules:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    index:
+                      type: string
+                      maxLength: 249
+                      pattern: "[^\\s\\/]+"
+                      description: OpenSearch index pattern
+                    permission:
+                      "$ref": "#/components/schemas/enum-opensearch-rule-permission"
+                      description: OpenSearch permission
+                  required:
+                  - index
+              username:
+                "$ref": "#/components/schemas/dbaas-user-username"
+          description: List of OpenSearch ACLs
+        acl-enabled:
+          type: boolean
+          description: Enable OpenSearch ACLs. When disabled authenticated service
+            users have unrestricted access.
+        extended-acl-enabled:
+          type: boolean
+          description: Enable to enforce index rules in a limited fashion for requests
+            that use the _mget, _msearch, and _bulk APIs
+    block-storage-volume-target:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Block storage volume ID
+      description: Target block storage volume
+    dbaas-backup-config:
+      type: object
+      properties:
+        max-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Maximum number of backups to keep. Zero when no backups are
+            created.
+        interval:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: true
+          readOnly: true
+          description: |-
+            The interval, in hours, at which backups are generated.
+                                                        For some services, like PostgreSQL, this is the interval
+                                                        at which full snapshots are taken and continuous incremental
+                                                        backup stream is maintained in addition to that.
+        recovery-mode:
+          type: string
+          readOnly: true
+          description: |-
+            Mechanism how backups can be restored. 'regular'
+                                                        means a backup is restored as is so that the system
+                                                        is restored to the state it was when the backup was generated.
+                                                        'pitr' means point-in-time-recovery, which allows restoring the system to any state since the first available full snapshot.
+        frequent-interval-minutes:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Interval of taking a frequent backup in service types supporting
+            different backup schedules
+        frequent-oldest-age-minutes:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Maximum age of the oldest frequent backup in service types
+            supporting different backup schedules
+        infrequent-interval-minutes:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Interval of taking a frequent backup in service types supporting
+            different backup schedules
+        infrequent-oldest-age-minutes:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Maximum age of the oldest infrequent backup in service types
+            supporting different backup schedules
+      description: DBaaS plan backup config
+    dbaas-service-redis:
+      type: object
+      properties:
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            uri:
+              type: array
+              items:
+                type: string
+            password:
+              type: string
+            slave:
+              type: array
+              items:
+                type: string
+          description: Redis connection information properties
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        redis-settings:
+          "$ref": "#/components/schemas/json-schema-redis"
+          description: Redis-specific settings
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allowed CIDR address blocks for incoming connections
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              ssl:
+                type: boolean
+                description: |-
+                  Whether the endpoint is encrypted or accepts plaintext.
+                               By default endpoints are always encrypted and
+                               this property is only included for service components that may disable encryption.
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        version:
+          type: string
+          description: Redis version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              username:
+                type: string
+              password:
+                type: string
+              access-control:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      type: string
+                  channels:
+                    type: array
+                    items:
+                      type: string
+                  commands:
+                    type: array
+                    items:
+                      type: string
+                  keys:
+                    type: array
+                    items:
+                      type: string
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    zone-name:
+      type: string
+      enum:
+      - ch-dk-2
+      - de-muc-1
+      - ch-gva-2
+      - at-vie-1
+      - de-fra-1
+      - bg-sof-1
+      - at-vie-2
+    dbaas-kafka-acl-id:
+      type: string
+      maxLength: 40
+      minLength: 1
+    dbaas-service-opensearch:
+      type: object
+      properties:
+        description:
+          type: string
+          description: DbaaS service description
+        max-index-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Maximum number of indexes to keep before deleting the oldest
+            one
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        connection-info:
+          type: object
+          properties:
+            uri:
+              type: array
+              items:
+                type: string
+            username:
+              type: string
+            password:
+              type: string
+            dashboard-uri:
+              type: string
+          description: Opensearch connection information properties
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        node-states:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-node-state"
+          description: State of individual service nodes
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        keep-index-refresh-interval:
+          type: boolean
+          description: Aiven automation resets index.refresh_interval to default value
+            for every index to be sure that indices are always visible to search.
+            If it doesn't fit your case, you can disable this by setting up this flag
+            to true.
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        ip-filter:
+          type: array
+          items:
+            type: string
+          description: Allowed CIDR address blocks for incoming connections
+        backups:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-backup"
+          description: List of backups for the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        components:
+          type: array
+          items:
+            type: object
+            properties:
+              component:
+                type: string
+                description: Service component name
+              host:
+                type: string
+                description: DNS name for connecting to the service component
+              port:
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 65535
+                exclusiveMinimum: false
+                exclusiveMaximum: false
+                description: Port number for connecting to the service component
+              route:
+                "$ref": "#/components/schemas/enum-component-route"
+                description: Network access route
+              usage:
+                "$ref": "#/components/schemas/enum-component-usage"
+                description: DNS usage name
+            required:
+            - component
+            - host
+            - port
+            - route
+            - usage
+          description: Service component information objects
+        index-patterns:
+          type: array
+          items:
+            type: object
+            properties:
+              max-index-count:
+                type: integer
+                format: int64
+                minimum: 0
+                exclusiveMinimum: false
+                description: Maximum number of indexes to keep
+              sorting-algorithm:
+                type: string
+                enum:
+                - alphabetical
+                - creation_date
+                description: Deletion sorting algorithm
+              pattern:
+                type: string
+                maxLength: 1024
+                description: fnmatch pattern
+          description: 'Allows you to create glob style patterns and set a max number
+            of indexes matching this pattern you want to keep. Creating indexes exceeding
+            this value will cause the oldest one to get deleted. You could for example
+            create a pattern looking like ''logs.?'' and then create index logs.1,
+            logs.2 etc, it will delete logs.1 once you create logs.6. Do note ''logs.?''
+            does not apply to logs.10. Note: Setting max_index_count to 0 will do
+            nothing and the pattern gets ignored.'
+        maintenance:
+          "$ref": "#/components/schemas/dbaas-service-maintenance"
+          description: Automatic maintenance settings
+        index-template:
+          type: object
+          properties:
+            mapping-nested-objects-limit:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 100000
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The maximum number of nested JSON objects that a single
+                document can contain across all nested types. This limit helps to
+                prevent out of memory errors when a document contains too many nested
+                objects. Default is 10000.
+            number-of-replicas:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 29
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The number of replicas each primary shard has.
+            number-of-shards:
+              type: integer
+              format: int64
+              minimum: 1
+              maximum: 1024
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: The number of primary shards that an index should have.
+          description: Template settings for all new indexes
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        uri:
+          type: string
+          description: URI for connecting to the service (may be absent)
+        opensearch-settings:
+          "$ref": "#/components/schemas/json-schema-opensearch"
+          description: OpenSearch-specific settings
+        uri-params:
+          type: object
+          description: service_uri parameterized into key-value pairs
+        version:
+          type: string
+          description: OpenSearch version
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+        opensearch-dashboards:
+          type: object
+          properties:
+            opensearch-request-timeout:
+              type: integer
+              format: int64
+              minimum: 5000
+              maximum: 120000
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: 'Timeout in milliseconds for requests made by OpenSearch
+                Dashboards towards OpenSearch (default: 30000)'
+            enabled:
+              type: boolean
+              description: 'Enable or disable OpenSearch Dashboards (default: true)'
+            max-old-space-size:
+              type: integer
+              format: int64
+              minimum: 64
+              maximum: 1024
+              exclusiveMinimum: false
+              exclusiveMaximum: false
+              description: 'Limits the maximum amount of memory (in MiB) the OpenSearch
+                Dashboards process can use. This sets the max_old_space_size option
+                of the nodejs running the OpenSearch Dashboards. Note: the memory
+                reserved by OpenSearch Dashboards is not available for OpenSearch.
+                (default: 128)'
+          description: OpenSearch Dashboards settings
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              username:
+                type: string
+              password:
+                type: string
+          description: List of service users
+      required:
+      - name
+      - plan
+      - type
+    manager:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Manager ID
+        type:
+          type: string
+          enum:
+          - sks-nodepool
+          - instance-pool
+          description: Manager type
+      description: Resource manager
+    dbaas-node-state-progress-update:
+      type: object
+      properties:
+        completed:
+          type: boolean
+          description: Indicates whether this phase has been completed or not
+        current:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Current progress for this phase. May be missing or null.
+        max:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Maximum progress value for this phase. May be missing or null.
+            May change.
+        min:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Minimum progress value for this phase. May be missing or null.
+        phase:
+          type: string
+          enum:
+          - stream
+          - basebackup
+          - prepare
+          - finalize
+          description: Key identifying this phase
+        unit:
+          type: string
+          description: |-
+            Unit for current/min/max values. New units may be added.
+                                    If null should be treated as generic unit
+      required:
+      - completed
+      - phase
+      description: Extra information regarding the progress for current state
+    sks-nodepool-taints:
+      type: object
+      additionalProperties:
+        "$ref": "#/components/schemas/sks-nodepool-taint"
+    enum-master-link-status:
+      type: string
+      enum:
+      - up
+      - down
+    anti-affinity-group:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Anti-affinity Group ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Anti-affinity Group name
+        description:
+          type: string
+          maxLength: 255
+          description: Anti-affinity Group description
+        instances:
+          type: array
+          items:
+            "$ref": "#/components/schemas/instance"
+          readOnly: true
+          description: Anti-affinity Group instances
+      description: Anti-affinity Group
+    block-storage-snapshot:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Snapshot ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Snapshot name
+        size:
+          type: integer
+          format: int64
+          minimum: 10
+          exclusiveMinimum: false
+          description: Snapshot size
+        volume-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Original Volume size
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Snapshot creation date
+        state:
+          type: string
+          enum:
+          - partially-destroyed
+          - destroying
+          - creating
+          - created
+          - promoting
+          - error
+          - destroyed
+          - allocated
+          readOnly: true
+          description: Snapshot state
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Resource labels
+        block-storage-volume:
+          "$ref": "#/components/schemas/block-storage-volume-target"
+          description: Referenced volume
+      description: Block storage snapshot
+    dbaas-user-postgres-secrets:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Postgres username
+        password:
+          type: string
+          description: Postgres password
+      description: Postgres User secrets
+    dbaas-service-type-name:
+      type: string
+      maxLength: 64
+      minLength: 0
+    iam-service-policy-rule:
+      type: object
+      properties:
+        action:
+          type: string
+          enum:
+          - allow
+          - deny
+        expression:
+          type: string
+        resources:
+          type: array
+          items:
+            type: string
+    iam-role:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: IAM Role ID
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: IAM Role name
+        description:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: IAM Role description
+        permissions:
+          type: array
+          items:
+            type: string
+            enum:
+            - bypass-governance-retention
+          uniqueItems: true
+          description: IAM Role permissions
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: IAM Role Labels
+        editable:
+          type: boolean
+          description: IAM Role mutability
+        policy:
+          "$ref": "#/components/schemas/iam-policy"
+          description: IAM Role Policy
+      description: IAM Role
+    dbaas-service-common:
+      type: object
+      properties:
+        updated-at:
+          type: string
+          format: date-time
+          description: Service last update timestamp (ISO 8601)
+        node-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of service nodes in the active plan
+        node-cpu-count:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Number of CPUs for each node
+        integrations:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-integration"
+          description: Service integrations
+        zone:
+          type: string
+          description: The zone where the service is running
+        name:
+          "$ref": "#/components/schemas/dbaas-service-name"
+          description: Service name
+        type:
+          "$ref": "#/components/schemas/dbaas-service-type-name"
+          description: Service type code
+        state:
+          "$ref": "#/components/schemas/enum-service-state"
+          description: State of the service
+        termination-protection:
+          type: boolean
+          description: Service is protected against termination and powering off
+        notifications:
+          type: array
+          items:
+            "$ref": "#/components/schemas/dbaas-service-notification"
+          description: Service notifications
+        disk-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT disk space for data storage
+        node-memory:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: TODO UNIT of memory for each node
+        created-at:
+          type: string
+          format: date-time
+          description: Service creation timestamp (ISO 8601)
+        plan:
+          type: string
+          description: Subscription plan
+      required:
+      - name
+      - plan
+      - type
+    json-schema-timescaledb:
+      description: System-wide settings for the timescaledb extension
+      properties:
+        max_background_workers:
+          default: 16
+          description: The number of background workers for timescaledb operations.
+            You should configure this setting to the sum of your number of databases
+            and the total number of concurrent background workers you want running
+            at any given point in time.
+          example: 8
+          maximum: 4096
+          minimum: 1
+          title: timescaledb.max_background_workers
+          type: integer
+      title: TimescaleDB extension configuration values
+      type: object
+    snapshot-export:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Snapshot export ID
+        presigned-url:
+          type: string
+          description: Snapshot export presigned url
+        md5sum:
+          type: string
+          description: Snapshot export md5 checksum
+      description: Snapshot export information. This data is transient.
+    dbaas-postgres-users:
+      type: object
+      properties:
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              username:
+                "$ref": "#/components/schemas/dbaas-user-username"
+                description: Username
+              allow-replication:
+                type: boolean
+            required:
+            - username
+    json-schema-redis:
+      properties:
+        ssl:
+          default: true
+          title: Require SSL to access Redis
+          type: boolean
+        lfu_log_factor:
+          default: 10
+          maximum: 100
+          minimum: 0
+          title: Counter logarithm factor for volatile-lfu and allkeys-lfu maxmemory-policies
+          type: integer
+        maxmemory_policy:
+          default: noeviction
+          enum:
+          - noeviction
+          - allkeys-lru
+          - volatile-lru
+          - allkeys-random
+          - volatile-random
+          - volatile-ttl
+          - volatile-lfu
+          - allkeys-lfu
+          nullable: true
+          title: Redis maxmemory-policy
+          type: string
+        io_threads:
+          description: Set Redis IO thread count. Changing this will cause a restart
+            of the Redis service.
+          example: 1
+          maximum: 32
+          minimum: 1
+          title: Redis IO thread count
+          type: integer
+        lfu_decay_time:
+          default: 1
+          maximum: 120
+          minimum: 1
+          title: LFU maxmemory-policy counter decay time in minutes
+          type: integer
+        pubsub_client_output_buffer_limit:
+          description: Set output buffer limit for pub / sub clients in MB. The value
+            is the hard limit, the soft limit is 1/4 of the hard limit. When setting
+            the limit, be mindful of the available memory in the selected service
+            plan.
+          example: 64
+          maximum: 512
+          minimum: 32
+          title: Pub/sub client output buffer hard limit in MB
+          type: integer
+        notify_keyspace_events:
+          default: ''
+          maxLength: 32
+          pattern: "^[KEg\\$lshzxentdmA]*$"
+          title: Set notify-keyspace-events option
+          type: string
+        persistence:
+          description: When persistence is 'rdb', Redis does RDB dumps each 10 minutes
+            if any key is changed. Also RDB dumps are done according to backup schedule
+            for backup purposes. When persistence is 'off', no RDB dumps and backups
+            are done, so data can be lost at any moment if service is restarted for
+            any reason, or if service is powered off. Also service can't be forked.
+          enum:
+          - 'off'
+          - rdb
+          title: Redis persistence
+          type: string
+        timeout:
+          default: 300
+          maximum: 31536000
+          minimum: 0
+          title: Redis idle connection timeout in seconds
+          type: integer
+        acl_channels_default:
+          description: Determines default pub/sub channels' ACL for new users if ACL
+            is not supplied. When this option is not defined, all_channels is assumed
+            to keep backward compatibility. This option doesn't affect Redis configuration
+            acl-pubsub-default.
+          enum:
+          - allchannels
+          - resetchannels
+          title: Default ACL for pub/sub channels used when Redis user is created
+          type: string
+        number_of_databases:
+          description: Set number of Redis databases. Changing this will cause a restart
+            of the Redis service.
+          example: 16
+          maximum: 128
+          minimum: 1
+          title: Number of Redis databases
+          type: integer
+      title: Redis settings
+      type: object
+    dns-domain-record:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: DNS domain record ID
+        priority:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: DNS domain record priority
+        content:
+          type: string
+          description: DNS domain record content
+        type:
+          type: string
+          enum:
+          - NS
+          - CAA
+          - NAPTR
+          - POOL
+          - A
+          - HINFO
+          - CNAME
+          - SOA
+          - SSHFP
+          - SRV
+          - AAAA
+          - MX
+          - TXT
+          - ALIAS
+          - URL
+          - SPF
+          description: DNS domain record type
+        ttl:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: DNS domain record TTL
+        name:
+          type: string
+          description: DNS domain record name
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: DNS domain record creation date
+        updated-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: DNS domain record update date
+      description: DNS domain record
+    organization:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Organization ID
+        name:
+          type: string
+          readOnly: true
+          description: Organization name
+        address:
+          type: string
+          readOnly: true
+          description: Organization address
+        postcode:
+          type: string
+          readOnly: true
+          description: Organization postcode
+        city:
+          type: string
+          readOnly: true
+          description: Organization city
+        country:
+          type: string
+          readOnly: true
+          description: Organization country
+        balance:
+          type: number
+          readOnly: true
+          description: Organization balance
+        currency:
+          type: string
+          readOnly: true
+          description: Organization currency
+      description: Organization
+    dbaas-service-components:
+      type: object
+      properties:
+        component:
+          type: string
+          description: Service component name
+        host:
+          type: string
+          description: DNS name for connecting to the service component
+        kafka-authentication-method:
+          "$ref": "#/components/schemas/enum-kafka-auth-method"
+          description: Kafka authentication method. This is a value specific to the
+            'kafka' service component
+        path:
+          type: string
+          description: Path component of the service URL (useful only if service component
+            is HTTP or HTTPS endpoint)
+        port:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 65535
+          exclusiveMinimum: false
+          exclusiveMaximum: false
+          description: Port number for connecting to the service component
+        route:
+          type: string
+          enum:
+          - dynamic
+          - private
+          - public
+          - privatelink
+          description: Network access route
+        ssl:
+          type: boolean
+          description: |-
+            Whether the endpoint is encrypted or accepts plaintext.
+                                                       By default endpoints are always encrypted and
+                                                       this property is only included for service components that may disable encryption.
+        usage:
+          type: string
+          enum:
+          - primary
+          - replica
+          description: DNS usage name
+      required:
+      - component
+      - host
+      - port
+      - route
+      - usage
+      description: Service component information objects
+    json-schema-opensearch:
+      additionalProperties: false
+      properties:
+        thread_pool_search_throttled_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: search_throttled thread pool size
+          type: integer
+        thread_pool_analyze_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: analyze thread pool size
+          type: integer
+        thread_pool_get_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: get thread pool size
+          type: integer
+        thread_pool_get_queue_size:
+          description: Size for the thread pool queue. See documentation for exact
+            details.
+          maximum: 2000
+          minimum: 10
+          title: get thread pool queue size
+          type: integer
+        indices_recovery_max_concurrent_file_chunks:
+          description: Number of file chunks sent in parallel for each recovery. Defaults
+            to 2.
+          maximum: 5
+          minimum: 2
+          title: indices.recovery.max_concurrent_file_chunks
+          type: integer
+        indices_queries_cache_size:
+          description: Percentage value. Default is 10%. Maximum amount of heap used
+            for query cache. This is an expert setting. Too low value will decrease
+            query performance and increase performance for other operations; too high
+            value will cause issues with other OpenSearch functionality.
+          maximum: 40
+          minimum: 3
+          title: indices.queries.cache.size
+          type: integer
+        thread_pool_search_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: search thread pool size
+          type: integer
+        indices_recovery_max_bytes_per_sec:
+          description: Limits total inbound and outbound recovery traffic for each
+            node. Applies to both peer recoveries as well as snapshot recoveries (i.e.,
+            restores from a snapshot). Defaults to 40mb
+          maximum: 400
+          minimum: 40
+          title: indices.recovery.max_bytes_per_sec
+          type: integer
+        http_max_initial_line_length:
+          description: The max length of an HTTP URL, in bytes
+          example: 4096
+          maximum: 65536
+          minimum: 1024
+          title: http.max_initial_line_length
+          type: integer
+        enable_security_audit:
+          default: false
+          example: true
+          title: Enable/Disable security audit
+          type: boolean
+        thread_pool_write_queue_size:
+          description: Size for the thread pool queue. See documentation for exact
+            details.
+          maximum: 2000
+          minimum: 10
+          title: write thread pool queue size
+          type: integer
+        script_max_compilations_rate:
+          description: Script compilation circuit breaker limits the number of inline
+            script compilations within a period of time. Default is use-context
+          example: 75/5m
+          maxLength: 1024
+          title: Script max compilation rate - circuit breaker to prevent/minimize
+            OOMs
+          type: string
+        search_max_buckets:
+          description: Maximum number of aggregation buckets allowed in a single response.
+            OpenSearch default value is used when this is not defined.
+          example: 10000
+          maximum: 1000000
+          minimum: 1
+          nullable: true
+          title: search.max_buckets
+          type: integer
+        reindex_remote_whitelist:
+          description: Whitelisted addresses for reindexing. Changing this value will
+            cause all OpenSearch instances to restart.
+          items:
+            example: anotherservice.aivencloud.com:12398
+            maxLength: 261
+            nullable: true
+            title: Address (hostname:port or IP:port)
+            type: string
+          maxItems: 32
+          nullable: true
+          title: reindex_remote_whitelist
+          type: array
+        override_main_response_version:
+          description: Compatibility mode sets OpenSearch to report its version as
+            7.10 so clients continue to work. Default is false
+          example: true
+          title: compatibility.override_main_response_version
+          type: boolean
+        http_max_header_size:
+          description: The max size of allowed headers, in bytes
+          example: 8192
+          maximum: 262144
+          minimum: 1024
+          title: http.max_header_size
+          type: integer
+        email-sender:
+          properties:
+            email_sender_name:
+              description: This should be identical to the Sender name defined in
+                Opensearch dashboards
+              example: alert-sender
+              maxLength: 40
+              pattern: "^[a-zA-Z0-9-_]+$"
+              title: Sender name placeholder to be used in Opensearch Dashboards and
+                Opensearch keystore
+              type: string
+            email_sender_password:
+              description: Sender password for Opensearch alerts to authenticate with
+                SMTP server
+              example: very-secure-mail-password
+              maxLength: 1024
+              pattern: "^[^\\x00-\\x1F]+$"
+              title: Sender password for Opensearch alerts to authenticate with SMTP
+                server
+              type: string
+            email_sender_username:
+              example: jane@example.com
+              maxLength: 320
+              pattern: "^[^\\x00-\\x1F]+$"
+              title: Sender username for Opensearch alerts
+              type: string
+          required:
+          - email_sender_name
+          - email_sender_password
+          - email_sender_username
+          title: Opensearch Email Sender Settings
+          type: object
+        indices_fielddata_cache_size:
+          default: 
+          description: Relative amount. Maximum amount of heap memory used for field
+            data cache. This is an expert setting; decreasing the value too much will
+            increase overhead of loading field data; too much memory used for field
+            data cache will decrease amount of heap available for other operations.
+          maximum: 100
+          minimum: 3
+          nullable: true
+          title: indices.fielddata.cache.size
+          type: integer
+        action_destructive_requires_name:
+          example: true
+          nullable: true
+          title: Require explicit index names when deleting
+          type: boolean
+        plugins_alerting_filter_by_backend_roles:
+          description: Enable or disable filtering of alerting by backend roles. Requires
+            Security plugin. Defaults to false
+          example: false
+          title: plugins.alerting.filter_by_backend_roles
+          type: boolean
+        indices_memory_index_buffer_size:
+          description: Percentage value. Default is 10%. Total amount of heap used
+            for indexing buffer, before writing segments to disk. This is an expert
+            setting. Too low value will slow down indexing; too high value will increase
+            indexing performance but causes performance issues for query performance.
+          maximum: 40
+          minimum: 3
+          title: indices.memory.index_buffer_size
+          type: integer
+        thread_pool_force_merge_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: force_merge thread pool size
+          type: integer
+        auth_failure_listeners:
+          additionalProperties: false
+          properties:
+            internal_authentication_backend_limiting:
+              additionalProperties: false
+              properties:
+                allowed_tries:
+                  description: The number of login attempts allowed before login is
+                    blocked
+                  example: 10
+                  maximum: 2147483647
+                  minimum: 0
+                  title: internal_authentication_backend_limiting.allowed_tries
+                  type: integer
+                authentication_backend:
+                  description: The internal backend. Enter `internal`
+                  enum:
+                  - internal
+                  example: internal
+                  maxLength: 1024
+                  title: internal_authentication_backend_limiting.authentication_backend
+                  type: string
+                block_expiry_seconds:
+                  description: The duration of time that login remains blocked after
+                    a failed login
+                  example: 600
+                  maximum: 2147483647
+                  minimum: 0
+                  title: internal_authentication_backend_limiting.block_expiry_seconds
+                  type: integer
+                max_blocked_clients:
+                  description: The maximum number of blocked IP addresses
+                  example: 100000
+                  maximum: 2147483647
+                  minimum: 0
+                  title: internal_authentication_backend_limiting.max_blocked_clients
+                  type: integer
+                max_tracked_clients:
+                  description: The maximum number of tracked IP addresses that have
+                    failed login
+                  example: 100000
+                  maximum: 2147483647
+                  minimum: 0
+                  title: internal_authentication_backend_limiting.max_tracked_clients
+                  type: integer
+                time_window_seconds:
+                  description: The window of time in which the value for `allowed_tries`
+                    is enforced
+                  example: 3600
+                  maximum: 2147483647
+                  minimum: 0
+                  title: internal_authentication_backend_limiting.time_window_seconds
+                  type: integer
+                type:
+                  description: The type of rate limiting
+                  enum:
+                  - username
+                  example: username
+                  maxLength: 1024
+                  title: internal_authentication_backend_limiting.type
+                  type: string
+              title: Internal Authentication Backend Limiting
+              type: object
+            ip_rate_limiting:
+              additionalProperties: false
+              properties:
+                allowed_tries:
+                  description: The number of login attempts allowed before login is
+                    blocked
+                  example: 10
+                  maximum: 2147483647
+                  minimum: 1
+                  title: ip_rate_limiting.allowed_tries
+                  type: integer
+                block_expiry_seconds:
+                  description: The duration of time that login remains blocked after
+                    a failed login
+                  example: 600
+                  maximum: 36000
+                  minimum: 1
+                  title: ip_rate_limiting.block_expiry_seconds
+                  type: integer
+                max_blocked_clients:
+                  description: The maximum number of blocked IP addresses
+                  example: 100000
+                  maximum: 2147483647
+                  minimum: 0
+                  title: ip_rate_limiting.max_blocked_clients
+                  type: integer
+                max_tracked_clients:
+                  description: The maximum number of tracked IP addresses that have
+                    failed login
+                  example: 100000
+                  maximum: 2147483647
+                  minimum: 0
+                  title: ip_rate_limiting.max_tracked_clients
+                  type: integer
+                time_window_seconds:
+                  description: The window of time in which the value for `allowed_tries`
+                    is enforced
+                  example: 3600
+                  maximum: 36000
+                  minimum: 1
+                  title: ip_rate_limiting.time_window_seconds
+                  type: integer
+                type:
+                  description: The type of rate limiting
+                  enum:
+                  - ip
+                  example: ip
+                  maxLength: 1024
+                  title: ip_rate_limiting.type
+                  type: string
+              title: IP address rate limiting settings
+              type: object
+          title: Opensearch Security Plugin Settings
+          type: object
+        ism-history:
+          properties:
+            ism_enabled:
+              default: true
+              example: true
+              title: Specifies whether ISM is enabled or not
+              type: boolean
+            ism_history_enabled:
+              default: true
+              example: true
+              title: Specifies whether audit history is enabled or not. The logs from
+                ISM are automatically indexed to a logs document.
+              type: boolean
+            ism_history_max_age:
+              default: 24
+              example: 24
+              maximum: 2147483647
+              minimum: 1
+              title: The maximum age before rolling over the audit history index in
+                hours
+              type: integer
+            ism_history_max_docs:
+              default: 2500000
+              example: 2500000
+              maximum: 9223372036854775807
+              minimum: 1
+              title: The maximum number of documents before rolling over the audit
+                history index.
+              type: integer
+            ism_history_rollover_check_period:
+              default: 8
+              example: 8
+              maximum: 2147483647
+              minimum: 1
+              title: The time between rollover checks for the audit history index
+                in hours.
+              type: integer
+            ism_history_rollover_retention_period:
+              default: 30
+              example: 30
+              maximum: 2147483647
+              minimum: 1
+              title: How long audit history indices are kept in days.
+              type: integer
+          required:
+          - ism_enabled
+          title: Opensearch ISM History Settings
+          type: object
+        cluster_routing_allocation_node_concurrent_recoveries:
+          description: How many concurrent incoming/outgoing shard recoveries (normally
+            replicas) are allowed to happen on a node. Defaults to 2.
+          maximum: 16
+          minimum: 2
+          title: Concurrent incoming/outgoing shard recoveries per node
+          type: integer
+        thread_pool_analyze_queue_size:
+          description: Size for the thread pool queue. See documentation for exact
+            details.
+          maximum: 2000
+          minimum: 10
+          title: analyze thread pool queue size
+          type: integer
+        action_auto_create_index_enabled:
+          description: Explicitly allow or block automatic creation of indices. Defaults
+            to true
+          example: false
+          title: action.auto_create_index
+          type: boolean
+        http_max_content_length:
+          description: Maximum content length for HTTP requests to the OpenSearch
+            HTTP API, in bytes.
+          maximum: 2147483647
+          minimum: 1
+          title: http.max_content_length
+          type: integer
+        thread_pool_write_size:
+          description: Size for the thread pool. See documentation for exact details.
+            Do note this may have maximum value depending on CPU count - value is
+            automatically lowered if set to higher than maximum value.
+          maximum: 128
+          minimum: 1
+          title: write thread pool size
+          type: integer
+        thread_pool_search_queue_size:
+          description: Size for the thread pool queue. See documentation for exact
+            details.
+          maximum: 2000
+          minimum: 10
+          title: search thread pool queue size
+          type: integer
+        indices_query_bool_max_clause_count:
+          description: Maximum number of clauses Lucene BooleanQuery can have. The
+            default value (1024) is relatively high, and increasing it may cause performance
+            issues. Investigate other approaches first before increasing this value.
+          maximum: 4096
+          minimum: 64
+          title: indices.query.bool.max_clause_count
+          type: integer
+        thread_pool_search_throttled_queue_size:
+          description: Size for the thread pool queue. See documentation for exact
+            details.
+          maximum: 2000
+          minimum: 10
+          title: search_throttled thread pool queue size
+          type: integer
+        cluster_max_shards_per_node:
+          description: Controls the number of shards allowed in the cluster per data
+            node
+          example: 1000
+          maximum: 10000
+          minimum: 100
+          title: cluster.max_shards_per_node
+          type: integer
+      title: OpenSearch settings
+      type: object
+    dbaas-database-name:
+      type: string
+      maxLength: 40
+      minLength: 1
+    dbaas-user-username:
+      type: string
+      maxLength: 64
+      minLength: 1
+    enum-pg-synchronous-replication:
+      type: string
+      enum:
+      - quorum
+      - 'off'
+    block-storage-snapshot-target:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Block storage snapshot ID
+      description: Target block storage snapshot
+    block-storage-volume:
+      type: object
+      properties:
+        labels:
+          "$ref": "#/components/schemas/labels"
+          description: Resource labels
+        instance:
+          "$ref": "#/components/schemas/instance-target"
+          description: Volume attached instance, if any
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: Volume name
+        state:
+          type: string
+          enum:
+          - snapshotting
+          - deleted
+          - creating
+          - detached
+          - deleting
+          - attaching
+          - error
+          - attached
+          - detaching
+          readOnly: true
+          description: Volume state
+        size:
+          type: integer
+          format: int64
+          minimum: 10
+          exclusiveMinimum: false
+          description: Volume size
+        blocksize:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          readOnly: true
+          description: Volume block size
+        block-storage-snapshots:
+          type: array
+          items:
+            "$ref": "#/components/schemas/block-storage-snapshot-target"
+          description: Volume snapshots, if any
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Volume ID
+        created-at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Volume creation date
+      description: Block storage volume
+    enum-migration-method:
+      type: string
+      enum:
+      - dump
+      - replication
+    enum-sort-order:
+      type: string
+      enum:
+      - desc
+      - asc
+    enum-pg-variant:
+      type: string
+      enum:
+      - timescale
+      - aiven
+    dbaas-service-backup:
+      type: object
+      properties:
+        backup-name:
+          type: string
+          description: Internal name of this backup
+        backup-time:
+          type: string
+          format: date-time
+          description: Backup timestamp (ISO 8601)
+        data-size:
+          type: integer
+          format: int64
+          minimum: 0
+          exclusiveMinimum: false
+          description: Backup's original size before compression
+      required:
+      - backup-name
+      - backup-time
+      - data-size
+      description: List of backups for the service
+    iam-service-policy:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - rules
+          - allow
+          - deny
+        rules:
+          type: array
+          items:
+            "$ref": "#/components/schemas/iam-service-policy-rule"
+servers:
+- url: https://api-{zone}.exoscale.com/v2
+  variables:
+    zone:
+      default: ch-gva-2
+      enum:
+      - ch-gva-2
+      - ch-dk-2
+      - de-fra-1
+      - de-muc-1
+      - at-vie-1
+      - at-vie-2
+      - bg-sof-1
+paths:
+  "/load-balancer/{id}/service/{service-id}":
+    delete:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: service-id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Load Balancer Service
+      operationId: delete-load-balancer-service
+    put:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: service-id
+        schema:
+          type: string
+          format: uuid
+      summary: Update a Load Balancer Service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  description: Load Balancer Service name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Load Balancer Service description
+                protocol:
+                  type: string
+                  enum:
+                  - tcp
+                  - udp
+                  description: Network traffic protocol
+                strategy:
+                  type: string
+                  enum:
+                  - round-robin
+                  - maglev-hash
+                  - source-hash
+                  description: Load balancing strategy
+                port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Port exposed on the Load Balancer's public IP
+                target-port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Port on which the network traffic will be forwarded
+                    to on the receiving instance
+                healthcheck:
+                  "$ref": "#/components/schemas/load-balancer-service-healthcheck"
+                  description: Healthcheck configuration
+      operationId: update-load-balancer-service
+    get:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/load-balancer-service"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: service-id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Load Balancer Service details
+      operationId: get-load-balancer-service
+  "/dbaas-opensearch/{name}/acl-config":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-opensearch-acl-config"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get DBaaS OpenSearch ACL configuration
+      operationId: get-dbaas-opensearch-acl-config
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS OpenSearch ACL configuration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dbaas-opensearch-acl-config"
+      operationId: update-dbaas-opensearch-acl-config
+  "/instance-pool/{id}:scale":
+    put:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Scale an Instance Pool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: Number of managed Instances
+              required:
+              - size
+      operationId: scale-instance-pool
+  "/instance/{id}:create-snapshot":
+    post:
+      tags:
+      - instance
+      - snapshot
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Create a Snapshot of a Compute instance
+      operationId: create-snapshot
+  "/reverse-dns/elastic-ip/{id}":
+    get:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/reverse-dns-record"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Query the PTR DNS records for an elastic IP
+      operationId: get-reverse-dns-elastic-ip
+    post:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update/Create the PTR DNS record for an elastic IP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain-name:
+                  type: string
+                  maxLength: 253
+                  minLength: 1
+      operationId: update-reverse-dns-elastic-ip
+    delete:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete the PTR DNS record for an elastic IP
+      operationId: delete-reverse-dns-elastic-ip
+  "/anti-affinity-group":
+    get:
+      tags:
+      - anti-affinity-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  anti-affinity-groups:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/anti-affinity-group"
+      description: ''
+      parameters: []
+      summary: List Anti-affinity Groups
+      operationId: list-anti-affinity-groups
+    post:
+      tags:
+      - anti-affinity-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create an Anti-affinity Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Anti-affinity Group name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Anti-affinity Group description
+              required:
+              - name
+      operationId: create-anti-affinity-group
+  "/event":
+    get:
+      tags:
+      - event
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/event"
+      description: |-
+        Retrieve Mutation Events for a given date range. Defaults to retrieving Events for the past 24 hours.
+                 Both a `from` and `to` arguments can be specified to filter Events over a specific period.
+                 Events will be the the most descriptive possible but not all fields are mandatory
+      parameters:
+      - in: query
+        required: false
+        name: from
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        required: false
+        name: to
+        schema:
+          type: string
+          format: date-time
+      summary: List Events
+      operationId: list-events
+  "/security-group/{id}/rules/{rule-id}":
+    delete:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: rule-id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Security Group rule
+      operationId: delete-rule-from-security-group
+  "/dbaas-grafana/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate Grafana maintenance update
+      operationId: start-dbaas-grafana-maintenance
+  "/dbaas-postgres/{service}/upgrade-check":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-task"
+      description: Check whether you can upgrade Postgres service to a newer version
+      parameters:
+      - in: path
+        required: true
+        name: service
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: ''
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                target-version:
+                  "$ref": "#/components/schemas/dbaas-pg-target-versions"
+                  description: Target version for upgrade
+              required:
+              - target-version
+      operationId: create-dbaas-pg-upgrade-check
+  "/dbaas-mysql/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS mysql user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+                authentication:
+                  "$ref": "#/components/schemas/enum-mysql-authentication-plugin"
+                  description: Authentication method
+      operationId: reset-dbaas-mysql-user-password
+  "/dbaas-redis/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-redis-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS Redis user
+      operationId: reveal-dbaas-redis-user-password
+  "/load-balancer":
+    post:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create a Load Balancer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Load Balancer description
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Load Balancer name
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Load balancer labels
+              required:
+              - name
+      operationId: create-load-balancer
+    get:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  load-balancers:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/load-balancer"
+      description: ''
+      parameters: []
+      summary: List Load Balancers
+      operationId: list-load-balancers
+  "/security-group":
+    post:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create a Security Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Security Group name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Security Group description
+              required:
+              - name
+      operationId: create-security-group
+    get:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  security-groups:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/security-group"
+      description: |-
+        Lists security groups. When visibility is set to public, lists public security groups.
+        Public security groups are objects maintained by Exoscale which contain source addresses for
+        relevant services hosted by Exoscale. They can be used a source in ingress rules and as a destination
+        in egress rules.
+      parameters:
+      - in: query
+        required: false
+        name: visibility
+        schema:
+          type: string
+          enum:
+          - private
+          - public
+      summary: List Security Groups.
+      operationId: list-security-groups
+  "/dbaas-postgres/{service-name}/connection-pool":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS PostgreSQL connection pool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  "$ref": "#/components/schemas/dbaas-pg-pool-name"
+                  description: Connection pool name
+                database-name:
+                  "$ref": "#/components/schemas/dbaas-database-name"
+                  description: Service database name
+                mode:
+                  "$ref": "#/components/schemas/enum-pg-pool-mode"
+                  description: PGBouncer pool mode
+                size:
+                  "$ref": "#/components/schemas/dbaas-pg-pool-size"
+                  description: Size of PGBouncer's PostgreSQL side connection pool
+                username:
+                  "$ref": "#/components/schemas/dbaas-pg-pool-username"
+                  description: Pool username
+              required:
+              - name
+              - database-name
+      operationId: create-dbaas-pg-connection-pool
+  "/dbaas-mysql/{name}":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a DBaaS MySQL service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS MySQL service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                mysql-settings:
+                  "$ref": "#/components/schemas/json-schema-mysql"
+                  description: MySQL-specific settings
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+                binlog-retention-period:
+                  type: integer
+                  format: int64
+                  minimum: 600
+                  maximum: 86400
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: The minimum amount of time in seconds to keep binlog
+                    entries before deletion. This may be extended for services that
+                    require binlog entries for longer than the default for example
+                    if using the MySQL Debezium Kafka connector.
+                backup-schedule:
+                  type: object
+                  properties:
+                    backup-hour:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 23
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The hour of day (in UTC) when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                    backup-minute:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 59
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The minute of an hour when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+      operationId: update-dbaas-service-mysql
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-mysql"
+      description: Get a DBaaS MySQL service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS MySQL service
+      operationId: get-dbaas-service-mysql
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS MySQL service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS MySQL service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                backup-schedule:
+                  type: object
+                  properties:
+                    backup-hour:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 23
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The hour of day (in UTC) when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                    backup-minute:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 59
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The minute of an hour when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                integrations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - read_replica
+                        description: Integration type
+                      source-service:
+                        "$ref": "#/components/schemas/dbaas-service-name"
+                        description: A source service
+                      dest-service:
+                        "$ref": "#/components/schemas/dbaas-service-name"
+                        description: A destination service
+                      settings:
+                        type: object
+                        description: Integration settings
+                    required:
+                    - type
+                  description: Service integrations to be enabled when creating the
+                    service.
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                fork-from-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: Service to fork from
+                recovery-backup-time:
+                  type: string
+                  minLength: 1
+                  description: ISO time of a backup to recover from for services that
+                    support arbitrary times
+                mysql-settings:
+                  "$ref": "#/components/schemas/json-schema-mysql"
+                  description: MySQL-specific settings
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                admin-username:
+                  type: string
+                  maxLength: 64
+                  minLength: 1
+                  pattern: "^[_A-Za-z0-9][-._A-Za-z0-9]{0,63}$"
+                  description: Custom username for admin user. This must be set only
+                    when a new service is being created.
+                version:
+                  type: string
+                  minLength: 1
+                  description: MySQL major version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                admin-password:
+                  type: string
+                  maxLength: 256
+                  minLength: 8
+                  pattern: "^[a-zA-Z0-9-_]+$"
+                  description: Custom password for admin user. Defaults to random
+                    string. This must be set only when a new service is being created.
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+                binlog-retention-period:
+                  type: integer
+                  format: int64
+                  minimum: 600
+                  maximum: 86400
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: The minimum amount of time in seconds to keep binlog
+                    entries before deletion. This may be extended for services that
+                    require binlog entries for longer than the default for example
+                    if using the MySQL Debezium Kafka connector.
+              required:
+              - plan
+      operationId: create-dbaas-service-mysql
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a MySQL service
+      operationId: delete-dbaas-service-mysql
+  "/private-network/{id}:attach":
+    put:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Attach a Compute instance to a Private Network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ip:
+                  type: string
+                  format: ipv4
+                  description: Static IP address lease for the corresponding network
+                    interface
+                instance:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      description: Instance ID
+                  description: Compute instance
+              required:
+              - instance
+      operationId: attach-instance-to-private-network
+  "/dbaas-mysql/{service-name}/user":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS MySQL user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  "$ref": "#/components/schemas/dbaas-user-username"
+                  description: Username
+                authentication:
+                  "$ref": "#/components/schemas/enum-mysql-authentication-plugin"
+                  description: Authentication option
+              required:
+              - username
+      operationId: create-dbaas-mysql-user
+  "/dbaas-service-type":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dbaas-service-types:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/dbaas-service-type"
+      description: List available service types for DBaaS
+      parameters: []
+      summary: DBaaS Service Types
+      operationId: list-dbaas-service-types
+  "/instance-type/{id}":
+    get:
+      tags:
+      - instance-type
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/instance-type"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Instance Type details
+      operationId: get-instance-type
+  "/instance/{id}:password":
+    get:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/instance-password"
+      description: |-
+        Reveal the password used during instance creation or the latest password reset.
+                    This is only available for VMs created against templates having the `password-enabled`
+                    property set to `true`.
+
+                    Passwords are transiently stored for at most 24 hours and intended to be retrieved shortly after
+                    creation or resets.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Reveal the password used during instance creation or the latest password
+        reset.
+      operationId: reveal-instance-password
+  "/instance/{id}:resize-disk":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 'This operation resizes a Compute instance''s disk volume. Note:
+        the disk can only grow, cannot be shrunk.'
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Resize a Compute instance disk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Instance disk size in GiB
+              required:
+              - disk-size
+      operationId: resize-instance-disk
+  "/dbaas-service":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dbaas-services:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/dbaas-service-common"
+      description: List DBaaS services
+      parameters: []
+      summary: List DBaaS services
+      operationId: list-dbaas-services
+  "/elastic-ip":
+    post:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create an Elastic IP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                addressfamily:
+                  type: string
+                  enum:
+                  - inet4
+                  - inet6
+                  description: 'Elastic IP address family (default: :inet4)'
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Elastic IP description
+                healthcheck:
+                  "$ref": "#/components/schemas/elastic-ip-healthcheck"
+                  description: Elastic IP healthcheck
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+      operationId: create-elastic-ip
+    get:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  elastic-ips:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/elastic-ip"
+      description: ''
+      parameters: []
+      summary: List Elastic IPs
+      operationId: list-elastic-ips
+  "/zone":
+    get:
+      tags:
+      - zone
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  zones:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/zone"
+      description: ''
+      parameters: []
+      summary: List Zones
+      operationId: list-zones
+  "/instance-pool":
+    get:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  instance-pools:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/instance-pool"
+      description: ''
+      parameters: []
+      summary: List Instance Pools
+      operationId: list-instance-pools
+    post:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create an Instance Pool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                anti-affinity-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/anti-affinity-group"
+                  uniqueItems: true
+                  description: Instance Pool Anti-affinity Groups
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Instance Pool description
+                public-ip-assignment:
+                  type: string
+                  enum:
+                  - inet4
+                  - dual
+                  - none
+                  description: Determines public IP assignment of the Instances. Type
+                    `none` is final and can't be changed later on.
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Instance Pool Labels
+                security-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/security-group"
+                  uniqueItems: true
+                  description: Instance Pool Security Groups
+                elastic-ips:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/elastic-ip"
+                  uniqueItems: true
+                  description: Instances Elastic IPs
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Instance Pool name
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Instances type
+                min-available:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  description: Minimum number of running Instances
+                private-networks:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/private-network"
+                  uniqueItems: true
+                  description: Instance Pool Private Networks
+                template:
+                  "$ref": "#/components/schemas/template"
+                  description: Instances template
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: Number of Instances
+                ssh-key:
+                  "$ref": "#/components/schemas/ssh-key"
+                  description: Instances SSH key
+                instance-prefix:
+                  type: string
+                  maxLength: 30
+                  minLength: 1
+                  description: 'Prefix to apply to Instances names (default: pool)'
+                user-data:
+                  type: string
+                  minLength: 1
+                  description: Instances Cloud-init user-data
+                deploy-target:
+                  "$ref": "#/components/schemas/deploy-target"
+                  description: Deploy Target to deploy Instances on
+                ipv6-enabled:
+                  type: boolean
+                  description: 'Enable IPv6. DEPRECATED: use `public-ip-assignments`.'
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Instances disk size in GiB
+                ssh-keys:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/ssh-key"
+                  uniqueItems: true
+                  description: Instances SSH Keys
+              required:
+              - name
+              - size
+              - instance-type
+              - template
+              - disk-size
+      operationId: create-instance-pool
+  "/sks-cluster-kubeconfig/{id}":
+    post:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  kubeconfig:
+                    type: string
+      description: This operation returns a Kubeconfig file encoded in base64.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Generate a new Kubeconfig file for a SKS cluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/sks-kubeconfig-request"
+      operationId: generate-sks-cluster-kubeconfig
+  "/dns-domain/{domain-id}/record":
+    get:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dns-domain-records:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/dns-domain-record"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: domain-id
+        schema:
+          type: string
+          format: uuid
+      summary: List DNS domain records
+      operationId: list-dns-domain-records
+    post:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: domain-id
+        schema:
+          type: string
+          format: uuid
+      summary: Create DNS domain record
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: DNS domain record name
+                type:
+                  type: string
+                  enum:
+                  - NS
+                  - CAA
+                  - NAPTR
+                  - POOL
+                  - A
+                  - HINFO
+                  - CNAME
+                  - SSHFP
+                  - SRV
+                  - AAAA
+                  - MX
+                  - TXT
+                  - ALIAS
+                  - URL
+                  - SPF
+                  description: DNS domain record type
+                content:
+                  type: string
+                  description: DNS domain record content
+                ttl:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  description: DNS domain record TTL
+                priority:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  description: DNS domain record priority
+              required:
+              - name
+              - type
+              - content
+      operationId: create-dns-domain-record
+  "/dbaas-ca-certificate":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  certificate:
+                    type: string
+      description: Returns a CA Certificate required to reach a DBaaS service through
+        a TLS-protected connection.
+      parameters: []
+      summary: Get DBaaS CA Certificate
+      operationId: get-dbaas-ca-certificate
+  "/dbaas-settings-grafana":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      grafana:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Grafana configuration values
+      description: Get DBaaS Grafana settings
+      parameters: []
+      summary: Get DBaaS Grafana settings
+      operationId: get-dbaas-settings-grafana
+  "/deploy-target":
+    get:
+      tags:
+      - deploy-target
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deploy-targets:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/deploy-target"
+      description: ''
+      parameters: []
+      summary: List Deploy Targets
+      operationId: list-deploy-targets
+  "/instance-type":
+    get:
+      tags:
+      - instance-type
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  instance-types:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/instance-type"
+      description: ''
+      parameters: []
+      summary: List Compute instance Types
+      operationId: list-instance-types
+  "/dbaas-postgres/{service-name}/database/{database-name}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: database-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-pg-database-name"
+      summary: Delete a DBaaS Postgres database
+      operationId: delete-dbaas-pg-database
+  "/block-storage/{id}:attach":
+    put:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Attach block storage volume to an instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance-target"
+                  description: Instance to attach to, this can only be done if the
+                    volume is not currently attached
+              required:
+              - instance
+      operationId: attach-block-storage-volume-to-instance
+  "/dbaas-postgres/{name}/migration/stop":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Stop a DBaaS PostgreSQL migration
+      operationId: stop-dbaas-pg-migration
+  "/dbaas-kafka/{name}":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-kafka"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS Kafka service
+      operationId: get-dbaas-service-kafka
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS Kafka service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Kafka service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authentication-methods:
+                  type: object
+                  properties:
+                    certificate:
+                      type: boolean
+                      description: Enable certificate/SSL authentication
+                    sasl:
+                      type: boolean
+                      description: Enable SASL authentication
+                  description: Kafka authentication methods
+                kafka-rest-enabled:
+                  type: boolean
+                  description: Enable Kafka-REST service
+                kafka-connect-enabled:
+                  type: boolean
+                  description: Allow clients to connect to kafka_connect from the
+                    public internet for service nodes that are in a project VPC or
+                    another type of private network
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                schema-registry-settings:
+                  "$ref": "#/components/schemas/json-schema-schema-registry"
+                  description: Schema Registry configuration
+                kafka-rest-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka-rest"
+                  description: Kafka REST configuration
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                kafka-connect-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka-connect"
+                  description: Kafka Connect configuration values
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                kafka-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka"
+                  description: Kafka-specific settings
+                schema-registry-enabled:
+                  type: boolean
+                  description: Enable Schema-Registry service
+                version:
+                  type: string
+                  minLength: 1
+                  description: Kafka major version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+              required:
+              - plan
+      operationId: create-dbaas-service-kafka
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a DBaaS Kafka service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS Kafka service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authentication-methods:
+                  type: object
+                  properties:
+                    certificate:
+                      type: boolean
+                      description: Enable certificate/SSL authentication
+                    sasl:
+                      type: boolean
+                      description: Enable SASL authentication
+                  description: Kafka authentication methods
+                kafka-rest-enabled:
+                  type: boolean
+                  description: Enable Kafka-REST service
+                kafka-connect-enabled:
+                  type: boolean
+                  description: Allow clients to connect to kafka_connect from the
+                    public internet for service nodes that are in a project VPC or
+                    another type of private network
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                schema-registry-settings:
+                  "$ref": "#/components/schemas/json-schema-schema-registry"
+                  description: Schema Registry configuration
+                kafka-rest-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka-rest"
+                  description: Kafka REST configuration
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                kafka-connect-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka-connect"
+                  description: Kafka Connect configuration values
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                kafka-settings:
+                  "$ref": "#/components/schemas/json-schema-kafka"
+                  description: Kafka-specific settings
+                schema-registry-enabled:
+                  type: boolean
+                  description: Enable Schema-Registry service
+                version:
+                  type: string
+                  minLength: 1
+                  description: Kafka major version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+      operationId: update-dbaas-service-kafka
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a Kafka service
+      operationId: delete-dbaas-service-kafka
+  "/instance/{id}:reset-password":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Reset a compute instance password
+      operationId: reset-instance-password
+  "/dbaas-settings-redis":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      redis:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Redis configuration values
+      description: Returns the default settings for Redis.
+      parameters: []
+      summary: Get DBaaS Redis settings
+      operationId: get-dbaas-settings-redis
+  "/dbaas-kafka/{name}/schema-registry/acl-config":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Add a Kafka Schema Registry ACL entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dbaas-kafka-schema-registry-acl-entry"
+      operationId: create-dbaas-kafka-schema-registry-acl-config
+  "/private-network/{id}:update-ip":
+    put:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update the IP address of an instance attached to a managed private
+        network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ip:
+                  type: string
+                  format: ipv4
+                  description: Static IP address lease for the corresponding network
+                    interface
+                instance:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      description: Instance ID
+                  required:
+                  - id
+      operationId: update-private-network-instance-ip
+  "/sks-cluster/{id}/nodepool/{sks-nodepool-id}":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      summary: Update an SKS Nodepool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                anti-affinity-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/anti-affinity-group"
+                  uniqueItems: true
+                  description: Nodepool Anti-affinity Groups
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Nodepool description
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Nodepool labels
+                taints:
+                  "$ref": "#/components/schemas/sks-nodepool-taints"
+                  description: Nodepool taints
+                security-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/security-group"
+                  uniqueItems: true
+                  description: Nodepool Security Groups
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Nodepool name
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Nodepool instances type
+                private-networks:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/private-network"
+                  uniqueItems: true
+                  description: Nodepool Private Networks
+                instance-prefix:
+                  type: string
+                  maxLength: 30
+                  minLength: 1
+                  description: 'Prefix to apply to managed instances names (default:
+                    pool)'
+                deploy-target:
+                  "$ref": "#/components/schemas/deploy-target"
+                  nullable: true
+                  description: Nodepool Deploy Target
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 20
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Nodepool instances disk size in GiB
+      operationId: update-sks-nodepool
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/sks-nodepool"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve SKS Nodepool details
+      operationId: get-sks-nodepool
+    delete:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete an SKS Nodepool
+      operationId: delete-sks-nodepool
+  "/block-storage-snapshot/{id}":
+    delete:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a block storage snapshot, data will be unrecoverable
+      operationId: delete-block-storage-snapshot
+    put:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update block storage volume snapshot
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  description: Snapshot name
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  nullable: true
+                  description: Resource labels
+      operationId: update-block-storage-snapshot
+    get:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/block-storage-snapshot"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve block storage snapshot details
+      operationId: get-block-storage-snapshot
+  "/dbaas-postgres/{service-name}/user":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Postgres user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  "$ref": "#/components/schemas/dbaas-user-username"
+                  description: Username
+                allow-replication:
+                  type: boolean
+              required:
+              - username
+      operationId: create-dbaas-postgres-user
+  "/instance-pool/{id}":
+    delete:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete an Instance Pool
+      operationId: delete-instance-pool
+    get:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/instance-pool"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Instance Pool details
+      operationId: get-instance-pool
+    put:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update an Instance Pool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                anti-affinity-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/anti-affinity-group"
+                  uniqueItems: true
+                  nullable: true
+                  description: Instance Pool Anti-affinity Groups
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Instance Pool description
+                public-ip-assignment:
+                  type: string
+                  enum:
+                  - inet4
+                  - dual
+                  description: Determines public IP assignment of the Instances.
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Instance Pool Labels
+                security-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/security-group"
+                  uniqueItems: true
+                  nullable: true
+                  description: Instance Pool Security Groups
+                elastic-ips:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/elastic-ip"
+                  nullable: true
+                  description: Instances Elastic IPs
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Instance Pool name
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Instances type
+                min-available:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  nullable: true
+                  description: Minimum number of running Instances
+                private-networks:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/private-network"
+                  uniqueItems: true
+                  nullable: true
+                  description: Instance Pool Private Networks
+                template:
+                  "$ref": "#/components/schemas/template"
+                  description: Instances template
+                ssh-key:
+                  "$ref": "#/components/schemas/ssh-key"
+                  nullable: true
+                  description: Instances SSH key
+                instance-prefix:
+                  type: string
+                  nullable: true
+                  description: 'Prefix to apply to Instances names (default: pool)'
+                user-data:
+                  type: string
+                  minLength: 1
+                  nullable: true
+                  description: Instances Cloud-init user-data
+                deploy-target:
+                  "$ref": "#/components/schemas/deploy-target"
+                  nullable: true
+                  description: Instance Pool Deploy Target
+                ipv6-enabled:
+                  type: boolean
+                  description: 'Enable IPv6. DEPRECATED: use `public-ip-assignments`.'
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Instances disk size in GiB
+                ssh-keys:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/ssh-key"
+                  uniqueItems: true
+                  nullable: true
+                  description: Instances SSH keys
+      operationId: update-instance-pool
+  "/private-network":
+    get:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  private-networks:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/private-network"
+      description: ''
+      parameters: []
+      summary: List Private Networks
+      operationId: list-private-networks
+    post:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create a Private Network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Private Network name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Private Network description
+                netmask:
+                  type: string
+                  format: ipv4
+                  description: Private Network netmask
+                start-ip:
+                  type: string
+                  format: ipv4
+                  description: Private Network start IP address
+                end-ip:
+                  type: string
+                  format: ipv4
+                  description: Private Network end IP address
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+              required:
+              - name
+      operationId: create-private-network
+  "/instance/{id}:start":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: This operation starts a virtual machine, potentially using a rescue
+        profile if specified
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Start a Compute instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rescue-profile:
+                  type: string
+                  enum:
+                  - netboot-efi
+                  - netboot
+                  description: 'Boot in Rescue Mode, using named profile (supported:
+                    netboot, netboot-efi)'
+      operationId: start-instance
+  "/organization":
+    get:
+      tags:
+      - organization
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/organization"
+      description: ''
+      parameters: []
+      summary: Retrieve an organization
+      operationId: get-organization
+  "/dbaas-redis/{service-name}/user/{username}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Delete a DBaaS Redis user
+      operationId: delete-dbaas-redis-user
+  "/security-group/{id}":
+    get:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/security-group"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Security Group details
+      operationId: get-security-group
+    delete:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Security Group
+      operationId: delete-security-group
+  "/sks-cluster/{id}/authority/{authority}/cert":
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cacert:
+                    type: string
+      description: This operation returns the certificate for the given SKS cluster
+        authority encoded in base64.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: authority
+        schema:
+          type: string
+          enum:
+          - control-plane
+          - aggregation
+          - kubelet
+      summary: Get the certificate for a SKS cluster authority
+      operationId: get-sks-cluster-authority-cert
+  "/snapshot/{id}:export":
+    post:
+      tags:
+      - snapshot
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Export a Snapshot
+      operationId: export-snapshot
+  "/elastic-ip/{id}/{field}":
+    delete:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - description
+      summary: Reset an Elastic IP field to its default value
+      operationId: reset-elastic-ip-field
+  "/quota/{entity}":
+    get:
+      tags:
+      - quotas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/quota"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: entity
+        schema:
+          type: string
+      summary: Retrieve Resource Quota
+      operationId: get-quota
+  "/sks-cluster-deprecated-resources/{id}":
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/sks-cluster-deprecated-resource"
+      description: This operation returns the deprecated resources for a given cluster
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Resources that are scheduled to be removed in future kubernetes releases
+      operationId: list-sks-cluster-deprecated-resources
+  "/block-storage/{id}":
+    get:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/block-storage-volume"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve block storage volume details
+      operationId: get-block-storage-volume
+    put:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update block storage volume
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  description: Volume name
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  nullable: true
+                  description: Resource labels
+      operationId: update-block-storage-volume
+    delete:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a block storage volume, data will be unrecoverable
+      operationId: delete-block-storage-volume
+  "/dbaas-opensearch/{service-name}/user/{username}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Delete a DBaaS OpenSearch user
+      operationId: delete-dbaas-opensearch-user
+  "/block-storage/{id}:create-snapshot":
+    post:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Create a block storage snapshot
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Snapshot name
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+      operationId: create-block-storage-snapshot
+  "/private-network/{id}:detach":
+    put:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Detach a Compute instance from a Private Network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance"
+                  description: Compute instance
+              required:
+              - instance
+      operationId: detach-instance-from-private-network
+  "/private-network/{id}":
+    put:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update a Private Network
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Private Network name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Private Network description
+                netmask:
+                  type: string
+                  format: ipv4
+                  description: Private Network netmask
+                start-ip:
+                  type: string
+                  format: ipv4
+                  description: Private Network start IP address
+                end-ip:
+                  type: string
+                  format: ipv4
+                  description: Private Network end IP address
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+      operationId: update-private-network
+    get:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/private-network"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Private Network details
+      operationId: get-private-network
+    delete:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Private Network
+      operationId: delete-private-network
+  "/load-balancer/{id}/{field}":
+    delete:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - description
+          - labels
+      summary: Reset a Load Balancer field to its default value
+      operationId: reset-load-balancer-field
+  "/instance/{id}:scale":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 'This operation changes the Compute instance''s type. Note: the
+        new Instance Type must be within the same family (e.g. a standard instance
+        cannot be scaled to gpu2 or storage).'
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Scale a Compute instance to a new Instance Type
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Instance Type
+              required:
+              - instance-type
+      operationId: scale-instance
+  "/api-key":
+    post:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/iam-api-key-created"
+      description: 
+      parameters: []
+      summary: Create a new API key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role-id:
+                  type: string
+                  format: uuid
+                  description: IAM API Key Role ID
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: IAM API Key Name
+              required:
+              - role-id
+              - name
+      operationId: create-api-key
+    get:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  api-keys:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/iam-api-key"
+      description: 
+      parameters: []
+      summary: List API keys
+      operationId: list-api-keys
+  "/block-storage-snapshot":
+    get:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  block-storage-snapshots:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/block-storage-snapshot"
+      description: ''
+      parameters: []
+      summary: List block storage snapshots
+      operationId: list-block-storage-snapshots
+  "/dns-domain":
+    get:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dns-domains:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/dns-domain"
+      description: ''
+      parameters: []
+      summary: List DNS domains
+      operationId: list-dns-domains
+    post:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dns-domain"
+      description: ''
+      parameters: []
+      summary: Create DNS domain
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                unicode-name:
+                  type: string
+                  description: Domain name
+              description: DNS Domain
+      operationId: create-dns-domain
+  "/instance/{id}:stop":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Stop a Compute instance
+      operationId: stop-instance
+  "/dns-domain/{domain-id}/record/{record-id}":
+    get:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dns-domain-record"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: domain-id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: record-id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve DNS domain record details
+      operationId: get-dns-domain-record
+    put:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: domain-id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: record-id
+        schema:
+          type: string
+          format: uuid
+      summary: Update DNS domain record
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: DNS domain record name
+                content:
+                  type: string
+                  description: DNS domain record content
+                ttl:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: DNS domain record TTL
+                priority:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: DNS domain record priority
+      operationId: update-dns-domain-record
+    delete:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: domain-id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: record-id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete DNS domain record
+      operationId: delete-dns-domain-record
+  "/dbaas-kafka/{service-name}/user":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Kafka user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  "$ref": "#/components/schemas/dbaas-user-username"
+                  description: Username
+              required:
+              - username
+      operationId: create-dbaas-kafka-user
+  "/security-group/{id}:attach":
+    put:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Attach a Compute instance to a Security Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance"
+                  description: Compute instance
+              required:
+              - instance
+      operationId: attach-instance-to-security-group
+  "/snapshot/{id}":
+    delete:
+      tags:
+      - snapshot
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Snapshot
+      operationId: delete-snapshot
+    get:
+      tags:
+      - snapshot
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/snapshot"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Snapshot details
+      operationId: get-snapshot
+  "/sks-cluster/{id}/nodepool/{sks-nodepool-id}:scale":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      summary: Scale a SKS Nodepool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: Number of instances
+              required:
+              - size
+      operationId: scale-sks-nodepool
+  "/dbaas-settings-mysql":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      mysql:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: mysql.conf configuration values
+      description: Get DBaaS MySQL settings
+      parameters: []
+      summary: Get DBaaS MySQL settings
+      operationId: get-dbaas-settings-mysql
+  "/sks-cluster/{id}/upgrade-service-level":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Upgrade a SKS cluster to pro
+      operationId: upgrade-sks-cluster-service-level
+  "/api-key/{id}":
+    delete:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+      summary: Delete an API key
+      operationId: delete-api-key
+    get:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/iam-api-key"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+      summary: Get API key
+      operationId: get-api-key
+  "/load-balancer/{id}/service/{service-id}/{field}":
+    delete:
+      tags:
+      - network-load-balancer
+      - compute
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: service-id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - description
+      summary: Reset a Load Balancer Service field to its default value
+      operationId: reset-load-balancer-service-field
+  "/dbaas-postgres/{service-name}/database":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Postgres database
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                database-name:
+                  "$ref": "#/components/schemas/dbaas-database-name"
+                  description: Service database name
+                lc-collate:
+                  type: string
+                  maxLength: 128
+                  description: Default string sort order (LC_COLLATE) for PostgreSQL
+                    database
+                lc-ctype:
+                  type: string
+                  maxLength: 128
+                  description: Default character classification (LC_CTYPE) for PostgreSQL
+                    database
+              required:
+              - database-name
+      operationId: create-dbaas-pg-database
+  "/security-group/{id}/rules":
+    post:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Create a Security Group rule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                flow-direction:
+                  type: string
+                  enum:
+                  - ingress
+                  - egress
+                  description: Network flow direction to match
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Security Group rule description
+                network:
+                  type: string
+                  description: CIDR-formatted network allowed
+                security-group:
+                  "$ref": "#/components/schemas/security-group-resource"
+                  description: Security Group allowed
+                protocol:
+                  type: string
+                  enum:
+                  - tcp
+                  - esp
+                  - icmp
+                  - udp
+                  - gre
+                  - ah
+                  - ipip
+                  - icmpv6
+                  description: Network protocol
+                icmp:
+                  type: object
+                  properties:
+                    code:
+                      type: integer
+                      format: int64
+                      minimum: -1
+                      maximum: 254
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                    type:
+                      type: integer
+                      format: int64
+                      minimum: -1
+                      maximum: 254
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                  description: 'ICMP details (default: -1 (ANY))'
+                start-port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Start port of the range
+                end-port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: End port of the range
+              required:
+              - flow-direction
+              - protocol
+      operationId: add-rule-to-security-group
+  "/dbaas-opensearch/{service-name}/user":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS OpenSearch user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  "$ref": "#/components/schemas/dbaas-user-username"
+                  description: Username
+              required:
+              - username
+      operationId: create-dbaas-opensearch-user
+  "/dbaas-integration-types":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dbaas-integration-types:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/dbaas-integration-type"
+      description: Get DBaaS integration types
+      parameters: []
+      summary: Get DBaaS integration types
+      operationId: list-dbaas-integration-types
+  "/dbaas-postgres/{service-name}/user/{username}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Delete a DBaaS Postgres user
+      operationId: delete-dbaas-postgres-user
+  "/instance/{id}:add-protection":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Set instance destruction protection
+      operationId: add-instance-protection
+  "/dbaas-postgres/{service-name}/user/{username}/allow-replication":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-postgres-users"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Update access control for one service user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                allow-replication:
+                  type: boolean
+      operationId: update-dbaas-postgres-allow-replication
+  "/iam-role/{id}":
+    put:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update IAM Role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: IAM Role description
+                permissions:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - bypass-governance-retention
+                  uniqueItems: true
+                  description: IAM Role permissions
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: IAM Role labels
+      operationId: update-iam-role
+    get:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/iam-role"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve IAM Role
+      operationId: get-iam-role
+    delete:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete IAM Role
+      operationId: delete-iam-role
+  "/instance/{id}/{field}":
+    delete:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - labels
+      summary: Reset Instance field
+      operationId: reset-instance-field
+  "/instance-pool/{id}/{field}":
+    delete:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - anti-affinity-groups
+          - description
+          - labels
+          - security-groups
+          - elastic-ips
+          - private-networks
+          - ssh-key
+          - user-data
+          - deploy-target
+          - ipv6-enabled
+      summary: Reset an Instance Pool field to its default value
+      operationId: reset-instance-pool-field
+  "/instance/{id}:remove-protection":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Remove instance destruction protection
+      operationId: remove-instance-protection
+  "/dbaas-kafka/{name}/topic/acl-config":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Add a Kafka topic ACL entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/dbaas-kafka-topic-acl-entry"
+      operationId: create-dbaas-kafka-topic-acl-config
+  "/snapshot":
+    get:
+      tags:
+      - snapshot
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  snapshots:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/snapshot"
+      description: ''
+      parameters: []
+      summary: List Snapshots
+      operationId: list-snapshots
+  "/operation/{id}":
+    get:
+      tags:
+      - operation
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Operation details
+      operationId: get-operation
+  "/dns-domain/{id}/zone":
+    get:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  zone-file:
+                    type: string
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve DNS domain zone file
+      operationId: get-dns-domain-zone-file
+  "/dbaas-mysql/{service-name}/database/{database-name}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: database-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-mysql-database-name"
+      summary: Delete a DBaaS MySQL database
+      operationId: delete-dbaas-mysql-database
+  "/security-group/{id}:remove-source":
+    put:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Remove an external source from a Security Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cidr:
+                  type: string
+                  description: CIDR-formatted network to remove
+              required:
+              - cidr
+      operationId: remove-external-source-from-security-group
+  "/iam-organization-policy":
+    get:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/iam-policy"
+      description: ''
+      parameters: []
+      summary: Retrieve IAM Organization Policy
+      operationId: get-iam-organization-policy
+    put:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Update IAM Organization Policy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/iam-policy"
+      operationId: update-iam-organization-policy
+  "/dbaas-service-logs/{service-name}":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-logs"
+      description: Get logs of DBaaS service
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          type: string
+      summary: Get logs of DBaaS service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 500
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: 'How many log entries to receive at most, up to 500
+                    (default: 100)'
+                sort-order:
+                  "$ref": "#/components/schemas/enum-sort-order"
+                  description: 'Sort order for log messages (default: desc)'
+                offset:
+                  type: string
+                  description: Opaque offset identifier
+      operationId: get-dbaas-service-logs
+  "/template/{id}":
+    delete:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Template
+      operationId: delete-template
+    post:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Copy a Template from a zone to another
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                target-zone:
+                  "$ref": "#/components/schemas/zone"
+                  description: Target Zone name
+              required:
+              - target-zone
+      operationId: copy-template
+    put:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update template attributes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Template Description
+      operationId: update-template
+    get:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/template"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Template details
+      operationId: get-template
+  "/dbaas-postgres/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate PostgreSQL maintenance update
+      operationId: start-dbaas-pg-maintenance
+  "/dbaas-grafana/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-grafana-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS Grafana user
+      operationId: reveal-dbaas-grafana-user-password
+  "/reverse-dns/instance/{id}":
+    post:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update/Create the PTR DNS record for an instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                domain-name:
+                  type: string
+                  maxLength: 253
+                  minLength: 1
+      operationId: update-reverse-dns-instance
+    get:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/reverse-dns-record"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Query the PTR DNS records for an instance
+      operationId: get-reverse-dns-instance
+    delete:
+      tags:
+      - reverse-dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete the PTR DNS record for an instance
+      operationId: delete-reverse-dns-instance
+  "/instance-pool/{id}:evict":
+    put:
+      tags:
+      - instance-pool
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: This operation evicts the specified Compute instances member from
+        the Instance Pool, shrinking it to `&lt;current pool size&gt; - &lt;# evicted
+        members&gt;`.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Evict Instance Pool members
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instances:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+      operationId: evict-instance-pool-members
+  "/dbaas-grafana/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS Grafana user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+      operationId: reset-dbaas-grafana-user-password
+  "/security-group/{id}:detach":
+    put:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Detach a Compute instance from a Security Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance"
+                  description: Compute instance
+              required:
+              - instance
+      operationId: detach-instance-from-security-group
+  "/sks-cluster/{id}/nodepool/{sks-nodepool-id}:evict":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: This operation evicts the specified Compute instances member from
+        the Nodepool, shrinking it to `&lt;current nodepool size&gt; - &lt;# evicted
+        members&gt;`.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      summary: Evict Nodepool members
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instances:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                  uniqueItems: true
+      operationId: evict-sks-nodepool-members
+  "/dbaas-kafka/{name}/schema-registry/acl-config/{acl-id}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: acl-id
+        schema:
+          "$ref": "#/components/schemas/dbaas-kafka-acl-id"
+      summary: Delete a Kafka ACL entry
+      operationId: delete-dbaas-kafka-schema-registry-acl-config
+  "/dns-domain/{id}":
+    delete:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete DNS Domain
+      operationId: delete-dns-domain
+    get:
+      tags:
+      - dns
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dns-domain"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve DNS domain details
+      operationId: get-dns-domain
+  "/block-storage/{id}:resize-volume":
+    put:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/block-storage-volume"
+      description: 'This operation resizes a Block storage volume. Note: the volume
+        can only grow, cannot be shrunk.'
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Resize a block storage volume
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 11
+                  exclusiveMinimum: false
+                  description: Volume size in GiB
+              required:
+              - size
+      operationId: resize-block-storage-volume
+  "/dbaas-kafka/{service-name}/user/{username}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Delete a DBaaS kafka user
+      operationId: delete-dbaas-kafka-user
+  "/dbaas-service-type/{service-type-name}":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-type"
+      description: Get a DBaaS service type
+      parameters:
+      - in: path
+        required: true
+        name: service-type-name
+        schema:
+          type: string
+      summary: Get a DBaaS service type
+      operationId: get-dbaas-service-type
+  "/security-group/{id}:add-source":
+    put:
+      tags:
+      - security-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Add an external source as a member of a Security Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cidr:
+                  type: string
+                  description: CIDR-formatted network to add
+              required:
+              - cidr
+      operationId: add-external-source-to-security-group
+  "/dbaas-mysql/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate MySQL maintenance update
+      operationId: start-dbaas-mysql-maintenance
+  "/dbaas-opensearch/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS OpenSearch user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+      operationId: reset-dbaas-opensearch-user-password
+  "/sos-buckets-usage":
+    get:
+      tags:
+      - sos
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sos-buckets-usage:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/sos-bucket-usage"
+      description: ''
+      parameters: []
+      summary: List SOS Buckets Usage
+      operationId: list-sos-buckets-usage
+  "/instance/{id}:reset":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 'This operation re-installs a Compute instance to a base template.
+        If target template is provided it will be used to recreated instance from.
+        Warning: the operation wipes all data stored on the disk.'
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Reset a Compute instance to a base/target template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                template:
+                  "$ref": "#/components/schemas/template"
+                  description: Template to recreate Instance from
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Instance disk size in GiB
+      operationId: reset-instance
+  "/dbaas-mysql/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-mysql-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS MySQL user
+      operationId: reveal-dbaas-mysql-user-password
+  "/ssh-key/{name}":
+    delete:
+      tags:
+      - ssh-key
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a SSH key
+      operationId: delete-ssh-key
+    get:
+      tags:
+      - ssh-key
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ssh-key"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Retrieve SSH key details
+      operationId: get-ssh-key
+  "/dbaas-service-metrics/{service-name}":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metrics:
+                    type: object
+      description: Get metrics of DBaaS service
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          type: string
+      summary: Get metrics of DBaaS service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                period:
+                  type: string
+                  enum:
+                  - hour
+                  - week
+                  - year
+                  - month
+                  - day
+                  description: 'Metrics time period (default: hour)'
+      operationId: get-dbaas-service-metrics
+  "/deploy-target/{id}":
+    get:
+      tags:
+      - deploy-target
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/deploy-target"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Deploy Target details
+      operationId: get-deploy-target
+  "/elastic-ip/{id}:detach":
+    put:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Detach a Compute instance from an Elastic IP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance-target"
+                  description: Compute instance
+              required:
+              - instance
+      operationId: detach-instance-from-elastic-ip
+  "/dbaas-kafka/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-kafka-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS Kafka user
+      operationId: reveal-dbaas-kafka-user-password
+  "/dbaas-task-migration-check/{service}":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS task to check migration
+      parameters:
+      - in: path
+        required: true
+        name: service
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: ''
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                source-service-uri:
+                  type: string
+                  maxLength: 512
+                  minLength: 1
+                  description: Service URI of the source MySQL or PostgreSQL database
+                    with admin credentials.
+                method:
+                  "$ref": "#/components/schemas/enum-migration-method"
+                  description: The migration method to be used (currently supported
+                    only by Redis and MySQL service types)
+                ignore-dbs:
+                  type: string
+                  maxLength: 2048
+                  minLength: 1
+                  description: Comma-separated list of databases, which should be
+                    ignored during migration (supported by MySQL only at the moment)
+              required:
+              - source-service-uri
+      operationId: create-dbaas-task-migration-check
+  "/load-balancer/{id}/service":
+    post:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Add a Load Balancer Service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Load Balancer Service name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Load Balancer Service description
+                instance-pool:
+                  "$ref": "#/components/schemas/instance-pool"
+                  description: Instance Pool to forward traffic to
+                protocol:
+                  type: string
+                  enum:
+                  - tcp
+                  - udp
+                  description: Network traffic protocol
+                strategy:
+                  type: string
+                  enum:
+                  - round-robin
+                  - maglev-hash
+                  - source-hash
+                  description: Load balancing strategy
+                port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Port exposed on the Load Balancer's public IP
+                target-port:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 65535
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Port on which the network traffic will be forwarded
+                    to on the receiving instance
+                healthcheck:
+                  "$ref": "#/components/schemas/load-balancer-service-healthcheck"
+                  description: Healthcheck configuration
+              required:
+              - name
+              - instance-pool
+              - protocol
+              - strategy
+              - port
+              - target-port
+              - healthcheck
+      operationId: add-service-to-load-balancer
+  "/ssh-key":
+    get:
+      tags:
+      - ssh-key
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ssh-keys:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/ssh-key"
+      description: ''
+      parameters: []
+      summary: List SSH keys
+      operationId: list-ssh-keys
+    post:
+      tags:
+      - ssh-key
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Import SSH key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  pattern: "^[a-zA-Z]{1}[a-zA-Z0-9._-]{0,254}$"
+                  description: SSH key name
+                public-key:
+                  type: string
+                  description: Public key value
+              required:
+              - name
+              - public-key
+      operationId: register-ssh-key
+  "/snapshot/{id}:promote":
+    post:
+      tags:
+      - snapshot
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Promote a Snapshot to a Template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template name
+                description:
+                  type: string
+                  maxLength: 4096
+                  description: Template description
+                default-user:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template default user
+                ssh-key-enabled:
+                  type: boolean
+                  description: Enable SSH key-based login in the template
+                password-enabled:
+                  type: boolean
+                  description: Enable password-based login in the template
+              required:
+              - name
+      operationId: promote-snapshot-to-template
+  "/sks-cluster":
+    post:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create an SKS cluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  description: Cluster description
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Cluster Labels
+                cni:
+                  type: string
+                  enum:
+                  - calico
+                  - cilium
+                  description: Cluster CNI
+                auto-upgrade:
+                  type: boolean
+                  description: Enable auto upgrade of the control plane to the latest
+                    patch version available
+                oidc:
+                  "$ref": "#/components/schemas/sks-oidc"
+                  description: Cluster OpenID configmap
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Cluster name
+                level:
+                  type: string
+                  enum:
+                  - starter
+                  - pro
+                  description: Cluster service level
+                addons:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - exoscale-cloud-controller
+                    - exoscale-container-storage-interface
+                    - metrics-server
+                  uniqueItems: true
+                  description: Cluster addons
+                version:
+                  type: string
+                  description: Control plane Kubernetes version
+              required:
+              - name
+              - level
+              - version
+      operationId: create-sks-cluster
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sks-clusters:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/sks-cluster"
+      description: ''
+      parameters: []
+      summary: List SKS clusters
+      operationId: list-sks-clusters
+  "/block-storage/{id}:detach":
+    put:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Detach block storage volume
+      operationId: detach-block-storage-volume
+  "/console/{id}":
+    get:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                  host:
+                    type: string
+                  path:
+                    type: string
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve signed url valid for 60 seconds to connect via console-proxy
+        websocket to VM VNC console.
+      operationId: get-console-proxy-url
+  "/dbaas-integration/{id}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Delete a DBaaS Integration
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a DBaaS Integration
+      operationId: delete-dbaas-integration
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a existing DBaaS integration
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update a existing DBaaS integration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                settings:
+                  type: object
+                  description: Integration settings
+              required:
+              - settings
+      operationId: update-dbaas-integration
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-integration"
+      description: Get a DBaaS Integration
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Get a DBaaS Integration
+      operationId: get-dbaas-integration
+  "/elastic-ip/{id}:attach":
+    put:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Attach a Compute instance to an Elastic IP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instance:
+                  "$ref": "#/components/schemas/instance-target"
+                  description: Compute instance
+              required:
+              - instance
+      operationId: attach-instance-to-elastic-ip
+  "/sks-cluster/{id}":
+    delete:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete an SKS cluster
+      operationId: delete-sks-cluster
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/sks-cluster"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve SKS cluster details
+      operationId: get-sks-cluster
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update an SKS cluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Cluster name
+                description:
+                  type: string
+                  maxLength: 255
+                  nullable: true
+                  description: Cluster description
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Cluster labels
+                oidc:
+                  "$ref": "#/components/schemas/sks-oidc"
+                  nullable: true
+                  description: Cluster OpenID configmap
+                auto-upgrade:
+                  type: boolean
+                  description: Enable auto upgrade of the control plane to the latest
+                    patch version available
+                addons:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - exoscale-cloud-controller
+                    - exoscale-container-storage-interface
+                    - metrics-server
+                  uniqueItems: true
+                  description: Cluster addons
+      operationId: update-sks-cluster
+  "/quota":
+    get:
+      tags:
+      - quotas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  quotas:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/quota"
+      description: ''
+      parameters: []
+      summary: List Organization Quotas
+      operationId: list-quotas
+  "/dbaas-integration-settings/{integration-type}/{source-type}/{dest-type}":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      properties:
+                        type: object
+                      additionalProperties:
+                        type: boolean
+                      type:
+                        type: string
+                      title:
+                        type: string
+                    description: The JSON schema representing the settings for the
+                      given integration type, source, and destination service types.
+      description: Get DBaaS integration settings
+      parameters:
+      - in: path
+        required: true
+        name: integration-type
+        schema:
+          type: string
+      - in: path
+        required: true
+        name: source-type
+        schema:
+          type: string
+      - in: path
+        required: true
+        name: dest-type
+        schema:
+          type: string
+      summary: Get DBaaS integration settings
+      operationId: list-dbaas-integration-settings
+  "/dbaas-settings-pg":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      pg:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: postgresql.conf configuration values
+                      pglookout:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: PGLookout settings
+                      pgbouncer:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: PGBouncer connection pooling settings
+                      timescaledb:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: TimescaleDB extension configuration values
+      description: Get DBaaS PostgreSQL settings
+      parameters: []
+      summary: Get DBaaS PostgreSQL settings
+      operationId: get-dbaas-settings-pg
+  "/elastic-ip/{id}":
+    put:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update an Elastic IP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Elastic IP description
+                healthcheck:
+                  "$ref": "#/components/schemas/elastic-ip-healthcheck"
+                  description: Elastic IP healthcheck
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+      operationId: update-elastic-ip
+    get:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/elastic-ip"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Elastic IP details
+      operationId: get-elastic-ip
+    delete:
+      tags:
+      - elastic-ip
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete an Elastic IP
+      operationId: delete-elastic-ip
+  "/sks-cluster/{id}/inspection":
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+      description: Helps troubleshoot common problems when deploying a kubernetes
+        cluster. Inspections run every couple of minutes.
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Get the latest inspection result
+      operationId: get-sks-cluster-inspection
+  "/dbaas-redis/{name}/migration/stop":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Stop a DBaaS Redis migration
+      operationId: stop-dbaas-redis-migration
+  "/instance/{id}":
+    delete:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Compute instance
+      operationId: delete-instance
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update a Compute instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Instance name
+                user-data:
+                  type: string
+                  maxLength: 32768
+                  minLength: 1
+                  description: Instance Cloud-init user-data (base64 encoded)
+                public-ip-assignment:
+                  "$ref": "#/components/schemas/public-ip-assignment"
+                  description: Assign public IP to the Instance
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+      operationId: update-instance
+    get:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/instance"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Compute instance details
+      operationId: get-instance
+  "/dbaas-mysql/{name}/migration/stop":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Stop a DBaaS MySQL migration
+      operationId: stop-dbaas-mysql-migration
+  "/dbaas-kafka/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate Kafka maintenance update
+      operationId: start-dbaas-kafka-maintenance
+  "/sks-cluster/{id}/rotate-ccm-credentials":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Rotate Exoscale CCM credentials
+      operationId: rotate-sks-ccm-credentials
+  "/dbaas-postgres/{service-name}/connection-pool/{connection-pool-name}":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: connection-pool-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-pg-pool-name"
+      summary: Update a DBaaS PostgreSQL connection pool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                database-name:
+                  "$ref": "#/components/schemas/dbaas-database-name"
+                  description: Service database name
+                mode:
+                  "$ref": "#/components/schemas/enum-pg-pool-mode"
+                  description: PGBouncer pool mode
+                size:
+                  "$ref": "#/components/schemas/dbaas-pg-pool-size"
+                  description: Size of PGBouncer's PostgreSQL side connection pool
+                username:
+                  "$ref": "#/components/schemas/dbaas-pg-pool-username"
+                  description: Pool username
+      operationId: update-dbaas-pg-connection-pool
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: connection-pool-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-pg-pool-name"
+      summary: Delete a DBaaS PostgreSQL connection pool
+      operationId: delete-dbaas-pg-connection-pool
+  "/iam-role/{id}:policy":
+    put:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update IAM Role Policy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/iam-policy"
+      operationId: update-iam-role-policy
+  "/sks-cluster/{id}/{field}":
+    delete:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - description
+          - labels
+      summary: Reset an SKS cluster field to its default value
+      operationId: reset-sks-cluster-field
+  "/dbaas-migration-status/{name}":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-migration-status"
+      description: Get a DBaaS migration status
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS migration status
+      operationId: get-dbaas-migration-status
+  "/dbaas-mysql/{service-name}/user/{username}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Delete a DBaaS MySQL user
+      operationId: delete-dbaas-mysql-user
+  "/load-balancer/{id}":
+    put:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Update a Load Balancer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Load Balancer name
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Load Balancer description
+                labels:
+                  "$ref": "#/components/schemas/labels"
+      operationId: update-load-balancer
+    delete:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete a Load Balancer
+      operationId: delete-load-balancer
+    get:
+      tags:
+      - network-load-balancer
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/load-balancer"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Load Balancer details
+      operationId: get-load-balancer
+  "/dbaas-service/{name}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Delete a DBaaS service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a DBaaS service
+      operationId: delete-dbaas-service
+  "/dbaas-mysql/{service-name}/database":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS MySQL database
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                database-name:
+                  "$ref": "#/components/schemas/dbaas-database-name"
+                  description: Service database name
+              required:
+              - database-name
+      operationId: create-dbaas-mysql-database
+  "/template":
+    get:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  templates:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/template"
+      description: ''
+      parameters:
+      - in: query
+        required: false
+        name: visibility
+        schema:
+          type: string
+          enum:
+          - private
+          - public
+      - in: query
+        required: false
+        name: family
+        schema:
+          type: string
+      summary: List Templates
+      operationId: list-templates
+    post:
+      tags:
+      - template
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Register a Template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintainer:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template maintainer
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Template description
+                ssh-key-enabled:
+                  type: boolean
+                  description: Enable SSH key-based login
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template name
+                default-user:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template default user
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: Template size
+                password-enabled:
+                  type: boolean
+                  description: Enable password-based login
+                build:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template build
+                checksum:
+                  type: string
+                  minLength: 1
+                  description: Template MD5 checksum
+                boot-mode:
+                  type: string
+                  enum:
+                  - legacy
+                  - uefi
+                  description: 'Boot mode (default: legacy)'
+                url:
+                  type: string
+                  minLength: 1
+                  description: Template source URL
+                version:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Template version
+              required:
+              - name
+              - url
+              - checksum
+              - ssh-key-enabled
+              - password-enabled
+      operationId: register-template
+  "/instance/{id}:reboot":
+    put:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Reboot a Compute instance
+      operationId: reboot-instance
+  "/dbaas-settings-kafka":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      kafka:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Kafka broker configuration values
+                      kafka-connect:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Kafka Connect configuration values
+                      kafka-rest:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Kafka REST configuration
+                      schema-registry:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: Schema Registry configuration
+      description: Get DBaaS Kafka settings
+      parameters: []
+      summary: Get DBaaS Kafka settings
+      operationId: get-dbaas-settings-kafka
+  "/dbaas-postgres/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-postgres-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS Postgres user
+      operationId: reveal-dbaas-postgres-user-password
+  "/dbaas-settings-opensearch":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      opensearch:
+                        type: object
+                        properties:
+                          properties:
+                            type: object
+                          additionalProperties:
+                            type: boolean
+                          type:
+                            type: string
+                          title:
+                            type: string
+                        description: OpenSearch configuration values
+      description: Get DBaaS OpenSearch settings
+      parameters: []
+      summary: Get DBaaS OpenSearch settings
+      operationId: get-dbaas-settings-opensearch
+  "/dbaas-grafana/{name}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a Grafana service
+      operationId: delete-dbaas-service-grafana
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-grafana"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS Grafana service
+      operationId: get-dbaas-service-grafana
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS Grafana service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                grafana-settings:
+                  "$ref": "#/components/schemas/json-schema-grafana"
+                  description: Grafana specific settings
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allowed CIDR address blocks for incoming connections
+      operationId: update-dbaas-service-grafana
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS Grafana service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: ''
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                fork-from-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: Service to fork from
+                grafana-settings:
+                  "$ref": "#/components/schemas/json-schema-grafana"
+                  description: Grafana specific settings
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allowed CIDR address blocks for incoming connections
+              required:
+              - plan
+      operationId: create-dbaas-service-grafana
+  "/sks-cluster/{id}/nodepool":
+    post:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Create a new SKS Nodepool
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                anti-affinity-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/anti-affinity-group"
+                  uniqueItems: true
+                  description: Nodepool Anti-affinity Groups
+                description:
+                  type: string
+                  maxLength: 255
+                  description: Nodepool description
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Nodepool labels
+                taints:
+                  "$ref": "#/components/schemas/sks-nodepool-taints"
+                  description: Nodepool taints
+                security-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/security-group"
+                  uniqueItems: true
+                  description: Nodepool Security Groups
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Nodepool name
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Nodepool instances type
+                private-networks:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/private-network"
+                  uniqueItems: true
+                  description: Nodepool Private Networks
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: Number of instances
+                kubelet-image-gc:
+                  "$ref": "#/components/schemas/kubelet-image-gc"
+                  description: Kubelet image GC options
+                instance-prefix:
+                  type: string
+                  maxLength: 30
+                  minLength: 1
+                  description: 'Prefix to apply to instances names (default: pool)'
+                deploy-target:
+                  "$ref": "#/components/schemas/deploy-target"
+                  description: Nodepool Deploy Target
+                addons:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - storage-lvm
+                  uniqueItems: true
+                  description: Nodepool addons
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 20
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Nodepool instances disk size in GiB
+              required:
+              - name
+              - size
+              - disk-size
+              - instance-type
+      operationId: create-sks-nodepool
+  "/dbaas-redis/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS Redis user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+      operationId: reset-dbaas-redis-user-password
+  "/dbaas-opensearch/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate OpenSearch maintenance update
+      operationId: start-dbaas-opensearch-maintenance
+  "/dbaas-kafka/{name}/acl-config":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-kafka-acls"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get DBaaS kafka ACL configuration
+      operationId: get-dbaas-kafka-acl-config
+  "/dbaas-kafka/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS Kafka user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+      operationId: reset-dbaas-kafka-user-password
+  "/dbaas-opensearch/{service-name}/user/{username}/password/reveal":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-user-opensearch-secrets"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reveal the secrets of a DBaaS OpenSearch user
+      operationId: reveal-dbaas-opensearch-user-password
+  "/dbaas-opensearch/{name}":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS OpenSearch service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS OpenSearch service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                max-index-count:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  description: Maximum number of indexes to keep before deleting the
+                    oldest one
+                keep-index-refresh-interval:
+                  type: boolean
+                  description: Aiven automation resets index.refresh_interval to default
+                    value for every index to be sure that indices are always visible
+                    to search. If it doesn't fit your case, you can disable this by
+                    setting up this flag to true.
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                fork-from-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: Service to fork from
+                index-patterns:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      max-index-count:
+                        type: integer
+                        format: int64
+                        minimum: 0
+                        exclusiveMinimum: false
+                        description: Maximum number of indexes to keep
+                      sorting-algorithm:
+                        type: string
+                        enum:
+                        - alphabetical
+                        - creation_date
+                        description: Deletion sorting algorithm
+                      pattern:
+                        type: string
+                        maxLength: 1024
+                        description: fnmatch pattern
+                  description: 'Allows you to create glob style patterns and set a
+                    max number of indexes matching this pattern you want to keep.
+                    Creating indexes exceeding this value will cause the oldest one
+                    to get deleted. You could for example create a pattern looking
+                    like ''logs.?'' and then create index logs.1, logs.2 etc, it will
+                    delete logs.1 once you create logs.6. Do note ''logs.?'' does
+                    not apply to logs.10. Note: Setting max_index_count to 0 will
+                    do nothing and the pattern gets ignored.'
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                index-template:
+                  type: object
+                  properties:
+                    mapping-nested-objects-limit:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 100000
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The maximum number of nested JSON objects that
+                        a single document can contain across all nested types. This
+                        limit helps to prevent out of memory errors when a document
+                        contains too many nested objects. Default is 10000.
+                    number-of-replicas:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 29
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The number of replicas each primary shard has.
+                    number-of-shards:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 1024
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The number of primary shards that an index should
+                        have.
+                  description: Template settings for all new indexes
+                opensearch-settings:
+                  "$ref": "#/components/schemas/json-schema-opensearch"
+                  description: OpenSearch-specific settings
+                version:
+                  type: string
+                  minLength: 1
+                  description: OpenSearch major version
+                recovery-backup-name:
+                  type: string
+                  minLength: 1
+                  description: Name of a backup to recover from for services that
+                    support backup names
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                opensearch-dashboards:
+                  type: object
+                  properties:
+                    opensearch-request-timeout:
+                      type: integer
+                      format: int64
+                      minimum: 5000
+                      maximum: 120000
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: 'Timeout in milliseconds for requests made by OpenSearch
+                        Dashboards towards OpenSearch (default: 30000)'
+                    enabled:
+                      type: boolean
+                      description: 'Enable or disable OpenSearch Dashboards (default:
+                        true)'
+                    max-old-space-size:
+                      type: integer
+                      format: int64
+                      minimum: 64
+                      maximum: 1024
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: 'Limits the maximum amount of memory (in MiB) the
+                        OpenSearch Dashboards process can use. This sets the max_old_space_size
+                        option of the nodejs running the OpenSearch Dashboards. Note:
+                        the memory reserved by OpenSearch Dashboards is not available
+                        for OpenSearch. (default: 128)'
+                  description: OpenSearch Dashboards settings
+              required:
+              - plan
+      operationId: create-dbaas-service-opensearch
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-opensearch"
+      description: Get a DBaaS OpenSearch service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS OpenSearch service
+      operationId: get-dbaas-service-opensearch
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a OpenSearch service
+      operationId: delete-dbaas-service-opensearch
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a DBaaS OpenSearch service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS OpenSearch service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                max-index-count:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  exclusiveMinimum: false
+                  description: Maximum number of indexes to keep before deleting the
+                    oldest one
+                keep-index-refresh-interval:
+                  type: boolean
+                  description: Aiven automation resets index.refresh_interval to default
+                    value for every index to be sure that indices are always visible
+                    to search. If it doesn't fit your case, you can disable this by
+                    setting up this flag to true.
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                index-patterns:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      max-index-count:
+                        type: integer
+                        format: int64
+                        minimum: 0
+                        exclusiveMinimum: false
+                        description: Maximum number of indexes to keep
+                      sorting-algorithm:
+                        type: string
+                        enum:
+                        - alphabetical
+                        - creation_date
+                        description: Deletion sorting algorithm
+                      pattern:
+                        type: string
+                        maxLength: 1024
+                        description: fnmatch pattern
+                  description: 'Allows you to create glob style patterns and set a
+                    max number of indexes matching this pattern you want to keep.
+                    Creating indexes exceeding this value will cause the oldest one
+                    to get deleted. You could for example create a pattern looking
+                    like ''logs.?'' and then create index logs.1, logs.2 etc, it will
+                    delete logs.1 once you create logs.6. Do note ''logs.?'' does
+                    not apply to logs.10. Note: Setting max_index_count to 0 will
+                    do nothing and the pattern gets ignored.'
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                index-template:
+                  type: object
+                  properties:
+                    mapping-nested-objects-limit:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 100000
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The maximum number of nested JSON objects that
+                        a single document can contain across all nested types. This
+                        limit helps to prevent out of memory errors when a document
+                        contains too many nested objects. Default is 10000.
+                    number-of-replicas:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 29
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The number of replicas each primary shard has.
+                    number-of-shards:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 1024
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The number of primary shards that an index should
+                        have.
+                  description: Template settings for all new indexes
+                opensearch-settings:
+                  "$ref": "#/components/schemas/json-schema-opensearch"
+                  description: OpenSearch-specific settings
+                version:
+                  type: string
+                  description: Version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                opensearch-dashboards:
+                  type: object
+                  properties:
+                    opensearch-request-timeout:
+                      type: integer
+                      format: int64
+                      minimum: 5000
+                      maximum: 120000
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: 'Timeout in milliseconds for requests made by OpenSearch
+                        Dashboards towards OpenSearch (default: 30000)'
+                    enabled:
+                      type: boolean
+                      description: 'Enable or disable OpenSearch Dashboards (default:
+                        true)'
+                    max-old-space-size:
+                      type: integer
+                      format: int64
+                      minimum: 64
+                      maximum: 1024
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: 'Limits the maximum amount of memory (in MiB) the
+                        OpenSearch Dashboards process can use. This sets the max_old_space_size
+                        option of the nodejs running the OpenSearch Dashboards. Note:
+                        the memory reserved by OpenSearch Dashboards is not available
+                        for OpenSearch. (default: 128)'
+                  description: OpenSearch Dashboards settings
+      operationId: update-dbaas-service-opensearch
+  "/sks-cluster/{id}/nodepool/{sks-nodepool-id}/{field}":
+    delete:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: sks-nodepool-id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - anti-affinity-groups
+          - description
+          - labels
+          - security-groups
+          - private-networks
+          - deploy-target
+      summary: Reset an SKS Nodepool field to its default value
+      operationId: reset-sks-nodepool-field
+  "/dbaas-redis/{name}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a Redis service
+      operationId: delete-dbaas-service-redis
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a DBaaS Redis service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS Redis service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+                redis-settings:
+                  "$ref": "#/components/schemas/json-schema-redis"
+                  description: Redis.conf settings
+      operationId: update-dbaas-service-redis
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-redis"
+      description: Get a DBaaS Redis service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS Redis service
+      operationId: get-dbaas-service-redis
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a DBaaS Redis service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Redis service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+                redis-settings:
+                  "$ref": "#/components/schemas/json-schema-redis"
+                  description: Redis.conf settings
+                fork-from-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: Service to fork from
+                recovery-backup-name:
+                  type: string
+                  minLength: 1
+                  description: Name of a backup to recover from for services that
+                    support backup names
+              required:
+              - plan
+      operationId: create-dbaas-service-redis
+  "/dbaas-postgres/{name}":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Update a DBaaS PostgreSQL service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Update a DBaaS PostgreSQL service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pgbouncer-settings:
+                  "$ref": "#/components/schemas/json-schema-pgbouncer"
+                  description: PGBouncer connection pooling settings
+                backup-schedule:
+                  type: object
+                  properties:
+                    backup-hour:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 23
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The hour of day (in UTC) when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                    backup-minute:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 59
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The minute of an hour when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                variant:
+                  "$ref": "#/components/schemas/enum-pg-variant"
+                  description: Variant of the PostgreSQL service, may affect the features
+                    that are exposed by default
+                timescaledb-settings:
+                  "$ref": "#/components/schemas/json-schema-timescaledb"
+                  description: TimescaleDB extension configuration values
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                synchronous-replication:
+                  "$ref": "#/components/schemas/enum-pg-synchronous-replication"
+                  description: Synchronous replication type. Note that the service
+                    plan also needs to support synchronous replication.
+                pglookout-settings:
+                  "$ref": "#/components/schemas/json-schema-pglookout"
+                  description: PGLookout settings
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                version:
+                  type: string
+                  description: Version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                work-mem:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 1024
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Sets the maximum amount of memory to be used by a query
+                    operation (such as a sort or hash table) before writing to temporary
+                    disk files, in MB. Default is 1MB + 0.075% of total RAM (up to
+                    32MB).
+                shared-buffers-percentage:
+                  type: integer
+                  format: int64
+                  minimum: 20
+                  maximum: 60
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Percentage of total RAM that the database server uses
+                    for shared memory buffers. Valid range is 20-60 (float), which
+                    corresponds to 20% - 60%. This setting adjusts the shared_buffers
+                    configuration value.
+                pg-settings:
+                  "$ref": "#/components/schemas/json-schema-pg"
+                  description: PostgreSQL-specific settings
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+      operationId: update-dbaas-service-pg
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-service-pg"
+      description: Get a DBaaS PostgreSQL service
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Get a DBaaS PostgreSQL service
+      operationId: get-dbaas-service-pg
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS PostgreSQL service
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pgbouncer-settings:
+                  "$ref": "#/components/schemas/json-schema-pgbouncer"
+                  description: PGBouncer connection pooling settings
+                backup-schedule:
+                  type: object
+                  properties:
+                    backup-hour:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 23
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The hour of day (in UTC) when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                    backup-minute:
+                      type: integer
+                      format: int64
+                      minimum: 0
+                      maximum: 59
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: The minute of an hour when backup for the service
+                        is started. New backup is only started if previous backup
+                        has already completed.
+                variant:
+                  "$ref": "#/components/schemas/enum-pg-variant"
+                  description: Variant of the PostgreSQL service, may affect the features
+                    that are exposed by default
+                integrations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - read_replica
+                        description: Integration type
+                      source-service:
+                        "$ref": "#/components/schemas/dbaas-service-name"
+                        description: A source service
+                      dest-service:
+                        "$ref": "#/components/schemas/dbaas-service-name"
+                        description: A destination service
+                      settings:
+                        type: object
+                        description: Integration settings
+                    required:
+                    - type
+                  description: Service integrations to be enabled when creating the
+                    service.
+                timescaledb-settings:
+                  "$ref": "#/components/schemas/json-schema-timescaledb"
+                  description: TimescaleDB extension configuration values
+                ip-filter:
+                  type: array
+                  items:
+                    type: string
+                  description: Allow incoming connections from CIDR address block,
+                    e.g. '10.20.0.0/16'
+                termination-protection:
+                  type: boolean
+                  description: Service is protected against termination and powering
+                    off
+                fork-from-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: Service to fork from
+                synchronous-replication:
+                  "$ref": "#/components/schemas/enum-pg-synchronous-replication"
+                  description: Synchronous replication type. Note that the service
+                    plan also needs to support synchronous replication.
+                recovery-backup-time:
+                  type: string
+                  minLength: 1
+                  description: ISO time of a backup to recover from for services that
+                    support arbitrary times
+                pglookout-settings:
+                  "$ref": "#/components/schemas/json-schema-pglookout"
+                  description: PGLookout settings
+                maintenance:
+                  type: object
+                  properties:
+                    dow:
+                      type: string
+                      enum:
+                      - saturday
+                      - tuesday
+                      - never
+                      - wednesday
+                      - sunday
+                      - friday
+                      - monday
+                      - thursday
+                      description: Day of week for installing updates
+                    time:
+                      type: string
+                      maxLength: 8
+                      minLength: 8
+                      description: Time for installing updates, UTC
+                  required:
+                  - dow
+                  - time
+                  description: Automatic maintenance settings
+                admin-username:
+                  type: string
+                  maxLength: 64
+                  minLength: 1
+                  pattern: "^[_A-Za-z0-9][-._A-Za-z0-9]{0,63}$"
+                  description: Custom username for admin user. This must be set only
+                    when a new service is being created.
+                version:
+                  "$ref": "#/components/schemas/dbaas-pg-target-versions"
+                  description: PostgreSQL major version
+                plan:
+                  type: string
+                  maxLength: 128
+                  minLength: 1
+                  description: Subscription plan
+                work-mem:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  maximum: 1024
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Sets the maximum amount of memory to be used by a query
+                    operation (such as a sort or hash table) before writing to temporary
+                    disk files, in MB. Default is 1MB + 0.075% of total RAM (up to
+                    32MB).
+                shared-buffers-percentage:
+                  type: integer
+                  format: int64
+                  minimum: 20
+                  maximum: 60
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Percentage of total RAM that the database server uses
+                    for shared memory buffers. Valid range is 20-60 (float), which
+                    corresponds to 20% - 60%. This setting adjusts the shared_buffers
+                    configuration value.
+                pg-settings:
+                  "$ref": "#/components/schemas/json-schema-pg"
+                  description: PostgreSQL-specific settings
+                admin-password:
+                  type: string
+                  maxLength: 256
+                  minLength: 8
+                  pattern: "^[a-zA-Z0-9-_]+$"
+                  description: Custom password for admin user. Defaults to random
+                    string. This must be set only when a new service is being created.
+                migration:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Hostname or IP address of the server where to migrate
+                        data from
+                    port:
+                      type: integer
+                      format: int64
+                      minimum: 1
+                      maximum: 65535
+                      exclusiveMinimum: false
+                      exclusiveMaximum: false
+                      description: Port number of the server where to migrate data
+                        from
+                    password:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: Password for authentication with the server where
+                        to migrate data from
+                    ssl:
+                      type: boolean
+                      description: The server where to migrate data from is secured
+                        with SSL
+                    username:
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                      description: User name for authentication with the server where
+                        to migrate data from
+                    dbname:
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      description: Database name for bootstrapping the initial connection
+                    ignore-dbs:
+                      type: string
+                      maxLength: 2048
+                      minLength: 1
+                      description: Comma-separated list of databases, which should
+                        be ignored during migration (supported by MySQL only at the
+                        moment)
+                    method:
+                      "$ref": "#/components/schemas/enum-migration-method"
+                      description: The migration method to be used
+                  required:
+                  - host
+                  - port
+                  description: Migrate data from existing server
+              required:
+              - plan
+      operationId: create-dbaas-service-pg
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          type: string
+      summary: Delete a Postgres service
+      operationId: delete-dbaas-service-pg
+  "/dbaas-integration":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: Create a new DBaaS integration between two services
+      parameters: []
+      summary: Create a new DBaaS integration between two services
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                integration-type:
+                  "$ref": "#/components/schemas/enum-integration-types"
+                  description: Integration type
+                source-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: A source service
+                dest-service:
+                  "$ref": "#/components/schemas/dbaas-service-name"
+                  description: A destination service
+                settings:
+                  type: object
+                  description: Integration settings
+              required:
+              - integration-type
+              - source-service
+              - dest-service
+      operationId: create-dbaas-integration
+  "/dbaas-task/{service}/{id}":
+    get:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/dbaas-task"
+      description: Get a DBaaS task
+      parameters:
+      - in: path
+        required: true
+        name: service
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Get a DBaaS task
+      operationId: get-dbaas-task
+  "/sos/{bucket}/presigned-url":
+    get:
+      tags:
+      - sos
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+      description: Generates Presigned Download URL for SOS object
+      parameters:
+      - in: path
+        required: true
+        name: bucket
+        schema:
+          type: string
+      - in: query
+        required: false
+        name: key
+        schema:
+          type: string
+      summary: Retrieve Presigned Download URL for SOS object
+      operationId: get-sos-presigned-url
+  "/sks-cluster/{id}/rotate-operators-ca":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Rotate operators certificate authority
+      operationId: rotate-sks-operators-ca
+  "/anti-affinity-group/{id}":
+    get:
+      tags:
+      - anti-affinity-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/anti-affinity-group"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Retrieve Anti-affinity Group details
+      operationId: get-anti-affinity-group
+    delete:
+      tags:
+      - anti-affinity-group
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Delete an Anti-affinity Group
+      operationId: delete-anti-affinity-group
+  "/sks-cluster-version":
+    get:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sks-cluster-versions:
+                    type: array
+                    items:
+                      type: string
+      description: ''
+      parameters:
+      - in: query
+        required: false
+        name: include-deprecated
+        schema:
+          type: string
+      summary: List available versions for SKS clusters
+      operationId: list-sks-cluster-versions
+  "/dbaas-redis/{service-name}/user":
+    post:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Create a DBaaS Redis user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  "$ref": "#/components/schemas/dbaas-user-username"
+                  description: Username
+              required:
+              - username
+      operationId: create-dbaas-redis-user
+  "/instance":
+    post:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create a Compute instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                anti-affinity-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/anti-affinity-group"
+                  uniqueItems: true
+                  description: Instance Anti-affinity Groups
+                public-ip-assignment:
+                  "$ref": "#/components/schemas/public-ip-assignment"
+                  description: Assign public IP to the Instance
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+                auto-start:
+                  type: boolean
+                  description: 'Start Instance on creation (default: true)'
+                security-groups:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/security-group"
+                  uniqueItems: true
+                  description: Instance Security Groups
+                name:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: Instance name
+                instance-type:
+                  "$ref": "#/components/schemas/instance-type"
+                  description: Instance Type
+                template:
+                  "$ref": "#/components/schemas/template"
+                  description: Instance Template
+                ssh-key:
+                  "$ref": "#/components/schemas/ssh-key"
+                  description: Instance SSH Key
+                user-data:
+                  type: string
+                  maxLength: 32768
+                  minLength: 1
+                  description: Instance Cloud-init user-data (base64 encoded)
+                deploy-target:
+                  "$ref": "#/components/schemas/deploy-target"
+                  description: Instance Deploy Target
+                ipv6-enabled:
+                  type: boolean
+                  description: 'Enable IPv6. DEPRECATED: use `public-ip-assignments`.'
+                disk-size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  maximum: 51200
+                  exclusiveMinimum: false
+                  exclusiveMaximum: false
+                  description: Instance disk size in GiB
+                ssh-keys:
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/ssh-key"
+                  uniqueItems: true
+                  description: Instance SSH Keys
+              required:
+              - disk-size
+              - instance-type
+              - template
+      operationId: create-instance
+    get:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  instances:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        public-ip-assignment:
+                          "$ref": "#/components/schemas/public-ip-assignment"
+                          description: Instance public IP assignment
+                        labels:
+                          "$ref": "#/components/schemas/labels"
+                          description: Resource labels
+                        security-groups:
+                          type: array
+                          items:
+                            "$ref": "#/components/schemas/security-group"
+                          description: Instance Security Groups
+                        name:
+                          type: string
+                          maxLength: 255
+                          minLength: 1
+                          description: Instance name
+                        instance-type:
+                          "$ref": "#/components/schemas/instance-type"
+                          description: Instance Type
+                        private-networks:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                format: uuid
+                                description: Private Network ID
+                              mac-address:
+                                type: string
+                                description: Private Network MAC address
+                            description: Private Network
+                          description: Instance Private Networks
+                        template:
+                          "$ref": "#/components/schemas/template"
+                          description: Instance Template
+                        state:
+                          "$ref": "#/components/schemas/instance-state"
+                          description: Instance state
+                        ssh-key:
+                          "$ref": "#/components/schemas/ssh-key"
+                          description: Instance SSH Key
+                        mac-address:
+                          type: string
+                          description: Instance MAC address
+                        manager:
+                          "$ref": "#/components/schemas/manager"
+                          description: Instance manager
+                        ipv6-address:
+                          type: string
+                          description: Instance IPv6 address
+                        id:
+                          type: string
+                          format: uuid
+                          description: Instance ID
+                        ssh-keys:
+                          type: array
+                          items:
+                            "$ref": "#/components/schemas/ssh-key"
+                          description: Instance SSH Keys
+                        created-at:
+                          type: string
+                          format: date-time
+                          description: Instance creation date
+                        public-ip:
+                          type: string
+                          format: ipv4
+                          description: Instance public IPv4 address
+                      description: Instance
+      description: ''
+      parameters:
+      - in: query
+        required: false
+        name: manager-id
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        required: false
+        name: manager-type
+        schema:
+          type: string
+          enum:
+          - instance-pool
+      - in: query
+        required: false
+        name: ip-address
+        schema:
+          type: string
+      summary: List Compute instances
+      operationId: list-instances
+  "/iam-role":
+    get:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  iam-roles:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/iam-role"
+      description: ''
+      parameters: []
+      summary: List IAM Roles
+      operationId: list-iam-roles
+    post:
+      tags:
+      - iam
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create IAM Role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 191
+                  minLength: 1
+                  description: IAM Role name
+                description:
+                  type: string
+                  maxLength: 255
+                  minLength: 1
+                  description: IAM Role description
+                permissions:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                    - bypass-governance-retention
+                  uniqueItems: true
+                  description: IAM Role permissions
+                editable:
+                  type: boolean
+                  description: 'Sets if the IAM Role Policy is editable or not (default:
+                    true). This setting cannot be changed after creation'
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: IAM Role labels
+                policy:
+                  "$ref": "#/components/schemas/iam-policy"
+                  description: IAM Role policy
+              required:
+              - name
+      operationId: create-iam-role
+  "/private-network/{id}/{field}":
+    delete:
+      tags:
+      - private-network
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        required: true
+        name: field
+        schema:
+          type: string
+          enum:
+          - labels
+      summary: Reset Private Network field
+      operationId: reset-private-network-field
+  "/sks-cluster/{id}/upgrade":
+    put:
+      tags:
+      - sks
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters:
+      - in: path
+        required: true
+        name: id
+        schema:
+          type: string
+          format: uuid
+      summary: Upgrade an SKS cluster
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                version:
+                  type: string
+                  description: Control plane Kubernetes version
+              required:
+              - version
+      operationId: upgrade-sks-cluster
+  "/dbaas-redis/{name}/maintenance/start":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      summary: Initiate Redis maintenance update
+      operationId: start-dbaas-redis-maintenance
+  "/block-storage":
+    get:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  block-storage-volumes:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/block-storage-volume"
+      description: ''
+      parameters:
+      - in: query
+        required: false
+        name: instance-id
+        schema:
+          type: string
+          format: uuid
+      summary: List block storage volumes
+      operationId: list-block-storage-volumes
+    post:
+      tags:
+      - block-storage
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: ''
+      parameters: []
+      summary: Create a block storage volume
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  description: Volume name
+                size:
+                  type: integer
+                  format: int64
+                  minimum: 10
+                  exclusiveMinimum: false
+                  description: |-
+                    Volume size in GiB.
+                                                When a snapshot ID is supplied, this defaults to the size of the source volume, but can be set to a larger value.
+                labels:
+                  "$ref": "#/components/schemas/labels"
+                  description: Resource labels
+                block-storage-snapshot:
+                  "$ref": "#/components/schemas/block-storage-snapshot-target"
+                  description: Block storage snapshot
+      operationId: create-block-storage-volume
+  "/dbaas-kafka/{name}/topic/acl-config/{acl-id}":
+    delete:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: 
+      parameters:
+      - in: path
+        required: true
+        name: name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: acl-id
+        schema:
+          "$ref": "#/components/schemas/dbaas-kafka-acl-id"
+      summary: Delete a Kafka ACL entry
+      operationId: delete-dbaas-kafka-topic-acl-config
+  "/instance/{instance-id}:revert-snapshot":
+    post:
+      tags:
+      - instance
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: |-
+        This operation reverts the snapshot to the Compute instance volume, restoring stored data as it was at the time of the snapshot.
+        The Compute instance must be previously stopped.
+      parameters:
+      - in: path
+        required: true
+        name: instance-id
+        schema:
+          type: string
+          format: uuid
+      summary: Revert a snapshot for an instance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: Snapshot ID
+              required:
+              - id
+      operationId: revert-instance-to-snapshot
+  "/dbaas-postgres/{service-name}/user/{username}/password/reset":
+    put:
+      tags:
+      - dbaas
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/operation"
+      description: If no password is provided one will be generated automatically.
+      parameters:
+      - in: path
+        required: true
+        name: service-name
+        schema:
+          "$ref": "#/components/schemas/dbaas-service-name"
+      - in: path
+        required: true
+        name: username
+        schema:
+          "$ref": "#/components/schemas/dbaas-user-username"
+      summary: Reset the credentials of a DBaaS Postgres user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  "$ref": "#/components/schemas/dbaas-user-password"
+                  description: New password
+      operationId: reset-dbaas-postgres-user-password
+x-topics:
+- title: API Request Signature
+  content: |2+
+
+    In order to authenticate legitimate users, the Exoscale API requires incoming requests to be signed using valid Exoscale API account credentials with the following mechanism.
+
+    ## Signature Mechanism
+
+    The *message* (i.e. content) to sign contains several segments concatenated using a line return character (`\n`).
+
+    All segments must be included and in the described order. For cases where a segment doesn't fit the context of the request (e.g. no request body) **an empty line must be used instead**.
+
+    * Request method and request URL (path only), separated by a space character
+    * Request body
+    * Request URL parameters (Query String) values, concatenated without separator. The matching parameter names have to be specified in the resulting signature header `signed-query-args=` pragma, separated by semicolons (e.g. `p1;p2;pN`).
+    * Request header values, concatenated without separator (none at the moment, leave empty)
+    * Request expiration date in UNIX timestamp format
+
+    Example *message* to sign for `GET /v2/resource/a02baf5a-a3e4-49a0-857b-8a08d276c1c0?p1=v1&p2=v2`:
+
+    ```
+    GET /v2/resource/a02baf5a-a3e4-49a0-857b-8a08d276c1c0
+
+    v1v2
+
+    1599140767
+    ```
+
+    The two blank lines above are due to the absence of a request body and signed headers.
+
+    Example *message* to [create a security group](https://openapi-v2.exoscale.com/operation/operation-create-security-group)
+
+    ```
+    POST /v2/security-group
+    {"name": "my-security-group"}
+
+
+    1599140767
+    ```
+
+    The two blank lines above are due to the absence of query parameters and signed headers.
+
+    The request signature consists of the base64-encoded [HMAC](https://en.wikipedia.org/wiki/HMAC) hash of the UTF-8 encoded *message* and the Exoscale API secret using the SHA265 function:
+
+    ```
+    signature = BASE64_ENCODE(HMAC_SHA256(Exoscale API secret, message))
+    ```
+
+    Finally, the computed signature must be added to the API request in a `Authorization` header such as:
+
+    ```
+    Authorization: EXO2-HMAC-SHA256 credential=<Exoscale API key>,expires=<expiration date UNIX timestamp>,signature=<signature>
+    ```
+
+    Example API query:
+
+    ```
+    GET /v2/resource/a02baf5a-a3e4-49a0-857b-8a08d276c1c0?p1=v1&p2=v2 HTTP/1.1
+    Host: api-ch-gva-2.exoscale.com
+    Authorization: EXO2-HMAC-SHA256 credential=EXO29147e9f89102b7ac1e88514,signed-query-args=p1;p2,expires=1599140767,signature=2AOBQsbElQb4FpKT/FM/9T4NobjlmZkSGvvdUth/xlY=
+    ```
+
+    ## Reference Implementations
+
+    You can look up the following existing reference implementations:
+
+    * Go: [github.com/exoscale/egoscale/api/v2 > `SecurityProviderExoscale.signRequest`](https://github.com/exoscale/egoscale/blob/master/v2/api/security.go)
+    * Python: [requests-exoscale-auth > `ExoscaleV2Auth`](https://github.com/exoscale/requests-exoscale-auth/blob/master/exoscale_auth.py)
+
+- title: Zone local resources
+  content: |2
+
+    The API is deployed across multiple zones: `ch-gva-2`, `ch-dk-2`, `de-fra-1`, `de-muc-1`, `at-vie-1`, `at-vie-2`, `bg-sof-1`. When performing a compute call, you should use the relevant zone for your resource.
+    For example: https://api-de-fra-1.exoscale.com/v2/instance would return only the instances from `de-fra-1`, https://api-ch-gva-2.exoscale.com/v2/instance from `ch-gva-2`.
+    To obtain a list of all instances across all zones, you would need to do the corresponding request per zone.
+
+    Note that if no zone is specified during the call `ch-gva-2` will be used by default.

--- a/v3/generator/source.yaml
+++ b/v3/generator/source.yaml
@@ -3070,6 +3070,9 @@ components:
     event:
       type: object
       properties:
+        iam-user:
+          "$ref": "#/components/schemas/user"
+          description: Details about the IAM User
         request-id:
           type: string
           description: Operation unique identifier

--- a/v3/generator/source.yaml
+++ b/v3/generator/source.yaml
@@ -3070,9 +3070,6 @@ components:
     event:
       type: object
       properties:
-        iam-user:
-          "$ref": "#/components/schemas/user"
-          description: Details about the IAM User
         request-id:
           type: string
           description: Operation unique identifier

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -1537,6 +1537,8 @@ type Event struct {
 	IAMAPIKey *IAMAPIKey `json:"iam-api-key,omitempty"`
 	// IAM Role
 	IAMRole *IAMRole `json:"iam-role,omitempty"`
+	// User
+	IAMUser *User `json:"iam-user,omitempty"`
 	// Operation message
 	Message string `json:"message,omitempty"`
 	// URI path parameters (free form map)

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -1537,8 +1537,6 @@ type Event struct {
 	IAMAPIKey *IAMAPIKey `json:"iam-api-key,omitempty"`
 	// IAM Role
 	IAMRole *IAMRole `json:"iam-role,omitempty"`
-	// User
-	IAMUser *User `json:"iam-user,omitempty"`
 	// Operation message
 	Message string `json:"message,omitempty"`
 	// URI path parameters (free form map)


### PR DESCRIPTION
# Description
Everyday at 7 AM we trigger a GitHub Action that runs `make generate`. This will download the exoscale API spec and try to regenerate egoscale v3. If there are changes, we create a PR with those changes.

NOTE: the latest run of the action fails, because I changed the base to `master` which means there's a conflict, because source.yaml is ignored in `master`. [example](https://github.com/exoscale/egoscale/actions/runs/9955412776/job/27503113843?pr=643#step:4:108)
Once this PR is merged the problem will disappear. See testing below for tests on a previous commit.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated

## Testing
Pushing this PR automatically [generated this PR](https://github.com/exoscale/egoscale/pull/644)
