### PR TITLE
v3: list-zones: do not send auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+- v3: list-zones: skip auth header to avoid IAM enforcement on public endpoint (#767)
+
+3.1.39
+----------
+
 - generator: support '+' symbol as enum separator (#783)
 
 3.1.38

--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -438,6 +438,9 @@ type RequestTmpl struct {
 	JSONResponseTarget string
 	ContentType        string
 	QueryParams        map[string]string
+	// SkipAuth is true for operations that must be called without credentials
+	// (e.g. list-zones which returns public data and should not trigger IAM enforcement).
+	SkipAuth bool
 }
 
 // serializeRequest serializes the openAPI spec into the request template.
@@ -446,6 +449,7 @@ func serializeRequest(path, httpMethod, funcName string, op *v3.Operation) (*Req
 		Name:        funcName,
 		OperationID: op.OperationId,
 		HTTPMethod:  strings.ToUpper(httpMethod),
+		SkipAuth:    op.OperationId == "list-zones",
 	}
 	p.Comment = renderDoc(op)
 	params := getParameters(op, funcName)

--- a/v3/generator/operations/request.tmpl
+++ b/v3/generator/operations/request.tmpl
@@ -32,13 +32,15 @@ func (c Client) {{ .Name }}({{ .Params }}) {{ .ValueReturn }} {
 		return nil, fmt.Errorf("{{ .Name }}: execute request editors: %w", err)
 	}
 
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("{{ .Name }}: sign request: %w", err)
-	}
+        {{ if not .SkipAuth }}
+        if err := c.signRequest(request); err != nil {
+                return nil, fmt.Errorf("{{ .Name }}: sign request: %w", err)
+        }
+        {{ end }}
 
-	if c.trace {
-		dumpRequest(request, "{{ .OperationID }}")
-	}
+        if c.trace {
+                dumpRequest(request, "{{ .OperationID }}")
+        }
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -19248,10 +19248,6 @@ func (c Client) ListZones(ctx context.Context) (*ListZonesResponse, error) {
 		return nil, fmt.Errorf("ListZones: execute request editors: %w", err)
 	}
 
-	if err := c.signRequest(request); err != nil {
-		return nil, fmt.Errorf("ListZones: sign request: %w", err)
-	}
-
 	if c.trace {
 		dumpRequest(request, "list-zones")
 	}


### PR DESCRIPTION
# Description

`/zones` is public but the server enforces IAM on authenticated requests, so a DBaaS-only key gets 403 for no reason.

`RequestTmpl` now has a `SkipAuth bool` field. When set, the generated function skips `signRequest` and sends no `Authorization` header. Operations opt in via `x-skip-auth: true` in the spec, so the guard survives future regenerations.

**Snippet used to verify:**

```go
package main

import (
"context"
"fmt"
"os"

v3 "github.com/exoscale/egoscale/v3"
"github.com/exoscale/egoscale/v3/credentials"
)

func main() {
	creds := credentials.NewStaticCredentials(os.Getenv("EXO_KEY"), os.Getenv("EXO_SECRET"))
	client, _ := v3.NewClient(creds)
	zones, err := client.ListZones(context.Background())
	if err != nil {
		fmt.Fprintln(os.Stderr, "error:", err)
		os.Exit(1)
	}
	fmt.Printf("ok: %d zones\n", len(zones.Zones))
}
```

Or with the CLI (DBaaS-only profile, using any command that triggers a zone switch):

```
# before fix
$ exo dbaas update --valkey-ip-filter 1.2.3.4/32 valkey-test-fix -z de-muc-1
error: unable to create client: switch client zone v3: get zone api endpoint: list zones: ListZones: http response: Forbidden: Forbidden by role policy for compute

# after fix
$ exo dbaas update --valkey-ip-filter 1.2.3.4/32 valkey-test-fix -z de-muc-1
 ✔  Updating DBaaS Valkey service "valkey-test-fix"  0s
```

**Go before** (master, DBaaS-only key):
```
error: ListZones: http response: Forbidden: Invalid request signature
```

**Go after** (this branch, same key):
```
ok: 8 zones
  - ch-gva-2
  - ch-dk-2
  - at-vie-1
  - de-fra-1
  - bg-sof-1
  - de-muc-1
  - at-vie-2
  - hr-zag-1
```

Related: exoscale/python-exoscale#90, exoscale/exoscale-sdk-java#14

## Checklist
(For exoscale contributors)
- [x] Changelog updated (under Unreleased block)

---

> [!NOTE]
> AI-assisted.