### PR TITLE
Correctly exist non-zero if go generate fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ pull-oapi-spec:
 
 .PHONY: generate
 generate:
+	@set -e
 	@cd v3/generator/
 	@go generate
 	@go mod tidy


### PR DESCRIPTION
# Description
Before: 
<img width="1936" height="308" alt="image" src="https://github.com/user-attachments/assets/777fc9ee-4b35-4b28-bad1-840f50894aae" />
(and the program exit 0)

After:
<img width="1936" height="176" alt="image" src="https://github.com/user-attachments/assets/69c10f78-fe94-421f-9f1f-8a0b89268888" />
(and the program exit non zero)

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
