### PR TITLE
generate_v3: replace deprecated ::set-output

### DIFF
--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -1,6 +1,9 @@
 name: build-public-tooling
 
 on:
+  pull_request:
+    branches:
+      - generate-v3
   push
 
 jobs:

--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - generate-v3
-  push
+  push:
 
 jobs:
   build_public_tooling:

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,6 +1,9 @@
 name: check_and_regenerate_v3
 
 on:
+  push:
+    branches:
+    - philippsauter/fix-generate-v3-action
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * *" # everyday at 7 AM

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,9 +1,6 @@
 name: check_and_regenerate_v3
 
 on:
-  push:
-    branches:
-    - philippsauter/fix-generate-v3-action
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * *" # everyday at 7 AM

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -24,7 +24,7 @@ jobs:
       id: check_changes
       run: |
         make generate
-        git diff --quiet || echo "name=changes_detected::true" >> $GITHUB_OUTPUT
+        git diff --quiet || echo "changes_detected=true" >> $GITHUB_OUTPUT
 
     - name: Create PR
       if: steps.check_changes.outputs.changes_detected

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -1,6 +1,7 @@
 name: check_and_regenerate_v3
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 7 * * *" # everyday at 7 AM
 
@@ -20,7 +21,7 @@ jobs:
       id: check_changes
       run: |
         make generate
-        git diff --quiet || echo "::set-output name=changes_detected::true"
+        git diff --quiet || echo "name=changes_detected::true" >> $GITHUB_OUTPUT
 
     - name: Create PR
       if: steps.check_changes.outputs.changes_detected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- generate_v3: replace deprecated ::set-output #647 
+
 3.1.1
 ----------
 


### PR DESCRIPTION
# Description
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also allow manually triggering the PR and enable the public tooling build on the automatically created PR.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated

## Testing

The generated [PR](https://github.com/exoscale/egoscale/pull/648) appeared