### PR TITLE
v3: acl bug fix removing the "omitempty" tag from the acl DBAASOpensearchAclConfigAcl list

### DIFF
--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -792,7 +792,7 @@ type DBAASOpensearchAclConfig struct {
 	// Enable OpenSearch ACLs. When disabled authenticated service users have unrestricted access.
 	AclEnabled *bool `json:"acl-enabled,omitempty"`
 	// List of OpenSearch ACLs
-	Acls []DBAASOpensearchAclConfigAcls `json:"acls,omitempty"`
+	Acls []DBAASOpensearchAclConfigAcls `json:"acls"`
 	// Enable to enforce index rules in a limited fashion for requests that use the _mget, _msearch, and _bulk APIs
 	ExtendedAclEnabled *bool `json:"extended-acl-enabled,omitempty"`
 }


### PR DESCRIPTION
# Description
Removing the `omitempty` tag from the `acl DBAASOpensearchAclConfigAcls` list, because it will remove the `acl: []` from the `payload` if the list is empty therefore it will trigger api error if someone tried to delete the last acl user from the list.


with the `omitempty` the payload with an empty list will look like this:
```
2024/12/29 14:10:43 Payload Sent to API: {
  "acl-enabled": false,
  "extended-acl-enabled": false
}
```
which will trigger an error 
`Bad Request: Invalid value in [3].acls - should be a Collection` 

Without the `omitempty` the payload with an empty list will look like this:
```
2024/12/29 14:10:43 Payload Sent to API: {
  "acl-enabled": false,
  "acls": [],
  "extended-acl-enabled": false
}
```
Which will not trigger any error.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
