### PR TITLE
Bump go.mk (and goreleaser)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
 - skip: true
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v2.0.3
+GO_MK_REF := v2.0.4
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

* bumps goreleaser v2.10.2
* updates goreleaser.yaml for new major version of goreleaser

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] For a new resource or new attributes: test added/updated
