### PR TITLE
v3: add RevealAIAPIKey operation and update AI API key responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 - v3: add AI API key operations (ListAIAPIKeys, CreateAIAPIKey, GetAIAPIKey, UpdateAIAPIKey, DeleteAIAPIKey, RotateAIAPIKey)
 - v3 generator: align error messages with Go naming conventions (Json => JSON)
 - v3: close response body in handleHTTPErrorResp to avoid connection leaks
+- v3: add RevealAIAPIKey operation and update AI API key path (/ai/ai-api-key => /ai/api-key)
 
 3.1.36
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 - v3 generator: align error messages with Go naming conventions (Json => JSON)
 - v3: close response body in handleHTTPErrorResp to avoid connection leaks
 - v3: add RevealAIAPIKey operation and update AI API key path (/ai/ai-api-key => /ai/api-key)
+- v3: update AI API key responses (rotate/reveal return value only, create/update/get return metadata only)
 
 3.1.36
 ----------

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -33,7 +33,7 @@ func (l ListAIAPIKeysResponse) FindAIAPIKey(nameOrID string) (AIAPIKey, error) {
 
 // List AI API keys for an organization
 func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, error) {
-	path := "/ai/ai-api-key"
+	path := "/ai/api-key"
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -77,7 +77,7 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 
 // Create a new AI API key
 func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*AIAPIKeyWithValue, error) {
-	path := "/ai/ai-api-key"
+	path := "/ai/api-key"
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -132,7 +132,7 @@ type DeleteAIAPIKeyResponse struct {
 
 // Delete AI API key
 func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyResponse, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "DELETE", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -176,7 +176,7 @@ func (c Client) DeleteAIAPIKey(ctx context.Context, id UUID) (*DeleteAIAPIKeyRes
 
 // Get AI API key metadata
 func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -220,7 +220,7 @@ func (c Client) GetAIAPIKey(ctx context.Context, id UUID) (*AIAPIKey, error) {
 
 // Update AI API key name and/or scope
 func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyRequest) (*AIAPIKey, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v", id)
+	path := fmt.Sprintf("/ai/api-key/%v", id)
 
 	body, err := prepareJSONBody(req)
 	if err != nil {
@@ -271,7 +271,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 
 // Rotate AI API key value
 func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
-	path := fmt.Sprintf("/ai/ai-api-key/%v/rotate", id)
+	path := fmt.Sprintf("/ai/api-key/%v/rotate", id)
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, nil)
 	if err != nil {
@@ -308,6 +308,50 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 	bodyresp := new(AIAPIKeyWithValue)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateAIAPIKey: prepare JSON response: %w", err)
+	}
+
+	return bodyresp, nil
+}
+
+// Reveal AI API key plaintext value
+func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
+	path := fmt.Sprintf("/ai/api-key/%v/reveal", id)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: new request: %w", err)
+	}
+
+	request.Header.Add("User-Agent", c.getUserAgent())
+
+	if err := c.executeRequestInterceptors(ctx, request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: execute request editors: %w", err)
+	}
+
+	if err := c.signRequest(request); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: sign request: %w", err)
+	}
+
+	if c.trace {
+		dumpRequest(request, "reveal-ai-api-key")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http client do: %w", err)
+	}
+
+	if c.trace {
+		dumpResponse(response)
+	}
+
+	if err := handleHTTPErrorResp(response); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: http response: %w", err)
+	}
+
+	bodyresp := new(AIAPIKeyWithValue)
+	if err := prepareJSONResponse(response, bodyresp); err != nil {
+		return nil, fmt.Errorf("RevealAIAPIKey: prepare JSON response: %w", err)
 	}
 
 	return bodyresp, nil

--- a/v3/operations.go
+++ b/v3/operations.go
@@ -76,7 +76,7 @@ func (c Client) ListAIAPIKeys(ctx context.Context) (*ListAIAPIKeysResponse, erro
 }
 
 // Create a new AI API key
