### PR TITLE
generator: support '+' symbol as enum separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,28 @@
 Changelog
 =========
 
-3.1.38
+Unreleased
 ----------
+
+- generator: support '+' symbol as enum separator (#783)
+
+3.1.38
+------
 
 - v3: regenerate from new API spec (#779)
 
 3.1.37
-----------
+------
 
 - v3: regenerate from new API spec (#778)
 
 3.1.36
-----------
+------
 
 - v3: support for RFC-9457 error format responses
 
 3.1.35
-----------
+------
 
 - Bump Go to 1.26 (fixes govulncheck report) (#754)
 - v3 generator: implement format: uri-reference (#753)

--- a/v3/generator/helpers/helpers.go
+++ b/v3/generator/helpers/helpers.go
@@ -251,7 +251,7 @@ func toInitialCamel(s string, lower bool) string {
 		return ""
 	}
 
-	pattern := `[-_./\s]`
+	pattern := `[-_./+\s]`
 	s = trimBySeparators(s, pattern)
 	words := splitBySeparators(s, pattern)
 

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -215,7 +215,7 @@ func renderSchemaInternal(schemaName string, s *base.Schema, output *bytes.Buffe
 
 func renderSimpleTypeEnum(typeName string, s *base.Schema) string {
 	for _, e := range s.Enum {
-		if strings.Contains(e.Value, ",") {
+		if strings.Contains(e.Value, ",") || strings.Contains(e.Value, "+") {
 			return ""
 		}
 

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -215,7 +215,7 @@ func renderSchemaInternal(schemaName string, s *base.Schema, output *bytes.Buffe
 
 func renderSimpleTypeEnum(typeName string, s *base.Schema) string {
 	for _, e := range s.Enum {
-		if strings.Contains(e.Value, ",") || strings.Contains(e.Value, "+") {
+		if strings.Contains(e.Value, ",") {
 			return ""
 		}
 


### PR DESCRIPTION
# Description

Adds another possible separator for enum values: `+`.
Before enum value with `+` symbol would break generator.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)

# Testing

For a test change in spec:
```yaml
 git diff source.yaml 
diff --git a/v3/generator/source.yaml b/v3/generator/source.yaml
index a9d6bd2..f1cff27 100644
--- a/v3/generator/source.yaml
+++ b/v3/generator/source.yaml
@@ -505,6 +505,7 @@ components:
             - standby
             - master
             - read-replica
+            - write+replica
           description: Role of this node. Only returned for a subset of service types
         state:
           type: string
```
Before:
```
$ go generate
2026/06/15 15:00:18 schemas: format.Source: 942:24: expected ';', found '+' (and 3 more errors)
exit status 1
main.go:17: running "go": exit status 1
```

After:
```
$ go generate

$ git diff ../*.go
diff --git a/v3/schemas.go b/v3/schemas.go
index a058509..98ccc61 100755
--- a/v3/schemas.go
+++ b/v3/schemas.go
@@ -852,9 +852,10 @@ type DBAASMysqlUserPassword string
 type DBAASNodeStateRole string
 
 const (
-       DBAASNodeStateRoleStandby     DBAASNodeStateRole = "standby"
-       DBAASNodeStateRoleMaster      DBAASNodeStateRole = "master"
-       DBAASNodeStateRoleReadReplica DBAASNodeStateRole = "read-replica"
+       DBAASNodeStateRoleStandby      DBAASNodeStateRole = "standby"
+       DBAASNodeStateRoleMaster       DBAASNodeStateRole = "master"
+       DBAASNodeStateRoleReadReplica  DBAASNodeStateRole = "read-replica"
+       DBAASNodeStateRoleWriteReplica DBAASNodeStateRole = "write+replica"
 )
```