### PR TITLE
feat: run standard checks in PR

### DIFF
--- a/.github/workflows/build-public-tooling.yaml
+++ b/.github/workflows/build-public-tooling.yaml
@@ -3,10 +3,9 @@ name: build-public-tooling
 on:
   workflow_dispatch:
   push:
-  workflow_run:
-    workflows: ["check_and_regenerate_v3"]
-    types:
-      - completed
+    branches:
+      - master
+  pull_request: {}
 
 jobs:
   build_public_tooling:
@@ -29,6 +28,6 @@ jobs:
       run: |
         git clone https://github.com/exoscale/${{ matrix.case.repo }}
         cd ${{ matrix.case.repo }}
-        go get github.com/exoscale/egoscale/v3@${{ github.sha }}
+        go get github.com/exoscale/egoscale/v3@${{ github.event.pull_request.head.sha || github.sha }}
         go mod vendor
         ${{ matrix.case.build }}

--- a/.github/workflows/generate_v3.yaml
+++ b/.github/workflows/generate_v3.yaml
@@ -42,11 +42,3 @@ jobs:
         base: master
         author: "Exoscale <operation+build@exoscale.net>"
         committer: "Exoscale <operation+build@exoscale.net>"
-    - name: Start CI on newly created PR
-      if: steps.check_changes.outputs.changes_detected && steps.create_pr.outputs.pull-request-number
-      run: |
-        gh workflow run build-public-tooling.yaml --ref generate-v3
-        gh workflow run main.yml --ref generate-v3
-        gh workflow run govulncheck.yml --ref generate-v3
-      env:
-        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,7 +2,10 @@ name: govulncheck
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
   govulncheck:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,6 @@ on:
     - 'version/*'
     tags-ignore:
     - 'v**' # Don't run CI tests on release tags
-  workflow_run:
-    workflows: ["check_and_regenerate_v3"]
-    types:
-      - completed
 
 jobs:
   CI:


### PR DESCRIPTION
# Description
workflow `build-public-tooling` doesn't run when a PR with auto-generated code is created. This PR should fix this
https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/ 

