### PR TITLE
Bump Go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 
-go 1.23.8
+go 1.24
 
 retract (
 	v1.19.1 // Retracts the previous version


### PR DESCRIPTION
# Description

Fixes govulncheck report.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
