### PR TITLE
Revert breaking change in errors handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Revert breaking change in errors handling (#798)
+
 3.1.41
 ------
 

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -118,7 +118,10 @@ type APIErrorEntry struct {
 	Location string
 }
 
-func (e *APIError) Error() string { return e.sentinel.Error() }
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.sentinel.Error(), e.Message)
+}
+
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 func handleHTTPErrorResp(resp *http.Response) error {


### PR DESCRIPTION
# Description
Error rework introduced in https://github.com/exoscale/egoscale/pull/763 changed the format of default error (`.Error()`). This in turn broke some duck taping we have in tooling, eg. https://github.com/exoscale/terraform-provider-exoscale/blob/master/pkg/resources/block_storage/resource_volume.go#L552. This change was not necessary, my PR fixes the format to stay the same and un-break the tooling. Rich context is still available.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
