### PR TITLE
v3: support Go 1.25 stable version

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/exoscale/egoscale/v3
 
-go 1.26
+go 1.25
 
 require (
 	github.com/diskfs/go-diskfs v1.4.0


### PR DESCRIPTION
# Description

Relax the Go version requirement to both stable Go versions.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
