### PR TITLE
v3: github action to build tooling with new commit

### DIFF
--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Build ${{ matrix.repo }}
-      id: build_${{ matrix.repo }}
+      id: build
       run: |
         git clone git@github.com:exoscale/${{ matrix.repo }}
         go get github.com/exoscale/egoscale/v3@${{ github.sha }}

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -13,10 +13,10 @@ jobs:
           - exoscale-csi-driver
 
     steps:
-    - name: Build ${{ matrix.repo }}
+    - name: Build
       id: build
       run: |
-        git clone git@github.com:exoscale/${{ matrix.repo }}
+        git clone https://github.com/exoscale/${{ matrix.repo }}
         go get github.com/exoscale/egoscale/v3@${{ github.sha }}
         go mod vendor
         make build

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -9,15 +9,20 @@ jobs:
 
     strategy:
       matrix:
-        repo:
-          - exoscale-csi-driver
+        case:
+          - repo: exoscale-csi-driver
+            build: 'make build'
+          - repo: cli
+            build: 'make build'
+          - repo: terraform-provider-exoscale
+            build: 'go build'
 
     steps:
     - name: Build
       id: build
       run: |
-        git clone https://github.com/exoscale/${{ matrix.repo }}
-        cd ${{ matrix.repo }}
+        git clone https://github.com/exoscale/${{ matrix.case.repo }}
+        cd ${{ matrix.case.repo }}
         go get github.com/exoscale/egoscale/v3@${{ github.sha }}
         go mod vendor
-        make build
+        ${{ matrix.case.build }}

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -1,0 +1,22 @@
+name: build-public-tooling
+
+on:
+  push
+
+jobs:
+  build_public_tooling:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        repo:
+          - exoscale-csi-driver
+
+    steps:
+    - name: Build ${{ matrix.repo }}
+      id: build_${{ matrix.repo }}
+      run: |
+        git clone git@github.com:exoscale/${{ matrix.repo }}
+        go get github.com/exoscale/egoscale/v3@${{ github.sha }}
+        go mod vendor
+        make build

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -17,6 +17,7 @@ jobs:
       id: build
       run: |
         git clone https://github.com/exoscale/${{ matrix.repo }}
+        cd ${{ matrix.repo }}
         go get github.com/exoscale/egoscale/v3@${{ github.sha }}
         go mod vendor
         make build

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         case:
           - repo: exoscale-csi-driver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - v3: automate regeneration when spec changes #643 
+- v3: github action to build tooling with new commit #645 
 
 3.1.0
 ----------


### PR DESCRIPTION
# Description
Whenever new commits are pushed this action tries to build the cli, CSI and tf provider with the new change. The build usually needs under a minute and all three run in parallel. This check will help to prevent us from doing backwards incompatible changes by accident.

The CSI build will pass once this PR is merged: https://github.com/exoscale/exoscale-csi-driver/pull/35

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
