### PR TITLE
fix(v3): derive zone endpoint from name without calling ListZones

### DIFF
--- a/v3/client.go
+++ b/v3/client.go
@@ -32,6 +32,11 @@ const (
 	HrZag1 Endpoint = "https://api-hr-zag-1.exoscale.com/v2"
 )
 
+const (
+	zoneEndpointPrefix = "https://api-"
+	zoneEndpointSuffix = ".exoscale.com/v2"
+)
+
 // defaultHTTPClient is HTTP client with retry logic.
 // Default retry configuration can be found in go-retryablehttp repo.
 var defaultHTTPClient = func() *http.Client {
@@ -41,24 +46,6 @@ var defaultHTTPClient = func() *http.Client {
 	return rc.StandardClient()
 }()
 
-const (
-	zoneEndpointPrefix = "https://api-"
-	zoneEndpointSuffix = ".exoscale.com/v2"
-)
-
-// GetZoneAPIEndpoint returns the API endpoint URL for a given zone name.
-// It derives the URL directly from the zone name without making an API call,
-// which means it works with any IAM role regardless of compute permissions.
-func (c Client) GetZoneAPIEndpoint(_ context.Context, zoneName ZoneName) (Endpoint, error) {
-	if zoneName == "" {
-		return "", fmt.Errorf("get zone api endpoint: zone name is empty")
-	}
-	return Endpoint(zoneEndpointPrefix + string(zoneName) + zoneEndpointSuffix), nil
-}
-
-// GetZoneName returns the zone name for a given API endpoint URL.
-// It derives the zone name directly from the endpoint URL without making an API call,
-// which means it works with any IAM role regardless of compute permissions.
 func (c Client) GetZoneName(_ context.Context, endpoint Endpoint) (ZoneName, error) {
 	s := string(endpoint)
 	if !strings.HasPrefix(s, zoneEndpointPrefix) || !strings.HasSuffix(s, zoneEndpointSuffix) {
@@ -70,6 +57,16 @@ func (c Client) GetZoneName(_ context.Context, endpoint Endpoint) (ZoneName, err
 		return "", fmt.Errorf("get zone name: could not parse zone name from endpoint %q: %w", endpoint, ErrNotFound)
 	}
 	return ZoneName(name), nil
+}
+
+// GetZoneAPIEndpoint returns the API endpoint URL for a given zone name.
+// It derives the URL directly from the zone name without making an API call,
+// which means it works with any IAM role regardless of compute permissions.
+func (c Client) GetZoneAPIEndpoint(_ context.Context, zoneName ZoneName) (Endpoint, error) {
+	if zoneName == "" {
+		return "", fmt.Errorf("get zone api endpoint: zone name is empty")
+	}
+	return Endpoint(zoneEndpointPrefix + string(zoneName) + zoneEndpointSuffix), nil
 }
 
 // Client represents an Exoscale API client.

--- a/v3/client.go
+++ b/v3/client.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/exoscale/egoscale/v3/credentials"
@@ -40,32 +41,35 @@ var defaultHTTPClient = func() *http.Client {
 	return rc.StandardClient()
 }()
 
-func (c Client) GetZoneName(ctx context.Context, endpoint Endpoint) (ZoneName, error) {
-	resp, err := c.ListZones(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get zone name: list zones: %w", err)
-	}
+const (
+	zoneEndpointPrefix = "https://api-"
+	zoneEndpointSuffix = ".exoscale.com/v2"
+)
 
-	zone, err := resp.FindZone(string(endpoint))
-	if err != nil {
-		return "", fmt.Errorf("get zone name: find zone: %w", err)
+// GetZoneAPIEndpoint returns the API endpoint URL for a given zone name.
+// It derives the URL directly from the zone name without making an API call,
+// which means it works with any IAM role regardless of compute permissions.
+func (c Client) GetZoneAPIEndpoint(_ context.Context, zoneName ZoneName) (Endpoint, error) {
+	if zoneName == "" {
+		return "", fmt.Errorf("get zone api endpoint: zone name is empty")
 	}
-
-	return zone.Name, nil
+	return Endpoint(zoneEndpointPrefix + string(zoneName) + zoneEndpointSuffix), nil
 }
 
-func (c Client) GetZoneAPIEndpoint(ctx context.Context, zoneName ZoneName) (Endpoint, error) {
-	resp, err := c.ListZones(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get zone api endpoint: list zones: %w", err)
+// GetZoneName returns the zone name for a given API endpoint URL.
+// It derives the zone name directly from the endpoint URL without making an API call,
+// which means it works with any IAM role regardless of compute permissions.
+func (c Client) GetZoneName(_ context.Context, endpoint Endpoint) (ZoneName, error) {
+	s := string(endpoint)
+	if !strings.HasPrefix(s, zoneEndpointPrefix) || !strings.HasSuffix(s, zoneEndpointSuffix) {
+		return "", fmt.Errorf("get zone name: %q is not a recognized Exoscale zone endpoint: %w", endpoint, ErrNotFound)
 	}
-
-	zone, err := resp.FindZone(string(zoneName))
-	if err != nil {
-		return "", fmt.Errorf("get zone api endpoint: find zone: %w", err)
+	name := strings.TrimPrefix(s, zoneEndpointPrefix)
+	name = strings.TrimSuffix(name, zoneEndpointSuffix)
+	if name == "" {
+		return "", fmt.Errorf("get zone name: could not parse zone name from endpoint %q: %w", endpoint, ErrNotFound)
 	}
-
-	return zone.APIEndpoint, nil
+	return ZoneName(name), nil
 }
 
 // Client represents an Exoscale API client.

--- a/v3/client_test.go
+++ b/v3/client_test.go
@@ -1,0 +1,228 @@
+package v3
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGetZoneAPIEndpoint(t *testing.T) {
+	c := Client{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		zoneName    ZoneName
+		want        Endpoint
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "ch-gva-2",
+			zoneName: ZoneNameCHGva2,
+			want:     CHGva2,
+		},
+		{
+			name:     "ch-dk-2",
+			zoneName: ZoneNameCHDk2,
+			want:     CHDk2,
+		},
+		{
+			name:     "de-fra-1",
+			zoneName: ZoneNameDEFra1,
+			want:     DEFra1,
+		},
+		{
+			name:     "de-muc-1",
+			zoneName: ZoneNameDEMuc1,
+			want:     DEMuc1,
+		},
+		{
+			name:     "at-vie-1",
+			zoneName: ZoneNameATVie1,
+			want:     ATVie1,
+		},
+		{
+			name:     "at-vie-2",
+			zoneName: ZoneNameATVie2,
+			want:     ATVie2,
+		},
+		{
+			name:     "bg-sof-1",
+			zoneName: ZoneNameBGSof1,
+			want:     BGSof1,
+		},
+		{
+			name:     "hr-zag-1",
+			zoneName: ZoneNameHrZag1,
+			want:     HrZag1,
+		},
+		{
+			// A hypothetical future zone that doesn't exist in the constants yet
+			// should still produce a valid endpoint without needing an API call
+			name:     "future zone",
+			zoneName: ZoneName("xx-new-1"),
+			want:     Endpoint("https://api-xx-new-1.exoscale.com/v2"),
+		},
+		{
+			name:        "empty zone name",
+			zoneName:    "",
+			wantErr:     true,
+			errContains: "zone name is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.GetZoneAPIEndpoint(ctx, tt.zoneName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetZoneAPIEndpoint(%q) expected error, got nil", tt.zoneName)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("GetZoneAPIEndpoint(%q) error = %q, want it to contain %q", tt.zoneName, err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetZoneAPIEndpoint(%q) unexpected error: %v", tt.zoneName, err)
+			}
+			if got != tt.want {
+				t.Errorf("GetZoneAPIEndpoint(%q) = %q, want %q", tt.zoneName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetZoneName(t *testing.T) {
+	c := Client{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		endpoint    Endpoint
+		want        ZoneName
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "ch-gva-2",
+			endpoint: CHGva2,
+			want:     ZoneNameCHGva2,
+		},
+		{
+			name:     "ch-dk-2",
+			endpoint: CHDk2,
+			want:     ZoneNameCHDk2,
+		},
+		{
+			name:     "de-fra-1",
+			endpoint: DEFra1,
+			want:     ZoneNameDEFra1,
+		},
+		{
+			name:     "de-muc-1",
+			endpoint: DEMuc1,
+			want:     ZoneNameDEMuc1,
+		},
+		{
+			name:     "at-vie-1",
+			endpoint: ATVie1,
+			want:     ZoneNameATVie1,
+		},
+		{
+			name:     "at-vie-2",
+			endpoint: ATVie2,
+			want:     ZoneNameATVie2,
+		},
+		{
+			name:     "bg-sof-1",
+			endpoint: BGSof1,
+			want:     ZoneNameBGSof1,
+		},
+		{
+			name:     "hr-zag-1",
+			endpoint: HrZag1,
+			want:     ZoneNameHrZag1,
+		},
+		{
+			// Round-trip: an endpoint built by GetZoneAPIEndpoint for a future zone
+			// should survive a GetZoneName call
+			name:     "future zone round-trip",
+			endpoint: Endpoint("https://api-xx-new-1.exoscale.com/v2"),
+			want:     ZoneName("xx-new-1"),
+		},
+		{
+			name:        "unrecognized endpoint",
+			endpoint:    Endpoint("https://example.com/api"),
+			wantErr:     true,
+			errContains: "not a recognized Exoscale zone endpoint",
+		},
+		{
+			name:        "empty endpoint",
+			endpoint:    "",
+			wantErr:     true,
+			errContains: "not a recognized Exoscale zone endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.GetZoneName(ctx, tt.endpoint)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetZoneName(%q) expected error, got nil", tt.endpoint)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("GetZoneName(%q) error = %q, want it to contain %q", tt.endpoint, err.Error(), tt.errContains)
+				}
+				// Errors about unrecognized endpoints should wrap ErrNotFound
+				if !errors.Is(err, ErrNotFound) {
+					t.Errorf("GetZoneName(%q) error should wrap ErrNotFound, got: %v", tt.endpoint, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetZoneName(%q) unexpected error: %v", tt.endpoint, err)
+			}
+			if got != tt.want {
+				t.Errorf("GetZoneName(%q) = %q, want %q", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetZoneAPIEndpointRoundTrip(t *testing.T) {
+	c := Client{}
+	ctx := context.Background()
+
+	zones := []ZoneName{
+		ZoneNameCHGva2,
+		ZoneNameCHDk2,
+		ZoneNameDEFra1,
+		ZoneNameDEMuc1,
+		ZoneNameATVie1,
+		ZoneNameATVie2,
+		ZoneNameBGSof1,
+		ZoneNameHrZag1,
+	}
+
+	for _, zone := range zones {
+		t.Run(string(zone), func(t *testing.T) {
+			endpoint, err := c.GetZoneAPIEndpoint(ctx, zone)
+			if err != nil {
+				t.Fatalf("GetZoneAPIEndpoint(%q) unexpected error: %v", zone, err)
+			}
+
+			roundTripped, err := c.GetZoneName(ctx, endpoint)
+			if err != nil {
+				t.Fatalf("GetZoneName(%q) unexpected error: %v", endpoint, err)
+			}
+
+			if roundTripped != zone {
+				t.Errorf("round-trip mismatch: started with %q, got back %q", zone, roundTripped)
+			}
+		})
+	}
+}

--- a/v3/generator/client/client.go
+++ b/v3/generator/client/client.go
@@ -35,6 +35,7 @@ func Generate(doc libopenapi.Document, path, packageName string) error {
 		"net/http"
 		"context"
 		"runtime"
+		"strings"
 		"time"
 
 		"github.com/exoscale/egoscale/v3/credentials"

--- a/v3/generator/client/client.tmpl
+++ b/v3/generator/client/client.tmpl
@@ -5,6 +5,11 @@ const (
   {{ .Enum }}
 )
 
+const (
+	zoneEndpointPrefix = "https://api-"
+	zoneEndpointSuffix = ".exoscale.com/v2"
+)
+
 // defaultHTTPClient is HTTP client with retry logic.
 // Default retry configuration can be found in go-retryablehttp repo.
 var defaultHTTPClient = func() *http.Client {
@@ -14,32 +19,27 @@ var defaultHTTPClient = func() *http.Client {
 	return rc.StandardClient()
 }()
 
-func (c Client) GetZoneName(ctx context.Context, endpoint Endpoint) (ZoneName, error) {
-	resp, err := c.ListZones(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get zone name: list zones: %w", err)
+func (c Client) GetZoneName(_ context.Context, endpoint Endpoint) (ZoneName, error) {
+	s := string(endpoint)
+	if !strings.HasPrefix(s, zoneEndpointPrefix) || !strings.HasSuffix(s, zoneEndpointSuffix) {
+		return "", fmt.Errorf("get zone name: %q is not a recognized Exoscale zone endpoint: %w", endpoint, ErrNotFound)
 	}
-
-	zone, err := resp.FindZone(string(endpoint))
-	if err != nil {
-		return "", fmt.Errorf("get zone name: find zone: %w", err)
+	name := strings.TrimPrefix(s, zoneEndpointPrefix)
+	name = strings.TrimSuffix(name, zoneEndpointSuffix)
+	if name == "" {
+		return "", fmt.Errorf("get zone name: could not parse zone name from endpoint %q: %w", endpoint, ErrNotFound)
 	}
-
-	return zone.Name, nil
+	return ZoneName(name), nil
 }
 
-func (c Client) GetZoneAPIEndpoint(ctx context.Context, zoneName ZoneName) (Endpoint, error) {
-	resp, err := c.ListZones(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get zone api endpoint: list zones: %w", err)
+// GetZoneAPIEndpoint returns the API endpoint URL for a given zone name.
+// It derives the URL directly from the zone name without making an API call,
+// which means it works with any IAM role regardless of compute permissions.
+func (c Client) GetZoneAPIEndpoint(_ context.Context, zoneName ZoneName) (Endpoint, error) {
+	if zoneName == "" {
+		return "", fmt.Errorf("get zone api endpoint: zone name is empty")
 	}
-
-	zone, err := resp.FindZone(string(zoneName))
-	if err != nil {
-		return "", fmt.Errorf("get zone api endpoint: find zone: %w", err)
-	}
-
-	return zone.APIEndpoint, nil
+	return Endpoint(zoneEndpointPrefix + string(zoneName) + zoneEndpointSuffix), nil
 }
 
 // Client represents an Exoscale API client.


### PR DESCRIPTION
## Problem

`GetZoneAPIEndpoint` and `GetZoneName` both called `ListZones` internally. 

That operation belongs to the compute API, so any IAM role without compute permissions would hit a `Forbidden` error the moment any v3-based command tried to route to a zone-specific endpoint.

The symptom reported in https://github.com/exoscale/cli/issues/824 is a DBaaS-only role failing on `exo dbaas update --valkey-ip-filter` with:

```
error: unable to create client: switch client zone v3: get zone api endpoint: list zones: ListZones: http response: Forbidden: Forbidden by role policy for compute
```

The same role works fine for MySQL and OpenSearch because older code paths bypass `SwitchClientZoneV3`. 

All newer service types (Valkey, Thanos, and anything added going forward) are affected.

## Fix

The zone API endpoint follows a stable, consistent URL pattern:

```
https://api-<zone-name>.exoscale.com/v2
```

We can derive the endpoint directly from the zone name without touching the API. 

The reverse direction (endpoint to zone name) is equally straightforward by trimming the known prefix and suffix.

This means `GetZoneAPIEndpoint` and `GetZoneName` no longer need any API call at all, so they work with any IAM role, regardless of compute permissions.

The generator template is updated alongside the generated code so future regenerations produce the same behaviour.

## Changes

- `v3/client.go`: replace both functions with string-based derivation, no API call
- `v3/generator/client/client.tmpl`: update the template to match
- `v3/client_test.go`: new test file covering all known zones, error cases, and a round-trip test

## Testing

```
go test ./v3/... -run TestGetZone -v
```

All 29 subtests pass. The full package test suite is also clean.

> [!NOTE] 
> GitHub Copilot with Claude Sonnet 4.6 was used for writing tests, and proofreading this description.