### PR TITLE
chore: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 Changelog
 =========
 
-3.1.39
+3.1.40
 ------
 
 - v3: list-zones: skip auth header to avoid IAM enforcement on public endpoint (#767)
 
 3.1.39
-----------
+------
 
 - generator: support '+' symbol as enum separator (#783)
 

--- a/v3/version.go
+++ b/v3/version.go
@@ -1,4 +1,4 @@
 package v3
 
 // Version represents the current egoscale v3 version.
-const Version = "v3.1.39"
+const Version = "v3.1.40"


### PR DESCRIPTION
# Description

Prep for cutting the v3.1.40 release.

What it actually contains:

- [exoscale/egoscale#767](https://github.com/exoscale/egoscale/pull/767): `ListZones` no longer sends an `Authorization` header, so DBaaS-only IAM keys (and other restricted keys) can switch zones without hitting 403 on the public `/zone` endpoint.

Side fix:

- The `CHANGELOG.md` on master had two `3.1.39` blocks because #767's CHANGELOG entry was added on top of an already-released tag. This PR collapses them: `3.1.40` for #767, `3.1.39` for #783 (enum separator). The tagged `v3.1.39` content is unchanged.

Files:

- `CHANGELOG.md`
- `v3/version.go` (`v3.1.39` -> `v3.1.40`)

## Checklist

(For exoscale contributors)

* [x] Changelog updated (under new `3.1.40` block)
* [ ] Testing

## Testing

Diff is two lines plus a CHANGELOG reshuffle. The CI on the `release` workflow is tag-driven, so it'll be exercised when the maintainer pushes the `v3.1.40` tag.

## Notes for reviewers

> [!NOTE]
> AI-assisted: identified the duplicate 3.1.39 block, drafted the 3.1.40 entry, and bumped the version constant. 