-func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*AIAPIKeyWithValue, error) {
+func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (*AIAPIKey, error) {
 	path := "/ai/api-key"
 
 	body, err := prepareJSONBody(req)
@@ -118,7 +118,7 @@ func (c Client) CreateAIAPIKey(ctx context.Context, req CreateAIAPIKeyRequest) (
 		return nil, fmt.Errorf("CreateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(AIAPIKey)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("CreateAIAPIKey: prepare JSON response: %w", err)
 	}
@@ -270,7 +270,7 @@ func (c Client) UpdateAIAPIKey(ctx context.Context, id UUID, req UpdateAIAPIKeyR
 }
 
 // Rotate AI API key value
-func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
+func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyValue, error) {
 	path := fmt.Sprintf("/ai/api-key/%v/rotate", id)
 
 	request, err := http.NewRequestWithContext(ctx, "POST", c.serverEndpoint+path, nil)
@@ -305,7 +305,7 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 		return nil, fmt.Errorf("RotateAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(AIAPIKeyValue)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RotateAIAPIKey: prepare JSON response: %w", err)
 	}
@@ -314,7 +314,7 @@ func (c Client) RotateAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 }
 
 // Reveal AI API key plaintext value
-func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue, error) {
+func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyValue, error) {
 	path := fmt.Sprintf("/ai/api-key/%v/reveal", id)
 
 	request, err := http.NewRequestWithContext(ctx, "GET", c.serverEndpoint+path, nil)
@@ -349,7 +349,7 @@ func (c Client) RevealAIAPIKey(ctx context.Context, id UUID) (*AIAPIKeyWithValue
 		return nil, fmt.Errorf("RevealAIAPIKey: http response: %w", err)
 	}
 
-	bodyresp := new(AIAPIKeyWithValue)
+	bodyresp := new(AIAPIKeyValue)
 	if err := prepareJSONResponse(response, bodyresp); err != nil {
 		return nil, fmt.Errorf("RevealAIAPIKey: prepare JSON response: %w", err)
 	}

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -90,7 +90,7 @@ type AIAPIKey struct {
 	UpdatedAT time.Time `json:"updated-at,omitempty"`
 }
 
-// AI API key with plaintext value (only returned on create/rotate)
+// AI API key with plaintext value (returned on create, rotate, or reveal)
 type AIAPIKeyWithValue struct {
 	// Creation timestamp
 	CreatedAT time.Time `json:"created-at,omitempty"`
@@ -102,7 +102,7 @@ type AIAPIKeyWithValue struct {
 	Scope string `json:"scope,omitempty"`
 	// Last update timestamp
 	UpdatedAT time.Time `json:"updated-at,omitempty"`
-	// Plaintext API key value (returned once on create/rotate)
+	// Plaintext API key value (returned on create, rotate, or reveal)
 	Value string `json:"value,omitempty"`
 }
 

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -89,20 +89,9 @@ type AIAPIKey struct {
 	// Last update timestamp
 	UpdatedAT time.Time `json:"updated-at,omitempty"`
 }
-
-// AI API key with plaintext value (returned on create, rotate, or reveal)
-type AIAPIKeyWithValue struct {
-	// Creation timestamp
-	CreatedAT time.Time `json:"created-at,omitempty"`
-	// AI API key ID
-	ID UUID `json:"id,omitempty"`
-	// Human-readable name for the AI API key
-	Name string `json:"name,omitempty"`
-	// Key scope: 'public' for all deployments, or a specific deployment UUID
-	Scope string `json:"scope,omitempty"`
-	// Last update timestamp
-	UpdatedAT time.Time `json:"updated-at,omitempty"`
-	// Plaintext API key value (returned on create, rotate, or reveal)
+// AI API key plaintext value (returned on rotate or reveal)
+type AIAPIKeyValue struct {
+	// Plaintext API key value
 	Value string `json:"value,omitempty"`
 }
 


### PR DESCRIPTION
- Add RevealAIAPIKey operation
- Update update AI API key path (`/ai/ai-api-key` -> `/ai/api-key`)
- Update AI API key responses (rotate/reveal return value only, create/update/get return metadata only)
