### PR TITLE
v3: helper for finding instance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+----------
+- v3: Support for finding InstanceTypes by family and size #681
+
 3.1.9
 ----------
 - v3: Reduce minimum blockstorage size to 1GiB from 10GiB


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Code generated by egoscale for FindInstanceType only allows finding by `id`. We allow users to specify a string of the form `{{InstanceType.Family}}.{{InstanceType.Size}}` for instance types; as this is a unique case, rather that complexify the rendering template, we add a small different helper that allows for this.

Already exists in `terraform-provider-exoscale` as a [helper](https://github.com/exoscale/terraform-provider-exoscale/blob/ffc19c87f1b7f3d2e1a590d553f8ac9c7119aa96/pkg/utils/utils.go#L278), which should be removed

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
