### PR TITLE
handling multiple separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - generate_v3: replace deprecated ::set-output #647 
+- generate_v3: handle multiple separators #650
 
 3.1.1
 ----------

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := philippsauter/staticcheck-2024-1-1
+GO_MK_REF := v2.0.2
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v2.0.0
+GO_MK_REF := philippsauter/staticcheck-2024-1-1
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk

--- a/request_test.go
+++ b/request_test.go
@@ -96,7 +96,7 @@ func TestRequest(t *testing.T) {
 	}
 	resp, err := cs.Request(req)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	apis := resp.(*ListAPIsResponse)
 	if apis.Count != 1 {

--- a/v3/generator/helpers/helpers.go
+++ b/v3/generator/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -48,13 +49,10 @@ func toInitialCamel(s string, lower bool) string {
 		return ""
 	}
 
-	sep, ok := containSep(s)
-	if !ok {
-		sep = "-"
-	}
+	pattern := `[-_./\s]`
+	s = trimBySeparators(s,pattern)
+	words := splitBySeparators(s,pattern)
 
-	s = strings.Trim(s, sep)
-	words := strings.Split(s, sep)
 	for i, w := range words {
 		if w == "" {
 			continue
@@ -89,24 +87,22 @@ func toInitialCamel(s string, lower bool) string {
 	return strings.Join(words, "")
 }
 
-func containSep(s string) (string, bool) {
-	if strings.Contains(s, "-") {
-		return "-", true
-	}
-	if strings.Contains(s, "_") {
-		return "_", true
-	}
-	if strings.Contains(s, ".") {
-		return ".", true
-	}
-	if strings.Contains(s, "/") {
-		return "/", true
-	}
-	if strings.Contains(s, " ") {
-		return " ", true
-	}
+func trimBySeparators(s, separators string) string {
+    trimPattern := fmt.Sprintf("^%s+|%s+$", separators, separators)
+    re := regexp.MustCompile(trimPattern)
+    return re.ReplaceAllString(s, "")
+}
 
-	return "", false
+func splitBySeparators(s, separators string) []string {
+    re := regexp.MustCompile(separators)
+    parts := re.Split(s, -1)
+    var result []string
+    for _, part := range parts {
+        if part != "" {
+            result = append(result, part)
+        }
+    }
+    return result
 }
 
 // RenderDoc returns proper go doc comment from

--- a/v3/generator/helpers/helpers.go
+++ b/v3/generator/helpers/helpers.go
@@ -50,8 +50,8 @@ func toInitialCamel(s string, lower bool) string {
 	}
 
 	pattern := `[-_./\s]`
-	s = trimBySeparators(s,pattern)
-	words := splitBySeparators(s,pattern)
+	s = trimBySeparators(s, pattern)
+	words := splitBySeparators(s, pattern)
 
 	for i, w := range words {
 		if w == "" {
@@ -88,21 +88,21 @@ func toInitialCamel(s string, lower bool) string {
 }
 
 func trimBySeparators(s, separators string) string {
-    trimPattern := fmt.Sprintf("^%s+|%s+$", separators, separators)
-    re := regexp.MustCompile(trimPattern)
-    return re.ReplaceAllString(s, "")
+	trimPattern := fmt.Sprintf("^%s+|%s+$", separators, separators)
+	re := regexp.MustCompile(trimPattern)
+	return re.ReplaceAllString(s, "")
 }
 
 func splitBySeparators(s, separators string) []string {
-    re := regexp.MustCompile(separators)
-    parts := re.Split(s, -1)
-    var result []string
-    for _, part := range parts {
-        if part != "" {
-            result = append(result, part)
-        }
-    }
-    return result
+	re := regexp.MustCompile(separators)
+	parts := re.Split(s, -1)
+	var result []string
+	for _, part := range parts {
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
 }
 
 // RenderDoc returns proper go doc comment from

--- a/v3/generator/helpers/helpers_test.go
+++ b/v3/generator/helpers/helpers_test.go
@@ -16,26 +16,26 @@ func TestToCamel(t *testing.T) {
 
 	// trimming
 	require.Equal(t, "Test", ToCamel("---test"))
-    require.Equal(t, "Test", ToCamel("test___"))
-    require.Equal(t, "Test", ToCamel(".-_test_-."))
-    require.Equal(t, "Test", ToCamel("  test  "))
-    require.Equal(t, "Test", ToCamel(" .-_test_-. "))
+	require.Equal(t, "Test", ToCamel("test___"))
+	require.Equal(t, "Test", ToCamel(".-_test_-."))
+	require.Equal(t, "Test", ToCamel("  test  "))
+	require.Equal(t, "Test", ToCamel(" .-_test_-. "))
 
 	// splitting
-    require.Equal(t, "TestFooBarBaz", ToCamel("test-foo_bar.baz"))
-    require.Equal(t, "TestFooBar", ToCamel("test--_foo..bar"))
-    require.Equal(t, "TESTFooBAR", ToCamel("TEST-Foo-BAR"))
-    require.Equal(t, "Test123Foo", ToCamel("test-123-foo"))
-    require.Equal(t, "123", ToCamel("1-2-3"))
+	require.Equal(t, "TestFooBarBaz", ToCamel("test-foo_bar.baz"))
+	require.Equal(t, "TestFooBar", ToCamel("test--_foo..bar"))
+	require.Equal(t, "TESTFooBAR", ToCamel("TEST-Foo-BAR"))
+	require.Equal(t, "Test123Foo", ToCamel("test-123-foo"))
+	require.Equal(t, "123", ToCamel("1-2-3"))
 
 	// trimming and splitting
 	require.Equal(t, "TrimMixedSeparators", ToCamel("-_. trim-mixed/separators ._-"))
 
 	// Acronym handling
-    require.Equal(t, "HandleXMLHTTPRequest", ToCamel("handle-xml-http-request"))
-    require.Equal(t, "ParseJSONAPI", ToCamel("parse_json_api"))
-    require.Equal(t, "NewURLForID", ToCamel("new-url-for-id"))
-    require.Equal(t, "SupportSQLQueries", ToCamel("support-sql-queries"))
+	require.Equal(t, "HandleXMLHTTPRequest", ToCamel("handle-xml-http-request"))
+	require.Equal(t, "ParseJSONAPI", ToCamel("parse_json_api"))
+	require.Equal(t, "NewURLForID", ToCamel("new-url-for-id"))
+	require.Equal(t, "SupportSQLQueries", ToCamel("support-sql-queries"))
 
 }
 

--- a/v3/generator/helpers/helpers_test.go
+++ b/v3/generator/helpers/helpers_test.go
@@ -13,6 +13,30 @@ func TestToCamel(t *testing.T) {
 	require.Equal(t, "Test", ToCamel("test"))
 	require.Equal(t, "", ToCamel("."))
 	require.Equal(t, "TestFoo", ToCamel("test...foo"))
+
+	// trimming
+	require.Equal(t, "Test", ToCamel("---test"))
+    require.Equal(t, "Test", ToCamel("test___"))
+    require.Equal(t, "Test", ToCamel(".-_test_-."))
+    require.Equal(t, "Test", ToCamel("  test  "))
+    require.Equal(t, "Test", ToCamel(" .-_test_-. "))
+
+	// splitting
+    require.Equal(t, "TestFooBarBaz", ToCamel("test-foo_bar.baz"))
+    require.Equal(t, "TestFooBar", ToCamel("test--_foo..bar"))
+    require.Equal(t, "TESTFooBAR", ToCamel("TEST-Foo-BAR"))
+    require.Equal(t, "Test123Foo", ToCamel("test-123-foo"))
+    require.Equal(t, "123", ToCamel("1-2-3"))
+
+	// trimming and splitting
+	require.Equal(t, "TrimMixedSeparators", ToCamel("-_. trim-mixed/separators ._-"))
+
+	// Acronym handling
+    require.Equal(t, "HandleXMLHTTPRequest", ToCamel("handle-xml-http-request"))
+    require.Equal(t, "ParseJSONAPI", ToCamel("parse_json_api"))
+    require.Equal(t, "NewURLForID", ToCamel("new-url-for-id"))
+    require.Equal(t, "SupportSQLQueries", ToCamel("support-sql-queries"))
+
 }
 
 func TestToLowerCamel(t *testing.T) {


### PR DESCRIPTION
# Description
Generator would break with the [new DBaaS enums for Datadog](https://github.com/exoscale/dbaas-api/blob/40b1ba53298095740a736f55905f3e4aff62a542/modules/dbaas-schemas/resources/schemas/dbaas-api.edn#L2562)

```clojure
  :enum-datadog-site
  #{"us3.datadoghq.com"
    "ddog-gov.com"
    "datadoghq.eu"
    "us5.datadoghq.com"
    "ap1.datadoghq.com"
    "datadoghq.com"}
```
For the entry "ddog-gov.com" the existing code considers only one separator and it generates 
```go
EnumDatadogSiteDdogGov.com      EnumDatadogSite = "ddog-gov.com"
```

With these changes it would generate 
```go
EnumDatadogSiteDdogGovCom      EnumDatadogSite = "ddog-gov.com"
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] For a new resource or new attributes: test added/updated
