### PR TITLE
chore: downgrade min go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 
-go 1.26
+go 1.25
 
 retract (
 	v1.19.1 // Retracts the previous version

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/egoscale/v3
 
-go 1.26
+go 1.25
 
 require (
 	github.com/diskfs/go-diskfs v1.4.0


### PR DESCRIPTION
# Description

The PR #754 make no sense: `egoscale` is a library not a binary, updating the min Go version doesn't fix any security issue.

Since go1.21, the Go version used inside the [`go.mod`](https://github.com/exoscale/egoscale/blob/33446130ebd99367642264b5162a80752eaeafe8/v3/go.mod#L3) is the minimum Go version, and it's a hard requirement.

As `egoscale` is a library, each time you update the minimum Go version, you are forcing all the library consumers to update their minimum Go version.

A library should avoid doing that.

The minimum Go version defines the version of the language used to write the code.

The Go version inside `toolchain` defines the Go version used to compile a binary (`egoscale` doesn't have `main` package, so it's useless in this context) or run the tests, and doesn't affect lib consumers.

The Go team maintains the [2 latest minor versions](https://go.dev/doc/devel/release#policy): currently go1.25 and go1.26.
I can understand an update to min go1.25.0, even though there is no code requirement, but go1.26 is inappropriate for a library.

As a library, updating the min version doesn't fix any CVE related to Go.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
