### PR TITLE
v3/generator: handle OAS 3.1 nullable type arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- v3 generator: handle nullable OpenAPI 3.1 type arrays (#776)
+
 3.1.43
 ------
 

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -119,9 +119,18 @@ func RenderSimpleType(s *base.Schema) string {
 			return "string"
 		case "byte":
 			return "[]byte"
-		default:
-			return s.Format
+		case "int32":
+			return "int32"
+		case "int64":
+			return "int64"
+		case "float":
+			return "float32"
+		case "double":
+			return "float64"
 		}
+		// Any other format is still a string at the Go level;
+		// the format is just a validation hint.
+		return "string"
 	}
 
 	if len(s.Type) == 0 {

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -101,9 +101,9 @@ func RenderSchema(schemaName string, s *base.SchemaProxy) ([]byte, error) {
 // Add more simple type here.
 func RenderSimpleType(s *base.Schema) string {
 	if s.Extensions != nil {
-		typ, ok := s.Extensions.Get("x-go-type")
+		goType, ok := s.Extensions.Get("x-go-type")
 		if ok {
-			return typ.Value
+			return goType.Value
 		}
 	}
 
@@ -141,17 +141,27 @@ func RenderSimpleType(s *base.Schema) string {
 		)
 		return "any"
 	}
-	if s.Type[0] == "boolean" {
+
+	// OAS 3.1: type can be ["integer", "null"], skip null to get the real type.
+	kind := ""
+	for _, entry := range s.Type {
+		if entry != "null" {
+			kind = entry
+			break
+		}
+	}
+
+	if kind == "boolean" {
 		return "bool"
 	}
-	if s.Type[0] == "integer" {
+	if kind == "integer" {
 		return "int"
 	}
-	if s.Type[0] == "number" {
+	if kind == "number" {
 		return "float64"
 	}
 
-	return s.Type[0]
+	return kind
 }
 
 // renderSchemaInternal render a given libopenapi Schema into a buffer.
@@ -169,16 +179,16 @@ func renderSchemaInternal(schemaName string, s *base.Schema, output *bytes.Buffe
 	// In OpenAPI versions 2 and 3.0, this Type is a single value,
 	// so array will only ever have one value in version 3.1,
 	// Type can be multiple values
-	typ := ""
-	for _, t := range s.Type {
+	kind := ""
+	for _, entry := range s.Type {
 		// Find the first non-null type and use that for now.
-		if t != "null" {
-			typ = t
+		if entry != "null" {
+			kind = entry
 			break
 		}
 	}
 
-	switch typ {
+	switch kind {
 	case "boolean", "integer", "number", "string":
 		output.WriteString(doc)
 		var definition string
@@ -217,7 +227,7 @@ func renderSchemaInternal(schemaName string, s *base.Schema, output *bytes.Buffe
 		output.WriteString("type " + schemaName + " " + Map + "\n")
 		return nil
 	default:
-		slog.Error("type not implemented", slog.String("type", typ))
+		slog.Error("type not implemented", slog.String("type", kind))
 		return nil
 	}
 }
@@ -233,13 +243,13 @@ func renderSimpleTypeEnum(typeName string, s *base.Schema) string {
 		}
 	}
 
-	typ := RenderSimpleType(s)
-	definition := "type " + typeName + " " + typ + "\n"
+	goType := RenderSimpleType(s)
+	definition := "type " + typeName + " " + goType + "\n"
 	definition += "const (\n"
 
 	for _, e := range s.Enum {
 		value := e.Value
-		if typ == "string" {
+		if goType == "string" {
 			value = fmt.Sprintf("%q", e.Value)
 		}
 		name := typeName + helpers.ToCamel(e.Value)
@@ -363,9 +373,9 @@ func renderObject(typeName string, s *base.Schema, output *bytes.Buffer, schemaN
 		InferType(prop)
 
 		propType := ""
-		for _, t := range prop.Type {
-			if t != "null" {
-				propType = t
+		for _, entry := range prop.Type {
+			if entry != "null" {
+				propType = entry
 				break
 			}
 		}
@@ -373,6 +383,14 @@ func renderObject(typeName string, s *base.Schema, output *bytes.Buffer, schemaN
 		var nullable = false
 		if prop.Nullable != nil {
 			nullable = *prop.Nullable
+		}
+
+		// OAS 3.1 expresses nullability via "null" in the type array.
+		for _, kind := range prop.Type {
+			if kind == "null" {
+				nullable = true
+				break
+			}
 		}
 
 		// https://github.com/pb33f/libopenapi/issues/283
@@ -558,7 +576,14 @@ func IsSimpleSchema(s *base.Schema) bool {
 		return true
 	}
 
-	return s.Type[0] != "object" && s.Type[0] != "map" && s.Type[0] != "array"
+	for _, kind := range s.Type {
+		if kind == "null" {
+			continue
+		}
+		return kind != "object" && kind != "map" && kind != "array"
+	}
+
+	return true
 }
 
 func renderDoc(s *base.Schema) string {

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/exoscale/egoscale/v3/generator/helpers"
@@ -371,19 +372,25 @@ func renderObject(typeName string, s *base.Schema, output *bytes.Buffer, schemaN
 			}
 		}
 
-		InferType(prop)
+		nullable := prop.Nullable != nil && *prop.Nullable
+		if slices.Contains(prop.Type, "null") {
+			types := slices.DeleteFunc(slices.Clone(prop.Type), func(typ string) bool { return typ == "null" })
+			if len(types) != 1 {
+				return "", fmt.Errorf("property %q: nullable type must contain exactly one non-null type", propName)
+			}
+			propCopy := *prop
+			propCopy.Type = types
+			prop = &propCopy
+			nullable = true
+		}
 
+		InferType(prop)
 		propType := ""
 		for _, t := range prop.Type {
 			if t != "null" {
 				propType = t
 				break
 			}
-		}
-
-		var nullable = false
-		if prop.Nullable != nil {
-			nullable = *prop.Nullable
 		}
 
 		// https://github.com/pb33f/libopenapi/issues/283

--- a/v3/generator/schemas/schemas_test.go
+++ b/v3/generator/schemas/schemas_test.go
@@ -1,0 +1,53 @@
+package schemas
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderSchemaNullableTypeArray(t *testing.T) {
+	for _, types := range []string{`[integer, "null"]`, `["null", integer]`} {
+		t.Run(types, func(t *testing.T) {
+			got, err := renderTestSchema(t, types)
+			require.NoError(t, err)
+			require.Contains(t, got, "Value *int")
+		})
+	}
+}
+
+func TestRenderSchemaRejectsUnsupportedNullableTypes(t *testing.T) {
+	for _, types := range []string{`[integer, string, "null"]`, `["null"]`} {
+		t.Run(types, func(t *testing.T) {
+			_, err := renderTestSchema(t, types)
+			require.EqualError(t, err, `property "value": nullable type must contain exactly one non-null type`)
+		})
+	}
+}
+
+func renderTestSchema(t *testing.T, types string) (string, error) {
+	t.Helper()
+
+	doc, err := libopenapi.NewDocument([]byte(fmt.Sprintf(`openapi: 3.1.0
+info:
+  title: test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    test:
+      type: object
+      properties:
+        value:
+          type: %s
+`, types)))
+	require.NoError(t, err)
+
+	model, errs := doc.BuildV3Model()
+	require.Empty(t, errs)
+
+	result, err := RenderSchema("test", model.Model.Components.Schemas.GetOrZero("test"))
+	return string(result), err
+}

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -4454,7 +4454,7 @@ type OperationResourceRef struct {
 // Per-org token consumption quota response
 type OrgConsumptionQuotaResponse struct {
 	// Per-org token consumption quota (tokens/min). Null means unlimited.
-	QuotaTokensPerMinute int `json:"quota-tokens-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaTokensPerMinute *int `json:"quota-tokens-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Organization
@@ -4739,7 +4739,7 @@ type SecurityGroupRule struct {
 // Request to set per-org token consumption quota
 type SetOrgConsumptionQuotaRequest struct {
 	// Per-org token consumption quota (tokens/min). Pass null to remove the limit.
-	QuotaTokensPerMinute int `json:"quota-tokens-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaTokensPerMinute *int `json:"quota-tokens-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Kubernetes Audit parameters

--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -4935,7 +4935,7 @@ type Operation struct {
 // Per-org Unit Of Measurement (UOM) consumption quota response
 type OrgConsumptionQuotaResponse struct {
 	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Null means unlimited. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
-	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaUomPerMinute *int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Organization
@@ -5271,7 +5271,7 @@ type SecurityGroupRule struct {
 // Request to set per-org Unit Of Measurement (UOM) consumption quota
 type SetOrgConsumptionQuotaRequest struct {
 	// Per-org Unit Of Measurement (UOM) consumption quota (UOM/min). Pass null to remove the limit. UOM represents weighted units across different AI workloads (e.g., tokens for LLMs, minutes for TTS, pages for OCR).
-	QuotaUomPerMinute int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
+	QuotaUomPerMinute *int `json:"quota-uom-per-minute,omitempty" validate:"omitempty,gte=0"`
 }
 
 // Kubernetes Audit parameters


### PR DESCRIPTION
# Description

OpenAPI 3.1 expresses nullable values as a type array, such as `["integer", "null"]`. The v3 generator did not mark these object properties nullable, so it generated `int` instead of `*int`.

This change:

- handles exactly one concrete property type plus `null`
- rejects heterogeneous and null-only type arrays instead of silently choosing a type
- regenerates the affected quota request and response fields as `*int`
- adds focused regression tests for both type orderings and unsupported arrays

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)

---

> [!NOTE]
> AI assistance: test scaffolding.
