### PR TITLE
prettify Not found responses for show commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unrelease
+----------
+- v3: fix `Not Found` responses for `show` commands #683
+
 3.1.14
 ------
 

--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -283,8 +283,7 @@ func (l {{ .ListTypeName }}) Find{{ .TypeName }}({{ .ParamName }} string) ({{ .T
 	if len(result) > 1 {
 		return {{ .TypeName }}{}, fmt.Errorf("%q too many found in {{ .ListTypeName }}: %w", {{ .ParamName }}, ErrConflict)
 	}
-
-	return {{ .TypeName }}{}, fmt.Errorf("%q not found in {{ .ListTypeName }}: %w", {{ .ParamName }}, ErrNotFound)
+	return {{ .TypeName }}{}, fmt.Errorf("%q : %w", {{ .ParamName }}, ErrNotFound)
 }
 `
 

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -31,8 +31,7 @@ func (l ListAntiAffinityGroupsResponse) FindAntiAffinityGroup(nameOrID string) (
 	if len(result) > 1 {
 		return AntiAffinityGroup{}, fmt.Errorf("%q too many found in ListAntiAffinityGroupsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return AntiAffinityGroup{}, fmt.Errorf("%q not found in ListAntiAffinityGroupsResponse: %w", nameOrID, ErrNotFound)
+	return AntiAffinityGroup{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Anti-affinity Groups
@@ -244,8 +243,7 @@ func (l ListAPIKeysResponse) FindIAMAPIKey(nameOrKey string) (IAMAPIKey, error) 
 	if len(result) > 1 {
 		return IAMAPIKey{}, fmt.Errorf("%q too many found in ListAPIKeysResponse: %w", nameOrKey, ErrConflict)
 	}
-
-	return IAMAPIKey{}, fmt.Errorf("%q not found in ListAPIKeysResponse: %w", nameOrKey, ErrNotFound)
+	return IAMAPIKey{}, fmt.Errorf("%q : %w", nameOrKey, ErrNotFound)
 }
 
 // List API keys
@@ -457,8 +455,7 @@ func (l ListBlockStorageVolumesResponse) FindBlockStorageVolume(nameOrID string)
 	if len(result) > 1 {
 		return BlockStorageVolume{}, fmt.Errorf("%q too many found in ListBlockStorageVolumesResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return BlockStorageVolume{}, fmt.Errorf("%q not found in ListBlockStorageVolumesResponse: %w", nameOrID, ErrNotFound)
+	return BlockStorageVolume{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 type ListBlockStorageVolumesOpt func(url.Values)
@@ -602,8 +599,7 @@ func (l ListBlockStorageSnapshotsResponse) FindBlockStorageSnapshot(nameOrID str
 	if len(result) > 1 {
 		return BlockStorageSnapshot{}, fmt.Errorf("%q too many found in ListBlockStorageSnapshotsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return BlockStorageSnapshot{}, fmt.Errorf("%q not found in ListBlockStorageSnapshotsResponse: %w", nameOrID, ErrNotFound)
+	return BlockStorageSnapshot{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List block storage snapshots
@@ -2387,8 +2383,7 @@ func (l ListDBAASExternalEndpointsResponse) FindDBAASExternalEndpoint(nameOrID s
 	if len(result) > 1 {
 		return DBAASExternalEndpoint{}, fmt.Errorf("%q too many found in ListDBAASExternalEndpointsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return DBAASExternalEndpoint{}, fmt.Errorf("%q not found in ListDBAASExternalEndpointsResponse: %w", nameOrID, ErrNotFound)
+	return DBAASExternalEndpoint{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // [BETA] List available external endpoints for integrations
@@ -7361,8 +7356,7 @@ func (l ListDBAASServicesResponse) FindDBAASServiceCommon(name string) (DBAASSer
 	if len(result) > 1 {
 		return DBAASServiceCommon{}, fmt.Errorf("%q too many found in ListDBAASServicesResponse: %w", name, ErrConflict)
 	}
-
-	return DBAASServiceCommon{}, fmt.Errorf("%q not found in ListDBAASServicesResponse: %w", name, ErrNotFound)
+	return DBAASServiceCommon{}, fmt.Errorf("%q : %w", name, ErrNotFound)
 }
 
 // List DBaaS services
@@ -7557,8 +7551,7 @@ func (l ListDBAASServiceTypesResponse) FindDBAASServiceType(name string) (DBAASS
 	if len(result) > 1 {
 		return DBAASServiceType{}, fmt.Errorf("%q too many found in ListDBAASServiceTypesResponse: %w", name, ErrConflict)
 	}
-
-	return DBAASServiceType{}, fmt.Errorf("%q not found in ListDBAASServiceTypesResponse: %w", name, ErrNotFound)
+	return DBAASServiceType{}, fmt.Errorf("%q : %w", name, ErrNotFound)
 }
 
 // List available service types for DBaaS
@@ -8891,8 +8884,7 @@ func (l ListDeployTargetsResponse) FindDeployTarget(nameOrID string) (DeployTarg
 	if len(result) > 1 {
 		return DeployTarget{}, fmt.Errorf("%q too many found in ListDeployTargetsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return DeployTarget{}, fmt.Errorf("%q not found in ListDeployTargetsResponse: %w", nameOrID, ErrNotFound)
+	return DeployTarget{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Deploy Targets
@@ -9002,8 +8994,7 @@ func (l ListDNSDomainsResponse) FindDNSDomain(idOrUnicodeName string) (DNSDomain
 	if len(result) > 1 {
 		return DNSDomain{}, fmt.Errorf("%q too many found in ListDNSDomainsResponse: %w", idOrUnicodeName, ErrConflict)
 	}
-
-	return DNSDomain{}, fmt.Errorf("%q not found in ListDNSDomainsResponse: %w", idOrUnicodeName, ErrNotFound)
+	return DNSDomain{}, fmt.Errorf("%q : %w", idOrUnicodeName, ErrNotFound)
 }
 
 // List DNS domains
@@ -9126,8 +9117,7 @@ func (l ListDNSDomainRecordsResponse) FindDNSDomainRecord(nameOrID string) (DNSD
 	if len(result) > 1 {
 		return DNSDomainRecord{}, fmt.Errorf("%q too many found in ListDNSDomainRecordsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return DNSDomainRecord{}, fmt.Errorf("%q not found in ListDNSDomainRecordsResponse: %w", nameOrID, ErrNotFound)
+	return DNSDomainRecord{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List DNS domain records
@@ -9563,8 +9553,7 @@ func (l ListElasticIPSResponse) FindElasticIP(idOrIP string) (ElasticIP, error) 
 	if len(result) > 1 {
 		return ElasticIP{}, fmt.Errorf("%q too many found in ListElasticIPSResponse: %w", idOrIP, ErrConflict)
 	}
-
-	return ElasticIP{}, fmt.Errorf("%q not found in ListElasticIPSResponse: %w", idOrIP, ErrNotFound)
+	return ElasticIP{}, fmt.Errorf("%q : %w", idOrIP, ErrNotFound)
 }
 
 // List Elastic IPs
@@ -10214,8 +10203,7 @@ func (l ListIAMRolesResponse) FindIAMRole(nameOrID string) (IAMRole, error) {
 	if len(result) > 1 {
 		return IAMRole{}, fmt.Errorf("%q too many found in ListIAMRolesResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return IAMRole{}, fmt.Errorf("%q not found in ListIAMRolesResponse: %w", nameOrID, ErrNotFound)
+	return IAMRole{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List IAM Roles
@@ -10585,8 +10573,7 @@ func (l ListInstancesResponse) FindListInstancesResponseInstances(nameOrID strin
 	if len(result) > 1 {
 		return ListInstancesResponseInstances{}, fmt.Errorf("%q too many found in ListInstancesResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return ListInstancesResponseInstances{}, fmt.Errorf("%q not found in ListInstancesResponse: %w", nameOrID, ErrNotFound)
+	return ListInstancesResponseInstances{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 type ListInstancesManagerType string
@@ -10770,8 +10757,7 @@ func (l ListInstancePoolsResponse) FindInstancePool(nameOrID string) (InstancePo
 	if len(result) > 1 {
 		return InstancePool{}, fmt.Errorf("%q too many found in ListInstancePoolsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return InstancePool{}, fmt.Errorf("%q not found in ListInstancePoolsResponse: %w", nameOrID, ErrNotFound)
+	return InstancePool{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Instance Pools
@@ -11290,8 +11276,7 @@ func (l ListInstanceTypesResponse) FindInstanceType(id string) (InstanceType, er
 	if len(result) > 1 {
 		return InstanceType{}, fmt.Errorf("%q too many found in ListInstanceTypesResponse: %w", id, ErrConflict)
 	}
-
-	return InstanceType{}, fmt.Errorf("%q not found in ListInstanceTypesResponse: %w", id, ErrNotFound)
+	return InstanceType{}, fmt.Errorf("%q : %w", id, ErrNotFound)
 }
 
 // List Compute instance Types
@@ -12245,8 +12230,7 @@ func (l ListLoadBalancersResponse) FindLoadBalancer(nameOrID string) (LoadBalanc
 	if len(result) > 1 {
 		return LoadBalancer{}, fmt.Errorf("%q too many found in ListLoadBalancersResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return LoadBalancer{}, fmt.Errorf("%q not found in ListLoadBalancersResponse: %w", nameOrID, ErrNotFound)
+	return LoadBalancer{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Load Balancers
@@ -12963,8 +12947,7 @@ func (l ListPrivateNetworksResponse) FindPrivateNetwork(nameOrID string) (Privat
 	if len(result) > 1 {
 		return PrivateNetwork{}, fmt.Errorf("%q too many found in ListPrivateNetworksResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return PrivateNetwork{}, fmt.Errorf("%q not found in ListPrivateNetworksResponse: %w", nameOrID, ErrNotFound)
+	return PrivateNetwork{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Private Networks
@@ -13862,8 +13845,7 @@ func (l ListSecurityGroupsResponse) FindSecurityGroup(nameOrID string) (Security
 	if len(result) > 1 {
 		return SecurityGroup{}, fmt.Errorf("%q too many found in ListSecurityGroupsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return SecurityGroup{}, fmt.Errorf("%q not found in ListSecurityGroupsResponse: %w", nameOrID, ErrNotFound)
+	return SecurityGroup{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 type ListSecurityGroupsVisibility string
@@ -14465,8 +14447,7 @@ func (l ListSKSClustersResponse) FindSKSCluster(nameOrID string) (SKSCluster, er
 	if len(result) > 1 {
 		return SKSCluster{}, fmt.Errorf("%q too many found in ListSKSClustersResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return SKSCluster{}, fmt.Errorf("%q not found in ListSKSClustersResponse: %w", nameOrID, ErrNotFound)
+	return SKSCluster{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List SKS clusters
@@ -15712,8 +15693,7 @@ func (l ListSnapshotsResponse) FindSnapshot(nameOrID string) (Snapshot, error) {
 	if len(result) > 1 {
 		return Snapshot{}, fmt.Errorf("%q too many found in ListSnapshotsResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return Snapshot{}, fmt.Errorf("%q not found in ListSnapshotsResponse: %w", nameOrID, ErrNotFound)
+	return Snapshot{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 // List Snapshots
@@ -15975,8 +15955,7 @@ func (l ListSOSBucketsUsageResponse) FindSOSBucketUsage(name string) (SOSBucketU
 	if len(result) > 1 {
 		return SOSBucketUsage{}, fmt.Errorf("%q too many found in ListSOSBucketsUsageResponse: %w", name, ErrConflict)
 	}
-
-	return SOSBucketUsage{}, fmt.Errorf("%q not found in ListSOSBucketsUsageResponse: %w", name, ErrNotFound)
+	return SOSBucketUsage{}, fmt.Errorf("%q : %w", name, ErrNotFound)
 }
 
 // List SOS Buckets Usage
@@ -16106,8 +16085,7 @@ func (l ListSSHKeysResponse) FindSSHKey(nameOrFingerprint string) (SSHKey, error
 	if len(result) > 1 {
 		return SSHKey{}, fmt.Errorf("%q too many found in ListSSHKeysResponse: %w", nameOrFingerprint, ErrConflict)
 	}
-
-	return SSHKey{}, fmt.Errorf("%q not found in ListSSHKeysResponse: %w", nameOrFingerprint, ErrNotFound)
+	return SSHKey{}, fmt.Errorf("%q : %w", nameOrFingerprint, ErrNotFound)
 }
 
 // List SSH keys
@@ -16319,8 +16297,7 @@ func (l ListTemplatesResponse) FindTemplate(nameOrID string) (Template, error) {
 	if len(result) > 1 {
 		return Template{}, fmt.Errorf("%q too many found in ListTemplatesResponse: %w", nameOrID, ErrConflict)
 	}
-
-	return Template{}, fmt.Errorf("%q not found in ListTemplatesResponse: %w", nameOrID, ErrNotFound)
+	return Template{}, fmt.Errorf("%q : %w", nameOrID, ErrNotFound)
 }
 
 type ListTemplatesVisibility string
@@ -16702,8 +16679,7 @@ func (l ListUsersResponse) FindUser(id string) (User, error) {
 	if len(result) > 1 {
 		return User{}, fmt.Errorf("%q too many found in ListUsersResponse: %w", id, ErrConflict)
 	}
-
-	return User{}, fmt.Errorf("%q not found in ListUsersResponse: %w", id, ErrNotFound)
+	return User{}, fmt.Errorf("%q : %w", id, ErrNotFound)
 }
 
 // List Users
@@ -16927,8 +16903,7 @@ func (l ListZonesResponse) FindZone(nameOrAPIEndpoint string) (Zone, error) {
 	if len(result) > 1 {
 		return Zone{}, fmt.Errorf("%q too many found in ListZonesResponse: %w", nameOrAPIEndpoint, ErrConflict)
 	}
-
-	return Zone{}, fmt.Errorf("%q not found in ListZonesResponse: %w", nameOrAPIEndpoint, ErrNotFound)
+	return Zone{}, fmt.Errorf("%q : %w", nameOrAPIEndpoint, ErrNotFound)
 }
 
 // List Zones


### PR DESCRIPTION
# Description
current responses look something like:
`error: "privnet-sof" in ListPrivateNetworksResponse: Not Found`

with the fix:
```
go run main.go compute privnet list
┼──────────────────────────────────────┼───────────────────┼──────────┼
│                  ID                  │       NAME        │   ZONE   │
┼──────────────────────────────────────┼───────────────────┼──────────┼
│ 5695b65a-14d8-4871-b0fe-2bfa4ea4a58f │ manual-to-managed │ ch-gva-2 │
│ 670ad241-e06f-48af-08b2-8a0bc675a1c7 │ managed-privnet   │ ch-gva-2 │
┼──────────────────────────────────────┼───────────────────┼──────────┼

go run main.go compute privnet show privnet-sof
error: "privnet-sof" : Not Found
```
the same for other entities:
```
go run main.go compute sks show not-found-cluster
error: "not-found-cluster" : Not Found
```

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
