### PR TITLE
feat(generator): enable x-enum-varnames

### DIFF
--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -224,16 +224,34 @@ func renderSimpleTypeEnum(typeName string, s *base.Schema) string {
 		}
 	}
 
+	// x-enum-varnames provides explicit suffixes for each enum value
+	// It must be used in the same order as the enum array.
+	// Usefull when: '1g.24gb-me' and '1g.24gb+me' returns the same suffix '1g24gbMe'.
+	var varnames []string
+	if s.Extensions != nil {
+		if node, ok := s.Extensions.Get("x-enum-varnames"); ok {
+			for _, n := range node.Content {
+				varnames = append(varnames, n.Value)
+			}
+		}
+	}
+	useVarnames := len(varnames) == len(s.Enum)
+
 	typ := RenderSimpleType(s)
 	definition := "type " + typeName + " " + typ + "\n"
 	definition += "const (\n"
 
-	for _, e := range s.Enum {
+	for i, e := range s.Enum {
 		value := e.Value
 		if typ == "string" {
 			value = fmt.Sprintf("%q", e.Value)
 		}
-		name := typeName + helpers.ToCamel(e.Value)
+		var name string
+		if useVarnames {
+			name = typeName + varnames[i]
+		} else {
+			name = typeName + helpers.ToCamel(e.Value)
+		}
 
 		definition += fmt.Sprintf("%s %s = %s\n", name, typeName, value)
 	}


### PR DESCRIPTION
# Description
With special characters like `-,+,.` the egoscale generator can generate the same suffix for an enum
For example: `1g.24gb-me` and `1g.24gb+me` produce the same suffix `1g24gbMe`

This PR enables the [x-enum-varnames](https://openapi-generator.tech/docs/templating/#enum) behavior.
This will be a second list with explicit go variable name
ex:

```Yaml
nvidia-mig-profile-rtxpro6000.96gb:
      type: string
      enum:
        - 1g.24gb-me
        - 1g.24gb
        - 2g.48gb-me
        - 2g.48gb
        - 4g.96gb+gfx
        - 1g.24gb+me
        - 2g.48gb+me.all
        - 1g.24gb+gfx
        - 1g.24gb+me.all
        - 4g.96gb
        - 2g.48gb+gfx
      x-enum-varnames:
        - 1g24gbWithoutMe
        - 1g24gb
        - 2g48gbWithoutMe
        - 2g48gb
        - 4g96gbWithGfx
        - 1g24gbWithMe
        - 2g48gbWithMeAll
        - 1g24gbWithGfx
        - 1g24gbWithMeAll
        - 4g96gb
        - 2g48gbWithGfx
```
will generate:
```Go
type NvidiaMigProfileRtxpro600096gb string

const (
	NvidiaMigProfileRtxpro600096gb1g24gbWithoutMe NvidiaMigProfileRtxpro600096gb = "1g.24gb-me"
	NvidiaMigProfileRtxpro600096gb1g24gb          NvidiaMigProfileRtxpro600096gb = "1g.24gb"
	NvidiaMigProfileRtxpro600096gb2g48gbWithoutMe NvidiaMigProfileRtxpro600096gb = "2g.48gb-me"
	NvidiaMigProfileRtxpro600096gb2g48gb          NvidiaMigProfileRtxpro600096gb = "2g.48gb"
	NvidiaMigProfileRtxpro600096gb4g96gbWithGfx   NvidiaMigProfileRtxpro600096gb = "4g.96gb+gfx"
	NvidiaMigProfileRtxpro600096gb1g24gbWithMe    NvidiaMigProfileRtxpro600096gb = "1g.24gb+me"
	NvidiaMigProfileRtxpro600096gb2g48gbWithMeAll NvidiaMigProfileRtxpro600096gb = "2g.48gb+me.all"
	NvidiaMigProfileRtxpro600096gb1g24gbWithGfx   NvidiaMigProfileRtxpro600096gb = "1g.24gb+gfx"
	NvidiaMigProfileRtxpro600096gb1g24gbWithMeAll NvidiaMigProfileRtxpro600096gb = "1g.24gb+me.all"
	NvidiaMigProfileRtxpro600096gb4g96gb          NvidiaMigProfileRtxpro600096gb = "4g.96gb"
	NvidiaMigProfileRtxpro600096gb2g48gbWithGfx   NvidiaMigProfileRtxpro600096gb = "2g.48gb+gfx"
)
```


## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
