### PR TITLE
generator v3: correctly build parameter keys for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- v3 Generator: correctly build parameter keys for queries #701 
+
 3.1.19
 ------
 

--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -184,9 +184,9 @@ func renderRequestSchema(name string, op *v3.Operation) ([]byte, error) {
 }
 
 const queryParamTemplate = `
-func {{ .FuncName }}({{ .ParamName }} {{ .ParamType }}) {{ .FuncReturn }} {
+func {{ .FuncName }}({{ .FieldName }} {{ .ParamType }}) {{ .FuncReturn }} {
 	return func(q url.Values) {
-		q.Add("{{ .ParamName }}", fmt.Sprint({{ .ParamName }}))
+		q.Add("{{ .ParamName }}", fmt.Sprint({{ .FieldName }}))
 	}
 }
 `
@@ -196,6 +196,7 @@ type QueryParam struct {
 	ParamName  string
 	ParamType  string
 	FuncReturn string
+	FieldName  string
 }
 
 // renderRequestParametersSchema renders the schemas for optional query params and path params.
@@ -224,7 +225,8 @@ func renderRequestParametersSchema(name string, op *v3.Operation) ([]byte, error
 			}
 			if err := t.Execute(query, QueryParam{
 				FuncName:   name + "With" + helpers.ToCamel(p.Name),
-				ParamName:  helpers.ToLowerCamel(p.Name),
+				FieldName:  helpers.ToLowerCamel(p.Name),
+				ParamName:  p.Name,
 				ParamType:  typ,
 				FuncReturn: name + "Opt",
 			}); err != nil {

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -465,7 +465,7 @@ type ListBlockStorageVolumesOpt func(url.Values)
 
 func ListBlockStorageVolumesWithInstanceID(instanceID UUID) ListBlockStorageVolumesOpt {
 	return func(q url.Values) {
-		q.Add("instanceID", fmt.Sprint(instanceID))
+		q.Add("instance-id", fmt.Sprint(instanceID))
 	}
 }
 
@@ -10674,19 +10674,19 @@ type ListInstancesOpt func(url.Values)
 
 func ListInstancesWithManagerID(managerID UUID) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("managerID", fmt.Sprint(managerID))
+		q.Add("manager-id", fmt.Sprint(managerID))
 	}
 }
 
 func ListInstancesWithManagerType(managerType ListInstancesManagerType) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("managerType", fmt.Sprint(managerType))
+		q.Add("manager-type", fmt.Sprint(managerType))
 	}
 }
 
 func ListInstancesWithIPAddress(ipAddress string) ListInstancesOpt {
 	return func(q url.Values) {
-		q.Add("ipAddress", fmt.Sprint(ipAddress))
+		q.Add("ip-address", fmt.Sprint(ipAddress))
 	}
 }
 
@@ -14786,7 +14786,7 @@ type ListSKSClusterVersionsOpt func(url.Values)
 
 func ListSKSClusterVersionsWithIncludeDeprecated(includeDeprecated string) ListSKSClusterVersionsOpt {
 	return func(q url.Values) {
-		q.Add("includeDeprecated", fmt.Sprint(includeDeprecated))
+		q.Add("include-deprecated", fmt.Sprint(includeDeprecated))
 	}
 }
 


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->


`QueryParams` and its template vas missing a `FieldName` to differentiate between the name of the field in the golang struct and the actual json query

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
