### PR TITLE
v3: fix WithHttpClient name

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -214,7 +214,17 @@ func (c *Client) WithTrace() *Client {
 }
 
 // WithHttpClient returns a copy of Client with new http.Client.
+// Deprecated: use WithHTTPClient instead.
 func (c *Client) WithHttpClient(client *http.Client) *Client {
+	clone := cloneClient(c)
+
+	clone.httpClient = client
+
+	return clone
+}
+
+// WithHTTPClient returns a copy of Client with new http.Client.
+func (c *Client) WithHTTPClient(client *http.Client) *Client {
 	clone := cloneClient(c)
 
 	clone.httpClient = client

--- a/v3/generator/client/client.tmpl
+++ b/v3/generator/client/client.tmpl
@@ -192,7 +192,17 @@ func (c *Client) WithTrace() *Client {
 }
 
 // WithHttpClient returns a copy of Client with new http.Client.
+// Deprecated: use WithHTTPClient instead.
 func (c *Client) WithHttpClient(client *http.Client) *Client {
+	clone := cloneClient(c)
+
+	clone.httpClient = client
+
+	return clone
+}
+
+// WithHTTPClient returns a copy of Client with new http.Client.
+func (c *Client) WithHTTPClient(client *http.Client) *Client {
 	clone := cloneClient(c)
 
 	clone.httpClient = client


### PR DESCRIPTION
# Description

- deprecate `WithHttpClient`
- add `WithHTTPClient`

Use the same initialism as `ClientOptWithHTTPClient`.
