### PR TITLE
updated generate_v3 workflow to automatically release and bump cli/terraform provider

### DIFF
--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -3,50 +3,174 @@ name: check_and_regenerate_v3
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 7 * * *" # everyday at 7 AM
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: egoscale-auto-release
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
 
 jobs:
-  check_changes_and_create_pr:
+  generate_and_test:
     runs-on: ubuntu-latest
-
     permissions:
       contents: write
-      pull-requests: write
-      actions: write
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: v3/go.mod
 
     - name: Install yq
       run: |
         sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
         sudo chmod +x /usr/local/bin/yq
 
-    - name: Check for changes
-      id: check_changes
+    - name: Regenerate v3 from API spec
       run: |
         make pull-oapi-spec
         make generate
-        git diff --quiet || echo "changes_detected=true" >> $GITHUB_OUTPUT
 
-    - name: Create PR
-      id: create_pr
-      if: steps.check_changes.outputs.changes_detected
-      uses: peter-evans/create-pull-request@v8
-      with:
-        title: "v3: regenerate from new API spec"
-        body: "New changes have appeared in the API spec and egoscale v3 has been regenerated."
-        branch: generate-v3
-        delete-branch: true
-        base: master
-        author: "Exoscale <operation+build@exoscale.net>"
-        committer: "Exoscale <operation+build@exoscale.net>"
-    - name: Start CI on newly created PR
-      if: steps.check_changes.outputs.changes_detected && steps.create_pr.outputs.pull-request-number
+    - name: Check for changes
+      id: check_changes
       run: |
-        gh workflow run build-public-tooling.yaml --ref generate-v3
-        gh workflow run main.yml --ref generate-v3
-        gh workflow run govulncheck.yml --ref generate-v3
-      env:
-        GH_TOKEN: ${{ github.token }}
+        if ! git diff --quiet -- v3/schemas.go v3/client.go v3/operations.go; then
+          echo "changes_detected=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Run egoscale tests
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        make test-verbose
+        cd v3 && go test -race -mod=readonly -v ./...
+
+    - name: Bump version number
+      if: steps.check_changes.outputs.changes_detected
+      id: bump_version
+      run: |
+        CURRENT=$(awk -F'"' '/Version = /{print $2}' v3/version.go)
+        NUMERIC="${CURRENT#v}"
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$NUMERIC"
+        NEW_PATCH=$((PATCH + 1))
+        NEW_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+        echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Test cli compatibility
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        git clone --depth 1 https://github.com/exoscale/cli.git
+        cd cli
+        go mod edit -replace github.com/exoscale/egoscale/v3=$GITHUB_WORKSPACE/v3
+        go mod tidy
+        make build
+        make test
+
+    - name: Test terraform-provider-exoscale compatibility
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        git clone --depth 1 https://github.com/exoscale/terraform-provider-exoscale.git
+        cd terraform-provider-exoscale
+        go mod edit -replace github.com/exoscale/egoscale/v3=$GITHUB_WORKSPACE/v3
+        go mod tidy
+        go build ./...
+        go test ./...
+
+    - name: Update version
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        sed -i "s/const Version = \".*\"/const Version = \"${VERSION}\"/" v3/version.go
+
+    - name: Update CHANGELOG
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        VER="${VERSION#v}"
+        {
+           echo "Changelog"
+          echo "========="
+          echo ""
+          echo "${VER}"
+          echo "----------"
+          echo ""
+          echo "- v3: regenerate from new API spec"
+          echo ""
+          sed -n '4,$ p' CHANGELOG.md
+        } > CHANGELOG.md.tmp
+        mv CHANGELOG.md.tmp CHANGELOG.md
+
+    - name: Commit and push to master
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        git config --global user.name "Exoscale Bot"
+        git config --global user.email "operation+build@exoscale.net"
+        git remote set-url origin https://x-access-token:${{ secrets.CROSS_REPO_PAT }}@github.com/exoscale/egoscale.git
+        git add \
+          v3/schemas.go v3/client.go v3/operations.go \
+          v3/version.go v3/generator/source.yaml \
+          CHANGELOG.md
+        git commit -m "v3: regenerate from new API spec (${VERSION})"
+        git push origin master
+
+    - name: Tag release
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        git tag -a "$VERSION" -m "Release ${VERSION}"
+        git push origin "$VERSION"
+
+    - name: Wait for GitHub release to be created
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        for i in $(seq 1 20); do
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://api.github.com/repos/exoscale/egoscale/releases/tags/${VERSION}" \
+            -H "Authorization: Bearer ${{ secrets.CROSS_REPO_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Release $VERSION is ready"
+            exit 0
+          fi
+          echo "Waiting for release ($i/20)..."
+          sleep 30
+        done
+        echo "ERROR: Release $VERSION did not appear after 10 minutes"
+        exit 1
+
+    - name: Update cli dependency
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        git clone https://x-access-token:${{ secrets.CROSS_REPO_PAT }}@github.com/exoscale/cli.git
+        cd cli
+        git config user.name "Exoscale Bot"
+        git config user.email "operation+build@exoscale.net"
+        GOPROXY=direct go get github.com/exoscale/egoscale/v3@${VERSION}
+        go mod tidy
+        git add go.mod go.sum
+        git commit -m "upgrade egoscale to ${VERSION}" || echo "no dependency changes"
+        git push origin master
+
+    - name: Update terraform-provider-exoscale dependency
+      if: steps.check_changes.outputs.changes_detected
+      run: |
+        VERSION="${{ steps.bump_version.outputs.new_version }}"
+        git clone https://x-access-token:${{ secrets.CROSS_REPO_PAT }}@github.com/exoscale/terraform-provider-exoscale.git
+        cd terraform-provider-exoscale
+        git config user.name "Exoscale Bot"
+        git config user.email "operation+build@exoscale.net"
+        GOPROXY=direct go get github.com/exoscale/egoscale/v3@${VERSION}
+        go mod tidy
+        git add go.mod go.sum
+        git commit -m "upgrade egoscale to ${VERSION}" || echo "no dependency changes"
+        git push origin master


