### PR TITLE
v3: add AI API key operations and fix generator for RFC compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- v3 generator: fix panic on HTTP 204 and close response body on no-content responses (#766)
+- v3 generator: align error messages with Go naming conventions (Json => JSON) (#766)
+- v3: close response body in handleHTTPErrorResp to avoid connection leaks (#766)
+
 3.1.42
 ------
 

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -118,14 +118,13 @@ type APIErrorEntry struct {
 	Location string
 }
 
-func (e *APIError) Error() string {
-	return fmt.Sprintf("%s: %s", e.sentinel.Error(), e.Message)
-}
-
+func (e *APIError) Error() string { return e.sentinel.Error() }
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 func handleHTTPErrorResp(resp *http.Response) error {
 	if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
+		defer resp.Body.Close() // prevent connection leak on error responses
+
 		var res struct {
 			Message string          `json:"message"`
 			Error   string          `json:"error"`

--- a/v3/generator/main.go
+++ b/v3/generator/main.go
@@ -60,6 +60,7 @@ func init() {
 	// helpers package handle stardard Acronyms.
 	helpers.ConfigureAcronym("ssh", "SSH")
 	// Exoscale Specifics
+	helpers.ConfigureAcronym("ai", "AI")
 	helpers.ConfigureAcronym("iam", "IAM")
 	helpers.ConfigureAcronym("sks", "SKS")
 	helpers.ConfigureAcronym("sos", "SOS")

--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -113,6 +113,9 @@ func renderResponseSchema(name string, op *v3.Operation) ([]byte, error) {
 
 	for pair := op.Responses.Codes.First(); pair != nil; pair = pair.Next() {
 		response := pair.Value()
+		if response.Content == nil {
+			continue
+		}
 		// TODO support other content type from spec.
 		media, ok := response.Content.Get("application/json")
 		if !ok {
@@ -440,7 +443,21 @@ type RequestTmpl struct {
 	QueryParams        map[string]string
 	// SkipAuth is true for operations that must be called without credentials
 	// (e.g. list-zones which returns public data and should not trigger IAM enforcement).
-	SkipAuth bool
+	SkipAuth      bool
+	ErrReturn     string // "nil, " for body-returning ops, "" for no-body (error-only) ops
+	ReturnSection string // pre-rendered final return block injected verbatim into the template
+}
+
+// renderBodyReturnSection returns the final block of a generated operation function
+// that reads and decodes the JSON response body.
+func renderBodyReturnSection(bodyRespType, jsonResponseTarget, funcName string) string {
+	var b strings.Builder
+	b.WriteString("\tbodyresp := " + bodyRespType + "\n")
+	b.WriteString("\tif err := prepareJSONResponse(response, " + jsonResponseTarget + "); err != nil {\n")
+	b.WriteString("\t\treturn nil, fmt.Errorf(\"" + funcName + ": prepare JSON response: %w\", err)\n")
+	b.WriteString("\t}\n\n")
+	b.WriteString("\treturn bodyresp, nil")
+	return b.String()
 }
 
 // serializeRequest serializes the openAPI spec into the request template.
@@ -465,15 +482,14 @@ func serializeRequest(path, httpMethod, funcName string, op *v3.Operation) (*Req
 		}
 	}
 	p.ValueReturn = fmt.Sprintf("(%s)", strings.Join(valuesReturn, ", "))
-	// This should never happen in our Exoscale API spec.
-	// This is here as a reminder the day we add such a behavior in the OpenAPI spec.
 	if p.ValueReturn == "(error)" {
-		slog.Error(
-			"single error value return not implemented",
-			slog.String("path", path),
-			slog.String("operation", funcName),
-		)
-		return nil, nil
+		p.ErrReturn = ""
+		// response.Body must be closed even for no-content responses (e.g. HTTP 204)
+		// to return the underlying TCP connection to the pool.
+		p.ReturnSection = "\t_ = response.Body.Close()\n\treturn nil"
+	} else {
+		p.ErrReturn = "nil, "
+		p.ReturnSection = renderBodyReturnSection(p.BodyRespType, p.JSONResponseTarget, funcName)
 	}
 	p.URLPathBuilder = renderURLPathBuilder(path, op)
 

--- a/v3/generator/operations/request.tmpl
+++ b/v3/generator/operations/request.tmpl
@@ -5,13 +5,13 @@ func (c Client) {{ .Name }}({{ .Params }}) {{ .ValueReturn }} {
 	{{ if .BodyRequest }}
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: prepare Json body: %w", err)
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: prepare JSON body: %w", err)
 	}
 	{{ end }}
 
 	request, err := http.NewRequestWithContext(ctx, "{{ .HTTPMethod }}", c.serverEndpoint + path, {{ if .BodyRequest }}body{{else}}nil{{end}})
 	if err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: new request: %w", err)
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: new request: %w", err)
 	}
 
 	request.Header.Add("User-Agent", c.getUserAgent())
@@ -29,14 +29,14 @@ func (c Client) {{ .Name }}({{ .Params }}) {{ .ValueReturn }} {
 	{{ end }}
 
 	if err := c.executeRequestInterceptors(ctx, request); err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: execute request editors: %w", err)
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: execute request editors: %w", err)
 	}
 
-        {{ if not .SkipAuth }}
-        if err := c.signRequest(request); err != nil {
-                return nil, fmt.Errorf("{{ .Name }}: sign request: %w", err)
-        }
-        {{ end }}
+	{{ if not .SkipAuth }}
+	if err := c.signRequest(request); err != nil {
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: sign request: %w", err)
+	}
+	{{ end }}
 
         if c.trace {
                 dumpRequest(request, "{{ .OperationID }}")
@@ -44,7 +44,7 @@ func (c Client) {{ .Name }}({{ .Params }}) {{ .ValueReturn }} {
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: http client do: %w", err)
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: http client do: %w", err)
 	}
 
 	if c.trace {
@@ -52,13 +52,8 @@ func (c Client) {{ .Name }}({{ .Params }}) {{ .ValueReturn }} {
 	}
 
 	if err := handleHTTPErrorResp(response); err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: http response: %w", err)
+		return {{ .ErrReturn }}fmt.Errorf("{{ .Name }}: http response: %w", err)
 	}
 
-	bodyresp := {{ .BodyRespType }}
-	if err := prepareJSONResponse(response, {{ .JSONResponseTarget }}); err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: prepare Json response: %w", err)
-	}
-
-	return bodyresp, nil
+{{ .ReturnSection }}
 }

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -69,7 +69,7 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 
 	bodyresp := new(ListAIAPIKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAIAPIKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAIAPIKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -81,7 +81,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAIAPIKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -120,7 +120,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 
 	bodyresp := new(CreateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -164,7 +164,7 @@ func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -208,7 +208,7 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*GetAIAPIKeyResponse,
 
 	bodyresp := new(GetAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -220,7 +220,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateAIAPIKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PATCH", c.serverEndpoint+path, body)
@@ -259,7 +259,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 
 	bodyresp := new(UpdateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -303,7 +303,7 @@ func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*RevealAIAPIKeyRes
 
 	bodyresp := new(RevealAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -347,7 +347,7 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*RotateAIAPIKeyRes
 
 	bodyresp := new(RotateAIAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateAIAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -426,7 +426,7 @@ func (c Client) ListDeployments(ctx context.Context, opts ...ListDeploymentsOpt)
 
 	bodyresp := new(ListDeploymentsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDeployments: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDeployments: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -438,7 +438,7 @@ func (c Client) CreateDeployment(ctx context.Context, req CreateDeploymentReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -477,7 +477,7 @@ func (c Client) CreateDeployment(ctx context.Context, req CreateDeploymentReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -521,7 +521,7 @@ func (c Client) DeleteDeployment(ctx context.Context, id UUID) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -565,7 +565,7 @@ func (c Client) GetDeployment(ctx context.Context, id UUID) (*GetDeploymentRespo
 
 	bodyresp := new(GetDeploymentResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -577,7 +577,7 @@ func (c Client) UpdateDeployment(ctx context.Context, id UUID, req UpdateDeploym
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PATCH", c.serverEndpoint+path, body)
@@ -616,7 +616,7 @@ func (c Client) UpdateDeployment(ctx context.Context, id UUID, req UpdateDeploym
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -660,7 +660,7 @@ func (c Client) RevealDeploymentAPIKey(ctx context.Context, id UUID) (*RevealDep
 
 	bodyresp := new(RevealDeploymentAPIKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDeploymentAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDeploymentAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -726,7 +726,7 @@ func (c Client) GetDeploymentLogs(ctx context.Context, id UUID, opts ...GetDeplo
 
 	bodyresp := new(GetDeploymentLogsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeploymentLogs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeploymentLogs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -738,7 +738,7 @@ func (c Client) ScaleDeployment(ctx context.Context, id UUID, req ScaleDeploymen
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleDeployment: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleDeployment: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -777,7 +777,7 @@ func (c Client) ScaleDeployment(ctx context.Context, id UUID, req ScaleDeploymen
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleDeployment: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleDeployment: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -837,7 +837,7 @@ func (c Client) GetInferenceEngineHelp(ctx context.Context, opts ...GetInference
 
 	bodyresp := new(GetInferenceEngineHelpResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInferenceEngineHelp: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInferenceEngineHelp: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -881,7 +881,7 @@ func (c Client) ListAIInstanceTypes(ctx context.Context) (*ListAIInstanceTypesRe
 
 	bodyresp := new(ListAIInstanceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAIInstanceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAIInstanceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -960,7 +960,7 @@ func (c Client) ListModels(ctx context.Context, opts ...ListModelsOpt) (*ListMod
 
 	bodyresp := new(ListModelsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListModels: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListModels: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -974,7 +974,7 @@ func (c Client) CreateModel(ctx context.Context, req CreateModelRequest) (*Opera
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateModel: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateModel: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1013,7 +1013,7 @@ func (c Client) CreateModel(ctx context.Context, req CreateModelRequest) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1057,7 +1057,7 @@ func (c Client) DeleteModel(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1101,7 +1101,7 @@ func (c Client) GetModel(ctx context.Context, id UUID) (*GetModelResponse, error
 
 	bodyresp := new(GetModelResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetModel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetModel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1145,7 +1145,7 @@ func (c Client) GetUserOrgConsumptionQuota(ctx context.Context) (*OrgConsumption
 
 	bodyresp := new(OrgConsumptionQuotaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetUserOrgConsumptionQuota: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1212,7 +1212,7 @@ func (c Client) ListAntiAffinityGroups(ctx context.Context) (*ListAntiAffinityGr
 
 	bodyresp := new(ListAntiAffinityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAntiAffinityGroups: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAntiAffinityGroups: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1231,7 +1231,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1270,7 +1270,7 @@ func (c Client) CreateAntiAffinityGroup(ctx context.Context, req CreateAntiAffin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1314,7 +1314,7 @@ func (c Client) DeleteAntiAffinityGroup(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1358,7 +1358,7 @@ func (c Client) GetAntiAffinityGroup(ctx context.Context, id UUID) (*AntiAffinit
 
 	bodyresp := new(AntiAffinityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAntiAffinityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAntiAffinityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1424,7 +1424,7 @@ func (c Client) ListAPIKeys(ctx context.Context) (*ListAPIKeysResponse, error) {
 
 	bodyresp := new(ListAPIKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListAPIKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListAPIKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1442,7 +1442,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAPIKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateAPIKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1481,7 +1481,7 @@ func (c Client) CreateAPIKey(ctx context.Context, req CreateAPIKeyRequest) (*IAM
 
 	bodyresp := new(IAMAPIKeyCreated)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1524,7 +1524,7 @@ func (c Client) DeleteAPIKey(ctx context.Context, id string) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1567,7 +1567,7 @@ func (c Client) GetAPIKey(ctx context.Context, id string) (*IAMAPIKey, error) {
 
 	bodyresp := new(IAMAPIKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetAPIKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1650,7 +1650,7 @@ func (c Client) ListBlockStorageVolumes(ctx context.Context, opts ...ListBlockSt
 
 	bodyresp := new(ListBlockStorageVolumesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListBlockStorageVolumes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListBlockStorageVolumes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1673,7 +1673,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -1712,7 +1712,7 @@ func (c Client) CreateBlockStorageVolume(ctx context.Context, req CreateBlockSto
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1779,7 +1779,7 @@ func (c Client) ListBlockStorageSnapshots(ctx context.Context) (*ListBlockStorag
 
 	bodyresp := new(ListBlockStorageSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListBlockStorageSnapshots: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListBlockStorageSnapshots: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1823,7 +1823,7 @@ func (c Client) DeleteBlockStorageSnapshot(ctx context.Context, id UUID) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1867,7 +1867,7 @@ func (c Client) GetBlockStorageSnapshot(ctx context.Context, id UUID) (*BlockSto
 
 	bodyresp := new(BlockStorageSnapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1885,7 +1885,7 @@ func (c Client) UpdateBlockStorageSnapshot(ctx context.Context, id UUID, req Upd
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -1924,7 +1924,7 @@ func (c Client) UpdateBlockStorageSnapshot(ctx context.Context, id UUID, req Upd
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -1968,7 +1968,7 @@ func (c Client) DeleteBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2012,7 +2012,7 @@ func (c Client) GetBlockStorageVolume(ctx context.Context, id UUID) (*BlockStora
 
 	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2030,7 +2030,7 @@ func (c Client) UpdateBlockStorageVolume(ctx context.Context, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2069,7 +2069,7 @@ func (c Client) UpdateBlockStorageVolume(ctx context.Context, id UUID, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2086,7 +2086,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2125,7 +2125,7 @@ func (c Client) AttachBlockStorageVolumeToInstance(ctx context.Context, id UUID,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachBlockStorageVolumeToInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2143,7 +2143,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2182,7 +2182,7 @@ func (c Client) CreateBlockStorageSnapshot(ctx context.Context, id UUID, req Cre
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateBlockStorageSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2226,7 +2226,7 @@ func (c Client) DetachBlockStorageVolume(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2243,7 +2243,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2282,7 +2282,7 @@ func (c Client) ResizeBlockStorageVolume(ctx context.Context, id UUID, req Resiz
 
 	bodyresp := new(BlockStorageVolume)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResizeBlockStorageVolume: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2332,7 +2332,7 @@ func (c Client) GetConsoleProxyURL(ctx context.Context, id UUID) (*GetConsolePro
 
 	bodyresp := new(GetConsoleProxyURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetConsoleProxyURL: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetConsoleProxyURL: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2380,7 +2380,7 @@ func (c Client) GetDBAASCACertificate(ctx context.Context) (*GetDBAASCACertifica
 
 	bodyresp := new(GetDBAASCACertificateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASCACertificate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASCACertificate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2423,7 +2423,7 @@ func (c Client) DeleteDBAASServiceClickhouse(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2466,7 +2466,7 @@ func (c Client) GetDBAASServiceClickhouse(ctx context.Context, name string) (*DB
 
 	bodyresp := new(DBAASServiceClickhouse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2516,7 +2516,7 @@ func (c Client) CreateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2555,7 +2555,7 @@ func (c Client) CreateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2602,7 +2602,7 @@ func (c Client) UpdateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2641,7 +2641,7 @@ func (c Client) UpdateDBAASServiceClickhouse(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2684,7 +2684,7 @@ func (c Client) StartDBAASClickhouseMaintenance(ctx context.Context, name string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASClickhouseMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2727,7 +2727,7 @@ func (c Client) GetDBAASClickhouseAclConfig(ctx context.Context, serviceName str
 
 	bodyresp := new(DBAASClickhouseAclConfig)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASClickhouseAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2770,7 +2770,7 @@ func (c Client) ListDBAASClickhouseUsers(ctx context.Context, serviceName string
 
 	bodyresp := new(DBAASClickhouseUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASClickhouseUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASClickhouseUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2788,7 +2788,7 @@ func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -2827,7 +2827,7 @@ func (c Client) CreateDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASClickhouseUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2870,7 +2870,7 @@ func (c Client) DeleteDBAASClickhouseUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASClickhouseUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2885,7 +2885,7 @@ func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceNam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -2924,7 +2924,7 @@ func (c Client) ResetDBAASClickhouseUserPassword(ctx context.Context, serviceNam
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASClickhouseUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -2967,7 +2967,7 @@ func (c Client) RevealDBAASClickhouseUserPassword(ctx context.Context, serviceNa
 
 	bodyresp := new(DBAASUserClickhouseSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASClickhouseUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3011,7 +3011,7 @@ func (c Client) DeleteDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3055,7 +3055,7 @@ func (c Client) GetDBAASExternalEndpointDatadog(ctx context.Context, endpointID 
 
 	bodyresp := new(DBAASExternalEndpointDatadogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3067,7 +3067,7 @@ func (c Client) UpdateDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3106,7 +3106,7 @@ func (c Client) UpdateDBAASExternalEndpointDatadog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3118,7 +3118,7 @@ func (c Client) CreateDBAASExternalEndpointDatadog(ctx context.Context, name str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3157,7 +3157,7 @@ func (c Client) CreateDBAASExternalEndpointDatadog(ctx context.Context, name str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3201,7 +3201,7 @@ func (c Client) DeleteDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3245,7 +3245,7 @@ func (c Client) GetDBAASExternalEndpointElasticsearch(ctx context.Context, endpo
 
 	bodyresp := new(DBAASEndpointElasticsearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3257,7 +3257,7 @@ func (c Client) UpdateDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3296,7 +3296,7 @@ func (c Client) UpdateDBAASExternalEndpointElasticsearch(ctx context.Context, en
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3308,7 +3308,7 @@ func (c Client) CreateDBAASExternalEndpointElasticsearch(ctx context.Context, na
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3347,7 +3347,7 @@ func (c Client) CreateDBAASExternalEndpointElasticsearch(ctx context.Context, na
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointElasticsearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3391,7 +3391,7 @@ func (c Client) DeleteDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3435,7 +3435,7 @@ func (c Client) GetDBAASExternalEndpointOpensearch(ctx context.Context, endpoint
 
 	bodyresp := new(DBAASEndpointOpensearchOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3447,7 +3447,7 @@ func (c Client) UpdateDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3486,7 +3486,7 @@ func (c Client) UpdateDBAASExternalEndpointOpensearch(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3498,7 +3498,7 @@ func (c Client) CreateDBAASExternalEndpointOpensearch(ctx context.Context, name 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3537,7 +3537,7 @@ func (c Client) CreateDBAASExternalEndpointOpensearch(ctx context.Context, name 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3581,7 +3581,7 @@ func (c Client) DeleteDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3625,7 +3625,7 @@ func (c Client) GetDBAASExternalEndpointPrometheus(ctx context.Context, endpoint
 
 	bodyresp := new(DBAASEndpointExternalPrometheusOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3637,7 +3637,7 @@ func (c Client) UpdateDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3676,7 +3676,7 @@ func (c Client) UpdateDBAASExternalEndpointPrometheus(ctx context.Context, endpo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3688,7 +3688,7 @@ func (c Client) CreateDBAASExternalEndpointPrometheus(ctx context.Context, name 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3727,7 +3727,7 @@ func (c Client) CreateDBAASExternalEndpointPrometheus(ctx context.Context, name 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointPrometheus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3771,7 +3771,7 @@ func (c Client) DeleteDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3815,7 +3815,7 @@ func (c Client) GetDBAASExternalEndpointRsyslog(ctx context.Context, endpointID 
 
 	bodyresp := new(DBAASExternalEndpointRsyslogOutput)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3827,7 +3827,7 @@ func (c Client) UpdateDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -3866,7 +3866,7 @@ func (c Client) UpdateDBAASExternalEndpointRsyslog(ctx context.Context, endpoint
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3878,7 +3878,7 @@ func (c Client) CreateDBAASExternalEndpointRsyslog(ctx context.Context, name str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -3917,7 +3917,7 @@ func (c Client) CreateDBAASExternalEndpointRsyslog(ctx context.Context, name str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASExternalEndpointRsyslog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3971,7 +3971,7 @@ func (c Client) ListDBAASExternalEndpointTypes(ctx context.Context) (*ListDBAASE
 
 	bodyresp := new(ListDBAASExternalEndpointTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalEndpointTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -3989,7 +3989,7 @@ func (c Client) AttachDBAASServiceToEndpoint(ctx context.Context, sourceServiceN
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4028,7 +4028,7 @@ func (c Client) AttachDBAASServiceToEndpoint(ctx context.Context, sourceServiceN
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachDBAASServiceToEndpoint: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4045,7 +4045,7 @@ func (c Client) DetachDBAASServiceFromEndpoint(ctx context.Context, sourceServic
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4084,7 +4084,7 @@ func (c Client) DetachDBAASServiceFromEndpoint(ctx context.Context, sourceServic
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachDBAASServiceFromEndpoint: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4151,7 +4151,7 @@ func (c Client) ListDBAASExternalEndpoints(ctx context.Context) (*ListDBAASExter
 
 	bodyresp := new(ListDBAASExternalEndpointsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalEndpoints: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalEndpoints: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4199,7 +4199,7 @@ func (c Client) GetDBAASExternalIntegrationSettingsDatadog(ctx context.Context, 
 
 	bodyresp := new(GetDBAASExternalIntegrationSettingsDatadogResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalIntegrationSettingsDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4215,7 +4215,7 @@ func (c Client) UpdateDBAASExternalIntegrationSettingsDatadog(ctx context.Contex
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4254,7 +4254,7 @@ func (c Client) UpdateDBAASExternalIntegrationSettingsDatadog(ctx context.Contex
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASExternalIntegrationSettingsDatadog: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4298,7 +4298,7 @@ func (c Client) GetDBAASExternalIntegration(ctx context.Context, integrationID U
 
 	bodyresp := new(DBAASExternalIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASExternalIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASExternalIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4346,7 +4346,7 @@ func (c Client) ListDBAASExternalIntegrations(ctx context.Context, serviceName s
 
 	bodyresp := new(ListDBAASExternalIntegrationsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASExternalIntegrations: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASExternalIntegrations: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4389,7 +4389,7 @@ func (c Client) DeleteDBAASServiceGrafana(ctx context.Context, name string) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4432,7 +4432,7 @@ func (c Client) GetDBAASServiceGrafana(ctx context.Context, name string) (*DBAAS
 
 	bodyresp := new(DBAASServiceGrafana)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4479,7 +4479,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4518,7 +4518,7 @@ func (c Client) CreateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4563,7 +4563,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4602,7 +4602,7 @@ func (c Client) UpdateDBAASServiceGrafana(ctx context.Context, name string, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4645,7 +4645,7 @@ func (c Client) StartDBAASGrafanaMaintenance(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASGrafanaMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4661,7 +4661,7 @@ func (c Client) ResetDBAASGrafanaUserPassword(ctx context.Context, serviceName s
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -4700,7 +4700,7 @@ func (c Client) ResetDBAASGrafanaUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASGrafanaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4743,7 +4743,7 @@ func (c Client) RevealDBAASGrafanaUserPassword(ctx context.Context, serviceName 
 
 	bodyresp := new(DBAASUserGrafanaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASGrafanaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4763,7 +4763,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASIntegration: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASIntegration: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -4802,7 +4802,7 @@ func (c Client) CreateDBAASIntegration(ctx context.Context, req CreateDBAASInteg
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4859,7 +4859,7 @@ func (c Client) ListDBAASIntegrationSettings(ctx context.Context, integrationTyp
 
 	bodyresp := new(ListDBAASIntegrationSettingsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASIntegrationSettings: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASIntegrationSettings: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4907,7 +4907,7 @@ func (c Client) ListDBAASIntegrationTypes(ctx context.Context) (*ListDBAASIntegr
 
 	bodyresp := new(ListDBAASIntegrationTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASIntegrationTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASIntegrationTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4951,7 +4951,7 @@ func (c Client) DeleteDBAASIntegration(ctx context.Context, id UUID) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -4995,7 +4995,7 @@ func (c Client) GetDBAASIntegration(ctx context.Context, id UUID) (*DBAASIntegra
 
 	bodyresp := new(DBAASIntegration)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5012,7 +5012,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5051,7 +5051,7 @@ func (c Client) UpdateDBAASIntegration(ctx context.Context, id UUID, req UpdateD
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASIntegration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5094,7 +5094,7 @@ func (c Client) DeleteDBAASServiceKafka(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5137,7 +5137,7 @@ func (c Client) GetDBAASServiceKafka(ctx context.Context, name string) (*DBAASSe
 
 	bodyresp := new(DBAASServiceKafka)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5207,7 +5207,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5246,7 +5246,7 @@ func (c Client) CreateDBAASServiceKafka(ctx context.Context, name string, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5316,7 +5316,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5355,7 +5355,7 @@ func (c Client) UpdateDBAASServiceKafka(ctx context.Context, name string, req Up
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5398,7 +5398,7 @@ func (c Client) GetDBAASKafkaAclConfig(ctx context.Context, name string) (*DBAAS
 
 	bodyresp := new(DBAASKafkaAcls)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASKafkaAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5441,7 +5441,7 @@ func (c Client) StartDBAASKafkaMaintenance(ctx context.Context, name string) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASKafkaMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5452,7 +5452,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5491,7 +5491,7 @@ func (c Client) CreateDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaSchemaRegistryAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5534,7 +5534,7 @@ func (c Client) DeleteDBAASKafkaSchemaRegistryAclConfig(ctx context.Context, nam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaSchemaRegistryAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5545,7 +5545,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5584,7 +5584,7 @@ func (c Client) CreateDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaTopicAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5627,7 +5627,7 @@ func (c Client) DeleteDBAASKafkaTopicAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaTopicAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5670,7 +5670,7 @@ func (c Client) RevealDBAASKafkaConnectPassword(ctx context.Context, serviceName
 
 	bodyresp := new(DBAASUserKafkaConnectSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASKafkaConnectPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5685,7 +5685,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -5724,7 +5724,7 @@ func (c Client) CreateDBAASKafkaUser(ctx context.Context, serviceName string, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASKafkaUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5767,7 +5767,7 @@ func (c Client) DeleteDBAASKafkaUser(ctx context.Context, serviceName string, us
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASKafkaUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASKafkaUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5783,7 +5783,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -5822,7 +5822,7 @@ func (c Client) ResetDBAASKafkaUserPassword(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASKafkaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5865,7 +5865,7 @@ func (c Client) RevealDBAASKafkaUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(DBAASUserKafkaSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASKafkaUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5909,7 +5909,7 @@ func (c Client) GetDBAASMigrationStatus(ctx context.Context, name string) (*DBAA
 
 	bodyresp := new(DBAASMigrationStatus)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASMigrationStatus: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASMigrationStatus: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5952,7 +5952,7 @@ func (c Client) DeleteDBAASServiceMysql(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -5996,7 +5996,7 @@ func (c Client) GetDBAASServiceMysql(ctx context.Context, name string) (*DBAASSe
 
 	bodyresp := new(DBAASServiceMysql)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6098,7 +6098,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6137,7 +6137,7 @@ func (c Client) CreateDBAASServiceMysql(ctx context.Context, name string, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6216,7 +6216,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -6255,7 +6255,7 @@ func (c Client) UpdateDBAASServiceMysql(ctx context.Context, name string, req Up
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6298,7 +6298,7 @@ func (c Client) EnableDBAASMysqlWrites(ctx context.Context, name string) (*Opera
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableDBAASMysqlWrites: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableDBAASMysqlWrites: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6341,7 +6341,7 @@ func (c Client) StartDBAASMysqlMaintenance(ctx context.Context, name string) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASMysqlMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6384,7 +6384,7 @@ func (c Client) StopDBAASMysqlMigration(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASMysqlMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASMysqlMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6399,7 +6399,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6438,7 +6438,7 @@ func (c Client) CreateDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6481,7 +6481,7 @@ func (c Client) DeleteDBAASMysqlDatabase(ctx context.Context, serviceName string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASMysqlDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6497,7 +6497,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6536,7 +6536,7 @@ func (c Client) CreateDBAASMysqlUser(ctx context.Context, serviceName string, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASMysqlUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6579,7 +6579,7 @@ func (c Client) DeleteDBAASMysqlUser(ctx context.Context, serviceName string, us
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASMysqlUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASMysqlUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6596,7 +6596,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -6635,7 +6635,7 @@ func (c Client) ResetDBAASMysqlUserPassword(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASMysqlUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6678,7 +6678,7 @@ func (c Client) RevealDBAASMysqlUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(DBAASUserMysqlSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASMysqlUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6721,7 +6721,7 @@ func (c Client) DeleteDBAASServiceOpensearch(ctx context.Context, name string) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6765,7 +6765,7 @@ func (c Client) GetDBAASServiceOpensearch(ctx context.Context, name string) (*DB
 
 	bodyresp := new(DBAASServiceOpensearch)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6862,7 +6862,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -6901,7 +6901,7 @@ func (c Client) CreateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -6995,7 +6995,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7034,7 +7034,7 @@ func (c Client) UpdateDBAASServiceOpensearch(ctx context.Context, name string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7077,7 +7077,7 @@ func (c Client) GetDBAASOpensearchAclConfig(ctx context.Context, name string) (*
 
 	bodyresp := new(DBAASOpensearchAclConfig)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASOpensearchAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7088,7 +7088,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7127,7 +7127,7 @@ func (c Client) UpdateDBAASOpensearchAclConfig(ctx context.Context, name string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASOpensearchAclConfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7170,7 +7170,7 @@ func (c Client) StartDBAASOpensearchMaintenance(ctx context.Context, name string
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASOpensearchMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7185,7 +7185,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7224,7 +7224,7 @@ func (c Client) CreateDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASOpensearchUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7267,7 +7267,7 @@ func (c Client) DeleteDBAASOpensearchUser(ctx context.Context, serviceName strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASOpensearchUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7283,7 +7283,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7322,7 +7322,7 @@ func (c Client) ResetDBAASOpensearchUserPassword(ctx context.Context, serviceNam
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASOpensearchUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7365,7 +7365,7 @@ func (c Client) RevealDBAASOpensearchUserPassword(ctx context.Context, serviceNa
 
 	bodyresp := new(DBAASUserOpensearchSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASOpensearchUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7408,7 +7408,7 @@ func (c Client) DeleteDBAASServicePG(ctx context.Context, name string) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7452,7 +7452,7 @@ func (c Client) GetDBAASServicePG(ctx context.Context, name string) (*DBAASServi
 
 	bodyresp := new(DBAASServicePG)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7565,7 +7565,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServicePG: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServicePG: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7604,7 +7604,7 @@ func (c Client) CreateDBAASServicePG(ctx context.Context, name string, req Creat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7695,7 +7695,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7734,7 +7734,7 @@ func (c Client) UpdateDBAASServicePG(ctx context.Context, name string, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServicePG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7777,7 +7777,7 @@ func (c Client) StartDBAASPGMaintenance(ctx context.Context, name string) (*Oper
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASPGMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASPGMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7820,7 +7820,7 @@ func (c Client) StopDBAASPGMigration(ctx context.Context, name string) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASPGMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASPGMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7840,7 +7840,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -7879,7 +7879,7 @@ func (c Client) CreateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7923,7 +7923,7 @@ func (c Client) DeleteDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -7942,7 +7942,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -7981,7 +7981,7 @@ func (c Client) UpdateDBAASPGConnectionPool(ctx context.Context, serviceName str
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPGConnectionPool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8000,7 +8000,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8039,7 +8039,7 @@ func (c Client) CreateDBAASPGDatabase(ctx context.Context, serviceName string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8082,7 +8082,7 @@ func (c Client) DeleteDBAASPGDatabase(ctx context.Context, serviceName string, d
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPGDatabase: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPGDatabase: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8098,7 +8098,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8137,7 +8137,7 @@ func (c Client) CreateDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPostgresUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8180,7 +8180,7 @@ func (c Client) DeleteDBAASPostgresUser(ctx context.Context, serviceName string,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASPostgresUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASPostgresUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8195,7 +8195,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -8234,7 +8234,7 @@ func (c Client) UpdateDBAASPostgresAllowReplication(ctx context.Context, service
 
 	bodyresp := new(DBAASPostgresUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASPostgresAllowReplication: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8250,7 +8250,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -8289,7 +8289,7 @@ func (c Client) ResetDBAASPostgresUserPassword(ctx context.Context, serviceName 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASPostgresUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8332,7 +8332,7 @@ func (c Client) RevealDBAASPostgresUserPassword(ctx context.Context, serviceName
 
 	bodyresp := new(DBAASUserPostgresSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASPostgresUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8348,7 +8348,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8387,7 +8387,7 @@ func (c Client) CreateDBAASPGUpgradeCheck(ctx context.Context, service string, r
 
 	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASPGUpgradeCheck: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8454,7 +8454,7 @@ func (c Client) ListDBAASServices(ctx context.Context) (*ListDBAASServicesRespon
 
 	bodyresp := new(ListDBAASServicesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASServices: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASServices: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8474,7 +8474,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8513,7 +8513,7 @@ func (c Client) GetDBAASServiceLogs(ctx context.Context, serviceName string, req
 
 	bodyresp := new(DBAASServiceLogs)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceLogs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8544,7 +8544,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -8583,7 +8583,7 @@ func (c Client) GetDBAASServiceMetrics(ctx context.Context, serviceName string, 
 
 	bodyresp := new(GetDBAASServiceMetricsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceMetrics: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8650,7 +8650,7 @@ func (c Client) ListDBAASServiceTypes(ctx context.Context) (*ListDBAASServiceTyp
 
 	bodyresp := new(ListDBAASServiceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASServiceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASServiceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8694,7 +8694,7 @@ func (c Client) GetDBAASServiceType(ctx context.Context, serviceTypeName string)
 
 	bodyresp := new(DBAASServiceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceType: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceType: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8738,7 +8738,7 @@ func (c Client) DeleteDBAASService(ctx context.Context, name string) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8798,7 +8798,7 @@ func (c Client) GetDBAASSettingsClickhouse(ctx context.Context) (*GetDBAASSettin
 
 	bodyresp := new(GetDBAASSettingsClickhouseResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsClickhouse: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8859,7 +8859,7 @@ func (c Client) GetDBAASSettingsGrafana(ctx context.Context) (*GetDBAASSettingsG
 
 	bodyresp := new(GetDBAASSettingsGrafanaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsGrafana: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsGrafana: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -8950,7 +8950,7 @@ func (c Client) GetDBAASSettingsKafka(ctx context.Context) (*GetDBAASSettingsKaf
 
 	bodyresp := new(GetDBAASSettingsKafkaResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsKafka: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsKafka: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9011,7 +9011,7 @@ func (c Client) GetDBAASSettingsMysql(ctx context.Context) (*GetDBAASSettingsMys
 
 	bodyresp := new(GetDBAASSettingsMysqlResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsMysql: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsMysql: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9072,7 +9072,7 @@ func (c Client) GetDBAASSettingsOpensearch(ctx context.Context) (*GetDBAASSettin
 
 	bodyresp := new(GetDBAASSettingsOpensearchResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsOpensearch: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9163,7 +9163,7 @@ func (c Client) GetDBAASSettingsPG(ctx context.Context) (*GetDBAASSettingsPGResp
 
 	bodyresp := new(GetDBAASSettingsPGResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsPG: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsPG: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9224,7 +9224,7 @@ func (c Client) GetDBAASSettingsThanos(ctx context.Context) (*GetDBAASSettingsTh
 
 	bodyresp := new(GetDBAASSettingsThanosResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9285,7 +9285,7 @@ func (c Client) GetDBAASSettingsValkey(ctx context.Context) (*GetDBAASSettingsVa
 
 	bodyresp := new(GetDBAASSettingsValkeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASSettingsValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASSettingsValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9305,7 +9305,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9344,7 +9344,7 @@ func (c Client) CreateDBAASTaskMigrationCheck(ctx context.Context, service strin
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASTaskMigrationCheck: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9388,7 +9388,7 @@ func (c Client) GetDBAASTask(ctx context.Context, service string, id UUID) (*DBA
 
 	bodyresp := new(DBAASTask)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASTask: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASTask: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9431,7 +9431,7 @@ func (c Client) DeleteDBAASServiceThanos(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9475,7 +9475,7 @@ func (c Client) GetDBAASServiceThanos(ctx context.Context, name string) (*DBAASS
 
 	bodyresp := new(DBAASServiceThanos)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9521,7 +9521,7 @@ func (c Client) CreateDBAASServiceThanos(ctx context.Context, name string, req C
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9560,7 +9560,7 @@ func (c Client) CreateDBAASServiceThanos(ctx context.Context, name string, req C
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9606,7 +9606,7 @@ func (c Client) UpdateDBAASServiceThanos(ctx context.Context, name string, req U
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -9645,7 +9645,7 @@ func (c Client) UpdateDBAASServiceThanos(ctx context.Context, name string, req U
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceThanos: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9688,7 +9688,7 @@ func (c Client) StartDBAASThanosMaintenance(ctx context.Context, name string) (*
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASThanosMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASThanosMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9731,7 +9731,7 @@ func (c Client) RevealDBAASThanosUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(DBAASUserThanosSecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASThanosUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASThanosUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9774,7 +9774,7 @@ func (c Client) DeleteDBAASServiceValkey(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9818,7 +9818,7 @@ func (c Client) GetDBAASServiceValkey(ctx context.Context, name string) (*DBAASS
 
 	bodyresp := new(DBAASServiceValkey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9890,7 +9890,7 @@ func (c Client) CreateDBAASServiceValkey(ctx context.Context, name string, req C
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -9929,7 +9929,7 @@ func (c Client) CreateDBAASServiceValkey(ctx context.Context, name string, req C
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -9998,7 +9998,7 @@ func (c Client) UpdateDBAASServiceValkey(ctx context.Context, name string, req U
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10037,7 +10037,7 @@ func (c Client) UpdateDBAASServiceValkey(ctx context.Context, name string, req U
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASServiceValkey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10080,7 +10080,7 @@ func (c Client) StartDBAASValkeyMaintenance(ctx context.Context, name string) (*
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartDBAASValkeyMaintenance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10123,7 +10123,7 @@ func (c Client) StopDBAASValkeyMigration(ctx context.Context, name string) (*Ope
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopDBAASValkeyMigration: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopDBAASValkeyMigration: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10166,7 +10166,7 @@ func (c Client) ListDBAASValkeyUsers(ctx context.Context, serviceName string) (*
 
 	bodyresp := new(DBAASValkeyUsers)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDBAASValkeyUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDBAASValkeyUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10182,7 +10182,7 @@ func (c Client) CreateDBAASValkeyUser(ctx context.Context, serviceName string, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10221,7 +10221,7 @@ func (c Client) CreateDBAASValkeyUser(ctx context.Context, serviceName string, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDBAASValkeyUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10264,7 +10264,7 @@ func (c Client) DeleteDBAASValkeyUser(ctx context.Context, serviceName string, u
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDBAASValkeyUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDBAASValkeyUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10279,7 +10279,7 @@ func (c Client) UpdateDBAASValkeyUserAccessControl(ctx context.Context, serviceN
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10318,7 +10318,7 @@ func (c Client) UpdateDBAASValkeyUserAccessControl(ctx context.Context, serviceN
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDBAASValkeyUserAccessControl: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10334,7 +10334,7 @@ func (c Client) ResetDBAASValkeyUserPassword(ctx context.Context, serviceName st
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10373,7 +10373,7 @@ func (c Client) ResetDBAASValkeyUserPassword(ctx context.Context, serviceName st
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetDBAASValkeyUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10416,7 +10416,7 @@ func (c Client) RevealDBAASValkeyUserPassword(ctx context.Context, serviceName s
 
 	bodyresp := new(DBAASUserValkeySecrets)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealDBAASValkeyUserPassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10483,7 +10483,7 @@ func (c Client) ListDeployTargets(ctx context.Context) (*ListDeployTargetsRespon
 
 	bodyresp := new(ListDeployTargetsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDeployTargets: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDeployTargets: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10527,7 +10527,7 @@ func (c Client) GetDeployTarget(ctx context.Context, id UUID) (*DeployTarget, er
 
 	bodyresp := new(DeployTarget)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDeployTarget: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDeployTarget: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10594,7 +10594,7 @@ func (c Client) ListDNSDomains(ctx context.Context) (*ListDNSDomainsResponse, er
 
 	bodyresp := new(ListDNSDomainsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDNSDomains: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDNSDomains: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10612,7 +10612,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDNSDomain: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomain: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10651,7 +10651,7 @@ func (c Client) CreateDNSDomain(ctx context.Context, req CreateDNSDomainRequest)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10718,7 +10718,7 @@ func (c Client) ListDNSDomainRecords(ctx context.Context, domainID UUID) (*ListD
 
 	bodyresp := new(ListDNSDomainRecordsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListDNSDomainRecords: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListDNSDomainRecords: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10762,7 +10762,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -10801,7 +10801,7 @@ func (c Client) CreateDNSDomainRecord(ctx context.Context, domainID UUID, req Cr
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10845,7 +10845,7 @@ func (c Client) DeleteDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10889,7 +10889,7 @@ func (c Client) GetDNSDomainRecord(ctx context.Context, domainID UUID, recordID 
 
 	bodyresp := new(DNSDomainRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10912,7 +10912,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -10951,7 +10951,7 @@ func (c Client) UpdateDNSDomainRecord(ctx context.Context, domainID UUID, record
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateDNSDomainRecord: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -10995,7 +10995,7 @@ func (c Client) DeleteDNSDomain(ctx context.Context, id UUID) (*Operation, error
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11039,7 +11039,7 @@ func (c Client) GetDNSDomain(ctx context.Context, id UUID) (*DNSDomain, error) {
 
 	bodyresp := new(DNSDomain)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomain: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomain: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11087,7 +11087,7 @@ func (c Client) GetDNSDomainZoneFile(ctx context.Context, id UUID) (*GetDNSDomai
 
 	bodyresp := new(GetDNSDomainZoneFileResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetDNSDomainZoneFile: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetDNSDomainZoneFile: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11154,7 +11154,7 @@ func (c Client) ListElasticIPS(ctx context.Context) (*ListElasticIPSResponse, er
 
 	bodyresp := new(ListElasticIPSResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListElasticIPS: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListElasticIPS: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11183,7 +11183,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -11222,7 +11222,7 @@ func (c Client) CreateElasticIP(ctx context.Context, req CreateElasticIPRequest)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11266,7 +11266,7 @@ func (c Client) DeleteElasticIP(ctx context.Context, id UUID) (*Operation, error
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11310,7 +11310,7 @@ func (c Client) GetElasticIP(ctx context.Context, id UUID) (*ElasticIP, error) {
 
 	bodyresp := new(ElasticIP)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11330,7 +11330,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11369,7 +11369,7 @@ func (c Client) UpdateElasticIP(ctx context.Context, id UUID, req UpdateElasticI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11419,7 +11419,7 @@ func (c Client) ResetElasticIPField(ctx context.Context, id UUID, field ResetEla
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetElasticIPField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetElasticIPField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11436,7 +11436,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11475,7 +11475,7 @@ func (c Client) AttachInstanceToElasticIP(ctx context.Context, id UUID, req Atta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11492,7 +11492,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11531,7 +11531,7 @@ func (c Client) DetachInstanceFromElasticIP(ctx context.Context, id UUID, req De
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11575,7 +11575,7 @@ func (c Client) GetEnvImpact(ctx context.Context, period string) (*EnvImpactRepo
 
 	bodyresp := new(EnvImpactReport)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetEnvImpact: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetEnvImpact: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11643,7 +11643,7 @@ func (c Client) ListEvents(ctx context.Context, opts ...ListEventsOpt) ([]Event,
 
 	bodyresp := []Event{}
 	if err := prepareJSONResponse(response, &bodyresp); err != nil {
-		return nil, fmt.Errorf("ListEvents: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListEvents: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11687,7 +11687,7 @@ func (c Client) GetIAMOrganizationPolicy(ctx context.Context) (*IAMPolicy, error
 
 	bodyresp := new(IAMPolicy)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11699,7 +11699,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -11738,7 +11738,7 @@ func (c Client) UpdateIAMOrganizationPolicy(ctx context.Context, req IAMPolicy) 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11782,7 +11782,7 @@ func (c Client) ResetIAMOrganizationPolicy(ctx context.Context) (*Operation, err
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetIAMOrganizationPolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11849,7 +11849,7 @@ func (c Client) ListIAMRoles(ctx context.Context) (*ListIAMRolesResponse, error)
 
 	bodyresp := new(ListIAMRolesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListIAMRoles: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListIAMRoles: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11879,7 +11879,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -11918,7 +11918,7 @@ func (c Client) CreateIAMRole(ctx context.Context, req CreateIAMRoleRequest) (*O
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -11962,7 +11962,7 @@ func (c Client) DeleteIAMRole(ctx context.Context, id UUID) (*Operation, error) 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12006,7 +12006,7 @@ func (c Client) GetIAMRole(ctx context.Context, id UUID) (*IAMRole, error) {
 
 	bodyresp := new(IAMRole)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12030,7 +12030,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12069,7 +12069,7 @@ func (c Client) UpdateIAMRole(ctx context.Context, id UUID, req UpdateIAMRoleReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12095,7 +12095,7 @@ func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12134,7 +12134,7 @@ func (c Client) AssumeIAMRole(ctx context.Context, id UUID, req AssumeIAMRoleReq
 
 	bodyresp := new(AssumeIAMRoleResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AssumeIAMRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AssumeIAMRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12146,7 +12146,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12185,7 +12185,7 @@ func (c Client) UpdateIAMRolePolicy(ctx context.Context, id UUID, req IAMPolicy)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateIAMRolePolicy: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12333,7 +12333,7 @@ func (c Client) ListInstances(ctx context.Context, opts ...ListInstancesOpt) (*L
 
 	bodyresp := new(ListInstancesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstances: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstances: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12380,7 +12380,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12419,7 +12419,7 @@ func (c Client) CreateInstance(ctx context.Context, req CreateInstanceRequest) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12486,7 +12486,7 @@ func (c Client) ListInstancePools(ctx context.Context) (*ListInstancePoolsRespon
 
 	bodyresp := new(ListInstancePoolsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstancePools: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstancePools: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12548,7 +12548,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -12587,7 +12587,7 @@ func (c Client) CreateInstancePool(ctx context.Context, req CreateInstancePoolRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12631,7 +12631,7 @@ func (c Client) DeleteInstancePool(ctx context.Context, id UUID) (*Operation, er
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12675,7 +12675,7 @@ func (c Client) GetInstancePool(ctx context.Context, id UUID) (*InstancePool, er
 
 	bodyresp := new(InstancePool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12734,7 +12734,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12773,7 +12773,7 @@ func (c Client) UpdateInstancePool(ctx context.Context, id UUID, req UpdateInsta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12832,7 +12832,7 @@ func (c Client) ResetInstancePoolField(ctx context.Context, id UUID, field Reset
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstancePoolField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstancePoolField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12848,7 +12848,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12887,7 +12887,7 @@ func (c Client) EvictInstancePoolMembers(ctx context.Context, id UUID, req Evict
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EvictInstancePoolMembers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -12904,7 +12904,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleInstancePool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleInstancePool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -12943,7 +12943,7 @@ func (c Client) ScaleInstancePool(ctx context.Context, id UUID, req ScaleInstanc
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleInstancePool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleInstancePool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13010,7 +13010,7 @@ func (c Client) ListInstanceTypes(ctx context.Context) (*ListInstanceTypesRespon
 
 	bodyresp := new(ListInstanceTypesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListInstanceTypes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListInstanceTypes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13054,7 +13054,7 @@ func (c Client) GetInstanceType(ctx context.Context, id UUID) (*InstanceType, er
 
 	bodyresp := new(InstanceType)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstanceType: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstanceType: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13098,7 +13098,7 @@ func (c Client) DeleteInstance(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13142,7 +13142,7 @@ func (c Client) GetInstance(ctx context.Context, id UUID) (*Instance, error) {
 
 	bodyresp := new(Instance)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13165,7 +13165,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13204,7 +13204,7 @@ func (c Client) UpdateInstance(ctx context.Context, id UUID, req UpdateInstanceR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13254,7 +13254,7 @@ func (c Client) ResetInstanceField(ctx context.Context, id UUID, field ResetInst
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstanceField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstanceField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13298,7 +13298,7 @@ func (c Client) AddInstanceProtection(ctx context.Context, id UUID) (*Operation,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddInstanceProtection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddInstanceProtection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13342,7 +13342,7 @@ func (c Client) CreateSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13386,7 +13386,7 @@ func (c Client) EnableTpm(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableTpm: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableTpm: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13434,7 +13434,7 @@ func (c Client) RevealInstancePassword(ctx context.Context, id UUID) (*InstanceP
 
 	bodyresp := new(InstancePassword)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevealInstancePassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevealInstancePassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13478,7 +13478,7 @@ func (c Client) RebootInstance(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RebootInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RebootInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13522,7 +13522,7 @@ func (c Client) RemoveInstanceProtection(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RemoveInstanceProtection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RemoveInstanceProtection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13541,7 +13541,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResetInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResetInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13580,7 +13580,7 @@ func (c Client) ResetInstance(ctx context.Context, id UUID, req ResetInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13624,7 +13624,7 @@ func (c Client) ResetInstancePassword(ctx context.Context, id UUID) (*Operation,
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetInstancePassword: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetInstancePassword: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13641,7 +13641,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ResizeInstanceDisk: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ResizeInstanceDisk: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13680,7 +13680,7 @@ func (c Client) ResizeInstanceDisk(ctx context.Context, id UUID, req ResizeInsta
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResizeInstanceDisk: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResizeInstanceDisk: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13697,7 +13697,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13736,7 +13736,7 @@ func (c Client) ScaleInstance(ctx context.Context, id UUID, req ScaleInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13760,7 +13760,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("StartInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("StartInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -13799,7 +13799,7 @@ func (c Client) StartInstance(ctx context.Context, id UUID, req StartInstanceReq
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StartInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StartInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13843,7 +13843,7 @@ func (c Client) StopInstance(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("StopInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("StopInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13861,7 +13861,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -13900,7 +13900,7 @@ func (c Client) RevertInstanceToSnapshot(ctx context.Context, instanceID UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RevertInstanceToSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13963,7 +13963,7 @@ func (c Client) ListKmsKeys(ctx context.Context) (*ListKmsKeysResponse, error) {
 
 	bodyresp := new(ListKmsKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListKmsKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListKmsKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -13975,7 +13975,7 @@ func (c Client) CreateKmsKey(ctx context.Context, req CreateKmsKeyRequest) (*Cre
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateKmsKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateKmsKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14014,7 +14014,7 @@ func (c Client) CreateKmsKey(ctx context.Context, req CreateKmsKeyRequest) (*Cre
 
 	bodyresp := new(CreateKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14058,7 +14058,7 @@ func (c Client) GetKmsKey(ctx context.Context, id UUID) (*GetKmsKeyResponse, err
 
 	bodyresp := new(GetKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14102,7 +14102,7 @@ func (c Client) CancelKmsKeyDeletion(ctx context.Context, id UUID) (*SuccessResp
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CancelKmsKeyDeletion: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CancelKmsKeyDeletion: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14114,7 +14114,7 @@ func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*Decr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("Decrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("Decrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14153,7 +14153,7 @@ func (c Client) Decrypt(ctx context.Context, id UUID, req DecryptRequest) (*Decr
 
 	bodyresp := new(DecryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("Decrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("Decrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14197,7 +14197,7 @@ func (c Client) DisableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, e
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DisableKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DisableKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14241,7 +14241,7 @@ func (c Client) DisableKmsKeyRotation(ctx context.Context, id UUID) (*DisableKms
 
 	bodyresp := new(DisableKmsKeyRotationResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DisableKmsKeyRotation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DisableKmsKeyRotation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14285,7 +14285,7 @@ func (c Client) EnableKmsKey(ctx context.Context, id UUID) (*SuccessResponse, er
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14297,7 +14297,7 @@ func (c Client) EnableKmsKeyRotation(ctx context.Context, id UUID, req EnableKms
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14336,7 +14336,7 @@ func (c Client) EnableKmsKeyRotation(ctx context.Context, id UUID, req EnableKms
 
 	bodyresp := new(EnableKmsKeyRotationResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EnableKmsKeyRotation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14348,7 +14348,7 @@ func (c Client) Encrypt(ctx context.Context, id UUID, req EncryptRequest) (*Encr
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("Encrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("Encrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14387,7 +14387,7 @@ func (c Client) Encrypt(ctx context.Context, id UUID, req EncryptRequest) (*Encr
 
 	bodyresp := new(EncryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("Encrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("Encrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14399,7 +14399,7 @@ func (c Client) GenerateDataKey(ctx context.Context, id UUID, req GenerateDataKe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GenerateDataKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GenerateDataKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14438,7 +14438,7 @@ func (c Client) GenerateDataKey(ctx context.Context, id UUID, req GenerateDataKe
 
 	bodyresp := new(GenerateDataKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateDataKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateDataKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14482,7 +14482,7 @@ func (c Client) ListKmsKeyRotations(ctx context.Context, id UUID) (*ListKmsKeyRo
 
 	bodyresp := new(ListKmsKeyRotationsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListKmsKeyRotations: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListKmsKeyRotations: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14494,7 +14494,7 @@ func (c Client) ReEncrypt(ctx context.Context, id UUID, req ReEncryptRequest) (*
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ReEncrypt: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ReEncrypt: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14533,7 +14533,7 @@ func (c Client) ReEncrypt(ctx context.Context, id UUID, req ReEncryptRequest) (*
 
 	bodyresp := new(ReEncryptResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ReEncrypt: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ReEncrypt: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14545,7 +14545,7 @@ func (c Client) ReplicateKmsKey(ctx context.Context, id UUID, req ReplicateKmsKe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ReplicateKmsKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ReplicateKmsKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14584,7 +14584,7 @@ func (c Client) ReplicateKmsKey(ctx context.Context, id UUID, req ReplicateKmsKe
 
 	bodyresp := new(SuccessResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ReplicateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ReplicateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14628,7 +14628,7 @@ func (c Client) RotateKmsKey(ctx context.Context, id UUID) (*RotateKmsKeyRespons
 
 	bodyresp := new(RotateKmsKeyResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateKmsKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateKmsKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14640,7 +14640,7 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14679,7 +14679,7 @@ func (c Client) ScheduleKmsKeyDeletion(ctx context.Context, id UUID, req Schedul
 
 	bodyresp := new(ScheduleKmsKeyDeletionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScheduleKmsKeyDeletion: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14723,7 +14723,7 @@ func (c Client) GetLiveBalance(ctx context.Context) (*LiveBalance, error) {
 
 	bodyresp := new(LiveBalance)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLiveBalance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLiveBalance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14790,7 +14790,7 @@ func (c Client) ListLoadBalancers(ctx context.Context) (*ListLoadBalancersRespon
 
 	bodyresp := new(ListLoadBalancersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListLoadBalancers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListLoadBalancers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14810,7 +14810,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -14849,7 +14849,7 @@ func (c Client) CreateLoadBalancer(ctx context.Context, req CreateLoadBalancerRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14893,7 +14893,7 @@ func (c Client) DeleteLoadBalancer(ctx context.Context, id UUID) (*Operation, er
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14937,7 +14937,7 @@ func (c Client) GetLoadBalancer(ctx context.Context, id UUID) (*LoadBalancer, er
 
 	bodyresp := new(LoadBalancer)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -14957,7 +14957,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -14996,7 +14996,7 @@ func (c Client) UpdateLoadBalancer(ctx context.Context, id UUID, req UpdateLoadB
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15042,7 +15042,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -15081,7 +15081,7 @@ func (c Client) AddServiceToLoadBalancer(ctx context.Context, id UUID, req AddSe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddServiceToLoadBalancer: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15125,7 +15125,7 @@ func (c Client) DeleteLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15169,7 +15169,7 @@ func (c Client) GetLoadBalancerService(ctx context.Context, id UUID, serviceID U
 
 	bodyresp := new(LoadBalancerService)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15213,7 +15213,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15252,7 +15252,7 @@ func (c Client) UpdateLoadBalancerService(ctx context.Context, id UUID, serviceI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateLoadBalancerService: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15302,7 +15302,7 @@ func (c Client) ResetLoadBalancerServiceField(ctx context.Context, id UUID, serv
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetLoadBalancerServiceField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetLoadBalancerServiceField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15353,7 +15353,7 @@ func (c Client) ResetLoadBalancerField(ctx context.Context, id UUID, field Reset
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetLoadBalancerField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetLoadBalancerField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15397,7 +15397,7 @@ func (c Client) GetOperation(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetOperation: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetOperation: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15441,7 +15441,7 @@ func (c Client) GetOrganization(ctx context.Context) (*Organization, error) {
 
 	bodyresp := new(Organization)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetOrganization: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetOrganization: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15508,7 +15508,7 @@ func (c Client) ListPrivateNetworks(ctx context.Context) (*ListPrivateNetworksRe
 
 	bodyresp := new(ListPrivateNetworksResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListPrivateNetworks: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListPrivateNetworks: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15536,7 +15536,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreatePrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreatePrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -15575,7 +15575,7 @@ func (c Client) CreatePrivateNetwork(ctx context.Context, req CreatePrivateNetwo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreatePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreatePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15619,7 +15619,7 @@ func (c Client) DeletePrivateNetwork(ctx context.Context, id UUID) (*Operation, 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeletePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeletePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15663,7 +15663,7 @@ func (c Client) GetPrivateNetwork(ctx context.Context, id UUID) (*PrivateNetwork
 
 	bodyresp := new(PrivateNetwork)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15691,7 +15691,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15730,7 +15730,7 @@ func (c Client) UpdatePrivateNetwork(ctx context.Context, id UUID, req UpdatePri
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15780,7 +15780,7 @@ func (c Client) ResetPrivateNetworkField(ctx context.Context, id UUID, field Res
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ResetPrivateNetworkField: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ResetPrivateNetworkField: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15805,7 +15805,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15844,7 +15844,7 @@ func (c Client) AttachInstanceToPrivateNetwork(ctx context.Context, id UUID, req
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15861,7 +15861,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15900,7 +15900,7 @@ func (c Client) DetachInstanceFromPrivateNetwork(ctx context.Context, id UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromPrivateNetwork: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -15923,7 +15923,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -15962,7 +15962,7 @@ func (c Client) UpdatePrivateNetworkInstanceIP(ctx context.Context, id UUID, req
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdatePrivateNetworkInstanceIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16010,7 +16010,7 @@ func (c Client) ListQuotas(ctx context.Context) (*ListQuotasResponse, error) {
 
 	bodyresp := new(ListQuotasResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListQuotas: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListQuotas: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16054,7 +16054,7 @@ func (c Client) GetQuota(ctx context.Context, entity string) (*Quota, error) {
 
 	bodyresp := new(Quota)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetQuota: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetQuota: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16098,7 +16098,7 @@ func (c Client) DeleteReverseDNSElasticIP(ctx context.Context, id UUID) (*Operat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16142,7 +16142,7 @@ func (c Client) GetReverseDNSElasticIP(ctx context.Context, id UUID) (*ReverseDN
 
 	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16158,7 +16158,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16197,7 +16197,7 @@ func (c Client) UpdateReverseDNSElasticIP(ctx context.Context, id UUID, req Upda
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSElasticIP: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16241,7 +16241,7 @@ func (c Client) DeleteReverseDNSInstance(ctx context.Context, id UUID) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16285,7 +16285,7 @@ func (c Client) GetReverseDNSInstance(ctx context.Context, id UUID) (*ReverseDNS
 
 	bodyresp := new(ReverseDNSRecord)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16301,7 +16301,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16340,7 +16340,7 @@ func (c Client) UpdateReverseDNSInstance(ctx context.Context, id UUID, req Updat
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateReverseDNSInstance: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16433,7 +16433,7 @@ func (c Client) ListSecurityGroups(ctx context.Context, opts ...ListSecurityGrou
 
 	bodyresp := new(ListSecurityGroupsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSecurityGroups: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSecurityGroups: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16452,7 +16452,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16491,7 +16491,7 @@ func (c Client) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroup
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16535,7 +16535,7 @@ func (c Client) DeleteSecurityGroup(ctx context.Context, id UUID) (*Operation, e
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16579,7 +16579,7 @@ func (c Client) GetSecurityGroup(ctx context.Context, id UUID) (*SecurityGroup, 
 
 	bodyresp := new(SecurityGroup)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16636,7 +16636,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -16675,7 +16675,7 @@ func (c Client) AddRuleToSecurityGroup(ctx context.Context, id UUID, req AddRule
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddRuleToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16719,7 +16719,7 @@ func (c Client) DeleteRuleFromSecurityGroup(ctx context.Context, id UUID, ruleID
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteRuleFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16736,7 +16736,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16775,7 +16775,7 @@ func (c Client) AddExternalSourceToSecurityGroup(ctx context.Context, id UUID, r
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AddExternalSourceToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16792,7 +16792,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16831,7 +16831,7 @@ func (c Client) AttachInstanceToSecurityGroup(ctx context.Context, id UUID, req 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16848,7 +16848,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16887,7 +16887,7 @@ func (c Client) DetachInstanceFromSecurityGroup(ctx context.Context, id UUID, re
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -16904,7 +16904,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -16943,7 +16943,7 @@ func (c Client) RemoveExternalSourceFromSecurityGroup(ctx context.Context, id UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RemoveExternalSourceFromSecurityGroup: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17010,7 +17010,7 @@ func (c Client) ListSKSClusters(ctx context.Context) (*ListSKSClustersResponse, 
 
 	bodyresp := new(ListSKSClustersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusters: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusters: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17066,7 +17066,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17105,7 +17105,7 @@ func (c Client) CreateSKSCluster(ctx context.Context, req CreateSKSClusterReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17149,7 +17149,7 @@ func (c Client) ListSKSClusterDeprecatedResources(ctx context.Context, id UUID) 
 
 	bodyresp := []SKSClusterDeprecatedResource{}
 	if err := prepareJSONResponse(response, &bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusterDeprecatedResources: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17165,7 +17165,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare Json body: %w", err)
+		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17204,7 +17204,7 @@ func (c Client) GenerateSKSClusterKubeconfig(ctx context.Context, id UUID, req S
 
 	bodyresp := new(GenerateSKSClusterKubeconfigResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSClusterKubeconfig: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17268,7 +17268,7 @@ func (c Client) ListSKSClusterVersions(ctx context.Context, opts ...ListSKSClust
 
 	bodyresp := new(ListSKSClusterVersionsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSKSClusterVersions: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSKSClusterVersions: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17312,7 +17312,7 @@ func (c Client) DeleteSKSCluster(ctx context.Context, id UUID) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17356,7 +17356,7 @@ func (c Client) GetSKSCluster(ctx context.Context, id UUID) (*SKSCluster, error)
 
 	bodyresp := new(SKSCluster)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17388,7 +17388,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17427,7 +17427,7 @@ func (c Client) UpdateSKSCluster(ctx context.Context, id UUID, req UpdateSKSClus
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17483,7 +17483,7 @@ func (c Client) GetSKSClusterAuthorityCert(ctx context.Context, id UUID, authori
 
 	bodyresp := new(GetSKSClusterAuthorityCertResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSClusterAuthorityCert: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17531,7 +17531,7 @@ func (c Client) GenerateSKSKarpenterExoscaleNodeclass(ctx context.Context, id UU
 
 	bodyresp := new(GenerateSKSKarpenterExoscaleNodeclassResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSKarpenterExoscaleNodeclass: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17579,7 +17579,7 @@ func (c Client) GenerateSKSKarpenterNodepool(ctx context.Context, id UUID) (*Gen
 
 	bodyresp := new(GenerateSKSKarpenterNodepoolResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GenerateSKSKarpenterNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17625,7 +17625,7 @@ func (c Client) GetSKSClusterInspection(ctx context.Context, id UUID) (*GetSKSCl
 
 	bodyresp := new(GetSKSClusterInspectionResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSClusterInspection: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSClusterInspection: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17679,7 +17679,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -17718,7 +17718,7 @@ func (c Client) CreateSKSNodepool(ctx context.Context, id UUID, req CreateSKSNod
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17762,7 +17762,7 @@ func (c Client) DeleteSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17806,7 +17806,7 @@ func (c Client) GetSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUID)
 
 	bodyresp := new(SKSNodepool)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17856,7 +17856,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17895,7 +17895,7 @@ func (c Client) UpdateSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UU
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17911,7 +17911,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare Json body: %w", err)
+		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -17950,7 +17950,7 @@ func (c Client) EvictSKSNodepoolMembers(ctx context.Context, id UUID, sksNodepoo
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("EvictSKSNodepoolMembers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -17967,7 +17967,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("ScaleSKSNodepool: prepare Json body: %w", err)
+		return nil, fmt.Errorf("ScaleSKSNodepool: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -18006,7 +18006,7 @@ func (c Client) ScaleSKSNodepool(ctx context.Context, id UUID, sksNodepoolID UUI
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ScaleSKSNodepool: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ScaleSKSNodepool: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18050,7 +18050,7 @@ func (c Client) RotateSKSCcmCredentials(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSCcmCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSCcmCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18094,7 +18094,7 @@ func (c Client) RotateSKSCsiCredentials(ctx context.Context, id UUID) (*Operatio
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSCsiCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSCsiCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18138,7 +18138,7 @@ func (c Client) RotateSKSKarpenterCredentials(ctx context.Context, id UUID) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSKarpenterCredentials: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18182,7 +18182,7 @@ func (c Client) RotateSKSOperatorsCA(ctx context.Context, id UUID) (*Operation, 
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RotateSKSOperatorsCA: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RotateSKSOperatorsCA: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18199,7 +18199,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpgradeSKSCluster: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSCluster: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -18238,7 +18238,7 @@ func (c Client) UpgradeSKSCluster(ctx context.Context, id UUID, req UpgradeSKSCl
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpgradeSKSCluster: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSCluster: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18282,7 +18282,7 @@ func (c Client) UpgradeSKSClusterServiceLevel(ctx context.Context, id UUID) (*Op
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpgradeSKSClusterServiceLevel: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18337,7 +18337,7 @@ func (c Client) GetActiveNodepoolTemplate(ctx context.Context, kubeVersion strin
 
 	bodyresp := new(GetActiveNodepoolTemplateResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetActiveNodepoolTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetActiveNodepoolTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18404,7 +18404,7 @@ func (c Client) ListSnapshots(ctx context.Context) (*ListSnapshotsResponse, erro
 
 	bodyresp := new(ListSnapshotsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSnapshots: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSnapshots: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18448,7 +18448,7 @@ func (c Client) DeleteSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18492,7 +18492,7 @@ func (c Client) GetSnapshot(ctx context.Context, id UUID) (*Snapshot, error) {
 
 	bodyresp := new(Snapshot)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18536,7 +18536,7 @@ func (c Client) ExportSnapshot(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ExportSnapshot: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ExportSnapshot: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18561,7 +18561,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -18600,7 +18600,7 @@ func (c Client) PromoteSnapshotToTemplate(ctx context.Context, id UUID, req Prom
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("PromoteSnapshotToTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18667,7 +18667,7 @@ func (c Client) ListSOSBucketsUsage(ctx context.Context) (*ListSOSBucketsUsageRe
 
 	bodyresp := new(ListSOSBucketsUsageResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSOSBucketsUsage: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSOSBucketsUsage: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18731,7 +18731,7 @@ func (c Client) GetSOSPresignedURL(ctx context.Context, bucket string, opts ...G
 
 	bodyresp := new(GetSOSPresignedURLResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSOSPresignedURL: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSOSPresignedURL: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18798,7 +18798,7 @@ func (c Client) ListSSHKeys(ctx context.Context) (*ListSSHKeysResponse, error) {
 
 	bodyresp := new(ListSSHKeysResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSSHKeys: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSSHKeys: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18817,7 +18817,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RegisterSSHKey: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RegisterSSHKey: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -18856,7 +18856,7 @@ func (c Client) RegisterSSHKey(ctx context.Context, req RegisterSSHKeyRequest) (
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RegisterSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RegisterSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18900,7 +18900,7 @@ func (c Client) DeleteSSHKey(ctx context.Context, name string) (*Operation, erro
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -18944,7 +18944,7 @@ func (c Client) GetSSHKey(ctx context.Context, name string) (*SSHKey, error) {
 
 	bodyresp := new(SSHKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSSHKey: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSSHKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19040,7 +19040,7 @@ func (c Client) ListTemplates(ctx context.Context, opts ...ListTemplatesOpt) (*L
 
 	bodyresp := new(ListTemplatesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListTemplates: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListTemplates: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19088,7 +19088,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("RegisterTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("RegisterTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19127,7 +19127,7 @@ func (c Client) RegisterTemplate(ctx context.Context, req RegisterTemplateReques
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("RegisterTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("RegisterTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19171,7 +19171,7 @@ func (c Client) DeleteTemplate(ctx context.Context, id UUID) (*Operation, error)
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19215,7 +19215,7 @@ func (c Client) GetTemplate(ctx context.Context, id UUID) (*Template, error) {
 
 	bodyresp := new(Template)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19232,7 +19232,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CopyTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CopyTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19271,7 +19271,7 @@ func (c Client) CopyTemplate(ctx context.Context, id UUID, req CopyTemplateReque
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CopyTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CopyTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19290,7 +19290,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateTemplate: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateTemplate: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19329,7 +19329,7 @@ func (c Client) UpdateTemplate(ctx context.Context, id UUID, req UpdateTemplateR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateTemplate: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateTemplate: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19411,7 +19411,7 @@ func (c Client) GetUsageReport(ctx context.Context, opts ...GetUsageReportOpt) (
 
 	bodyresp := new(GetUsageReportResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetUsageReport: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetUsageReport: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19477,7 +19477,7 @@ func (c Client) ListUsers(ctx context.Context) (*ListUsersResponse, error) {
 
 	bodyresp := new(ListUsersResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListUsers: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListUsers: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19495,7 +19495,7 @@ func (c Client) CreateUser(ctx context.Context, req CreateUserRequest) (*Operati
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateUser: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateUser: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19534,7 +19534,7 @@ func (c Client) CreateUser(ctx context.Context, req CreateUserRequest) (*Operati
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19577,7 +19577,7 @@ func (c Client) DeleteUser(ctx context.Context, id UUID) (*Operation, error) {
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteUser: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteUser: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19593,7 +19593,7 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateUserRole: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateUserRole: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19632,7 +19632,7 @@ func (c Client) UpdateUserRole(ctx context.Context, id UUID, req UpdateUserRoleR
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateUserRole: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateUserRole: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19699,7 +19699,7 @@ func (c Client) ListVpcs(ctx context.Context) (*ListVpcsResponse, error) {
 
 	bodyresp := new(ListVpcsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListVpcs: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListVpcs: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19719,7 +19719,7 @@ func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateVpc: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateVpc: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -19758,7 +19758,7 @@ func (c Client) CreateVpc(ctx context.Context, req CreateVpcRequest) (*Operation
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19802,7 +19802,7 @@ func (c Client) DeleteVpc(ctx context.Context, id UUID) (*Empty, error) {
 
 	bodyresp := new(Empty)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19846,7 +19846,7 @@ func (c Client) GetVpc(ctx context.Context, id UUID) (*Vpc, error) {
 
 	bodyresp := new(Vpc)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19866,7 +19866,7 @@ func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateVpc: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateVpc: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -19905,7 +19905,7 @@ func (c Client) UpdateVpc(ctx context.Context, id UUID, req UpdateVpcRequest) (*
 
 	bodyresp := new(Vpc)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateVpc: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateVpc: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -19972,7 +19972,7 @@ func (c Client) ListVpcRoutes(ctx context.Context, vpcID UUID) (*ListVpcRoutesRe
 
 	bodyresp := new(ListVpcRoutesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListVpcRoutes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListVpcRoutes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20039,7 +20039,7 @@ func (c Client) ListSubnets(ctx context.Context, vpcID UUID) (*ListSubnetsRespon
 
 	bodyresp := new(ListSubnetsResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListSubnets: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListSubnets: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20077,7 +20077,7 @@ func (c Client) CreateSubnet(ctx context.Context, vpcID UUID, req CreateSubnetRe
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -20116,7 +20116,7 @@ func (c Client) CreateSubnet(ctx context.Context, vpcID UUID, req CreateSubnetRe
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20160,7 +20160,7 @@ func (c Client) DeleteSubnet(ctx context.Context, vpcID UUID, id UUID) (*Empty, 
 
 	bodyresp := new(Empty)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20204,7 +20204,7 @@ func (c Client) GetSubnet(ctx context.Context, vpcID UUID, id UUID) (*Subnet, er
 
 	bodyresp := new(Subnet)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("GetSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("GetSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20226,7 +20226,7 @@ func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req Updat
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("UpdateSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("UpdateSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20265,7 +20265,7 @@ func (c Client) UpdateSubnet(ctx context.Context, vpcID UUID, id UUID, req Updat
 
 	bodyresp := new(Subnet)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("UpdateSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("UpdateSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20282,7 +20282,7 @@ func (c Client) AttachInstanceToSubnet(ctx context.Context, vpcID UUID, subnetID
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20321,7 +20321,7 @@ func (c Client) AttachInstanceToSubnet(ctx context.Context, vpcID UUID, subnetID
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("AttachInstanceToSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20338,7 +20338,7 @@ func (c Client) DetachInstanceFromSubnet(ctx context.Context, vpcID UUID, subnet
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json body: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "PUT", c.serverEndpoint+path, body)
@@ -20377,7 +20377,7 @@ func (c Client) DetachInstanceFromSubnet(ctx context.Context, vpcID UUID, subnet
 
 	bodyresp := new(Operation)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DetachInstanceFromSubnet: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20444,7 +20444,7 @@ func (c Client) ListRoutes(ctx context.Context, vpcID UUID, subnetID UUID) (*Lis
 
 	bodyresp := new(ListRoutesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListRoutes: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListRoutes: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20465,7 +20465,7 @@ func (c Client) CreateRoute(ctx context.Context, vpcID UUID, subnetID UUID, req 
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
-		return nil, fmt.Errorf("CreateRoute: prepare Json body: %w", err)
+		return nil, fmt.Errorf("CreateRoute: prepare JSON body: %w", err)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, body)
@@ -20504,7 +20504,7 @@ func (c Client) CreateRoute(ctx context.Context, vpcID UUID, subnetID UUID, req 
 
 	bodyresp := new(Route)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("CreateRoute: prepare Json response: %w", err)
+		return nil, fmt.Errorf("CreateRoute: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20548,7 +20548,7 @@ func (c Client) DeleteRoute(ctx context.Context, vpcID UUID, subnetID UUID, id U
 
 	bodyresp := new(Empty)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("DeleteRoute: prepare Json response: %w", err)
+		return nil, fmt.Errorf("DeleteRoute: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil
@@ -20611,7 +20611,7 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 
 	bodyresp := new(ListZonesResponse)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
-		return nil, fmt.Errorf("ListZones: prepare Json response: %w", err)
+		return nil, fmt.Errorf("ListZones: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil


### PR DESCRIPTION
## Description

This PR ~adds AI API key management to egoscale v3 and~ fixes some v3 generator issues discovered while making it compatible with AI Services using [204 No Content](https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content).

## Changes

- ~Add ListAIAPIKeys, CreateAIAPIKey, GetAIAPIKey, UpdateAIAPIKey, DeleteAIAPIKey, and RotateAIAPIKey~
- The generator crashed when rendering responses with no content (HTTP 204) because a nil check was missing. Then did a fix for generated functions signature because operations with no response body (like DELETE returning 204) now generate func (...) error instead of func (...) (*Type, error)
- Add ai acronym so generator produces AIAPIKey instead of AiApiKey

Bonus
- Every 4xx/5xx response leaks a TCP connection from the pool. The error handler read response bodies with `io.ReadAll` but never closed them. The fix is a one liner `defer resp.Body.Close()` inside the error-handling block.
- Generated error messages used "Json" instead of "JSON". [Go conventions says: consistent case for acronyms.](https://go.dev/wiki/CodeReviewComments#initialisms)

The connection leak and the JSON naming fix are outside the scope of my task which is to add support for the AI API key operations but I included them because they are minor one-line changes. I can revert those commits if you prefer

## Checklist

- [x] Changelog updated (under *Unreleased* block)