### PR TITLE
v3: read RFC 9457 detail and title from error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+unreleased
+----------
+
+- v3: read RFC 9457 detail and title from error responses
+
 3.1.35
 ----------
 

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -99,6 +99,8 @@ func handleHTTPErrorResp(resp *http.Response) error {
 		var res struct {
 			Message string `json:"message"`
 			Error   string `json:"error"`
+			Detail  string `json:"detail"`
+			Title   string `json:"title"`
 		}
 
 		data, err := io.ReadAll(resp.Body)
@@ -115,8 +117,14 @@ func handleHTTPErrorResp(resp *http.Response) error {
 		}
 
 		message := res.Message
-		if message == "" && res.Error != "" {
+		if message == "" {
 			message = res.Error
+		}
+		if message == "" {
+			message = res.Detail
+		}
+		if message == "" {
+			message = res.Title
 		}
 
 		err, ok := httpStatusCodeErrors[resp.StatusCode]

--- a/v3/errors_test.go
+++ b/v3/errors_test.go
@@ -1,0 +1,71 @@
+package v3
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHandleHTTPErrorResp(t *testing.T) {
+	tests := []struct {
+		statusCode    int
+		body          string
+		expectError   bool
+		expectedInMsg string
+		description   string
+	}{
+		{
+			statusCode:    400,
+			body:          `{"message":"something went wrong"}`,
+			expectError:   true,
+			expectedInMsg: "something went wrong",
+			description:   "Legacy message field should be used",
+		},
+		{
+			statusCode:    400,
+			body:          `{"type":"#/http-problem-types/bad-request","title":"Bad Request","detail":"required key [id] not found"}`,
+			expectError:   true,
+			expectedInMsg: "required key [id] not found",
+			description:   "RFC 9457 detail field should be used",
+		},
+		{
+			statusCode:    409,
+			body:          `{"type":"#/http-problem-types/conflict","title":"Conflict"}`,
+			expectError:   true,
+			expectedInMsg: "Conflict",
+			description:   "RFC 9457 title field as fallback",
+		},
+		{
+			statusCode:    200,
+			body:          `{"id":"abc"}`,
+			expectError:   false,
+			expectedInMsg: "",
+			description:   "2xx responses should pass through",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{
+				StatusCode: test.statusCode,
+				Body:       io.NopCloser(strings.NewReader(test.body)),
+			}
+			err := handleHTTPErrorResp(resp)
+
+			if test.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), test.expectedInMsg) {
+					t.Errorf("expected %q in error, got: %s", test.expectedInMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %s", err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
v3: handleHTTPErrorResp now reads detail and title fields from RFC 9457 problem+json error responses.

Some APIs return errors in RFC 9457 format with detail and title fields. The Go client only looked for message and error fields. Both are absent in RFC 9457 responses, so the error message stayed empty. Users saw "Bad Request:" with nothing after the colon.

I added Detail and Title to the response struct and extended the fallback chain to message → error → detail → title. Legacy responses with message/error fields still work. RFC 9457 responses now surface their error details.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)