### PR DESCRIPTION
# Description

Shortcut story: [sc-178260](https://app.shortcut.com/exoscale/story/178260/automate-egoscale-release-workflow)

From the story:

> We should improve the automation around releasing new versions of our public toolings. Here's the current situation:
>   - public-api is our public server gateway and exposes an openapi schema
>   - egoscale (current project) is our go SDK, and is auto-generated based on that openapi schema. On a daily basis, the schema is pulled, and if there are any changes then a PR is created. At this point, we need to manually review and merge the PR, and possibly create a new release by updating the changelog and creating a git tag.
>   - cli is our command line utility, and makes use of egoscale. We need to wait for a new release of egoscale, then update it, and then manually build the feature that we want.
>   - story is almost identical with terraform-provider-exoscale. 
> 
> This is very tedious and wastes a lot of time. I want to automate it all using github actions:
>   
> I propose to change the egoscale daily job so that it:
>   1. pulls the latest version of the public-api schema
>   2. generates the new version of the egoscale client
>   3. pulls the cli and terraform code bases, updates the egoscale dependency, tries to build them and run the tests. 
>   4. IF everything works smoothly, then update the [CHANGELOG.md](http://CHANGELOG.md) file, commit the changes directly to master, and trigger a new release. 
>   5. once the new release is done, update the egoscale dependency in both cli and terraform-provider-exoscale, and commit to master
> 
> The goals are that:
>   - I can go to the cli repo in the morning, and the current version of the SDK matches the current version of the openapi schema. 
>   - if any team breaks the compatibility of their openapi schema, then it becomes their burden as they've broken the automation. 

# Notes for the reviewer

- CHANGELOG format is hardcoded. The script assumes the existing RST-style header (`Changelog\n=========`) and a static "regenerate from new API spec" entry. Any format change to `CHANGELOG.md` may break this.
- I have gone with the assumption that this will run in the middle of the night and that we magically won't run into concurrency issues
- If there are breaking changes in the OpenAPI schema, we won't be releasing, however I have not implemented any notification system yet... 
- We need to configure a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). @brutasse / @arnaudgeiser ideally this would be as a github app that has read/write access to the three repos and read access to the repos metadata. I'll replace the `secrets.CROSS_REPO_PAT` in the PR once I have the name of the app. 

Use of AI: A first version of the new workflow was written by Qwen 3.6 27b. I then manually reviewed and iterated with Claude Opus until I got it where I wanted. 

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
