### PR TITLE
fix for response suffix and number parsing

### DIFF
--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -127,10 +127,20 @@ func renderResponseSchema(name string, op *v3.Operation) ([]byte, error) {
 			return nil, err
 		}
 
-		// Skip on reference.
+		// Skip on reference, unless the $ref schema name ends with "-response" —
+		// in that case the generated Go type matches funcName+"Response" and findable
+		// should still be emitted (e.g. list-ai-api-keys-response -> ListAIAPIKeysResponse).
 		if media.Schema.IsReference() {
-			// $ref schemas use the referenced type directly (e.g. DBAASClickhouseRoles),
-			// not funcName+Response.  Skip findable to keep the convention consistent.
+			refName := media.Schema.GetReference()
+			if !strings.HasSuffix(strings.ToLower(refName), "-response") {
+				// $ref to a non-Response schema (e.g. dbaas-clickhouse-roles).
+				// No funcName+Response type exists, so skip findable.
+				continue
+			}
+			// $ref to a *-response schema — findable is valid, fall through.
+			if findable != nil {
+				output.Write(findable)
+			}
 			continue
 		}
 

--- a/v3/generator/operations/operations.go
+++ b/v3/generator/operations/operations.go
@@ -129,10 +129,8 @@ func renderResponseSchema(name string, op *v3.Operation) ([]byte, error) {
 
 		// Skip on reference.
 		if media.Schema.IsReference() {
-			if findable != nil {
-				output.Write(findable)
-			}
-
+			// $ref schemas use the referenced type directly (e.g. DBAASClickhouseRoles),
+			// not funcName+Response.  Skip findable to keep the convention consistent.
 			continue
 		}
 

--- a/v3/generator/schemas/schemas.go
+++ b/v3/generator/schemas/schemas.go
@@ -119,6 +119,8 @@ func RenderSimpleType(s *base.Schema) string {
 			return "string"
 		case "byte":
 			return "[]byte"
+		case "double":
+			return "float64"
 		default:
 			return s.Format
 		}


### PR DESCRIPTION
Tested with local generation
fix for this two failures on double and response suffixes: https://github.com/exoscale/egoscale/actions/runs/30889757915/job/92859707463#step:2:126
## Checklist
* [x] Changelog updated (under *Unreleased* block)

### Generator on master's source.yaml
- [x] Result: No diff - no breaking changes introduced



