### PR TITLE
v2: preserve custom API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- v2: preserve custom API endpoints on zoned requests
+
 3.1.46
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-- v2: preserve custom API endpoints on zoned requests
+- v2: do not override custom API endpoints for zoned requests #806
 
 3.1.46
 ------

--- a/v2/client.go
+++ b/v2/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -254,21 +253,22 @@ func setUserAgent(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-// setEndpointFromContext is an HTTP client request interceptor that overrides the "Host" header
-// with information from a request endpoint optionally set in the context instance. If none is
-// found or host is an IP address, the request is left untouched.
+// setEndpointFromContext is an HTTP client request interceptor that overrides a generic API
+// endpoint with information from a request endpoint optionally set in the context instance.
+// Custom API endpoints are left untouched.
 func setEndpointFromContext(ctx context.Context, req *http.Request) error {
-	h, _, err := net.SplitHostPort(req.Host)
-	if err != nil {
-		h = req.Host
+	v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint)
+	if !ok {
+		return nil
 	}
-	if net.ParseIP(h) == nil {
-		v, ok := ctx.Value(api.ReqEndpoint{}).(api.ReqEndpoint)
-		if ok {
-			req.Host = v.Host()
-			req.URL.Host = v.Host()
-		}
+
+	origin := req.URL.Scheme + "://" + req.URL.Host + "/"
+	if origin != api.EndpointURL && origin != "https://"+v.Env()+".exoscale.com/" {
+		return nil
 	}
+
+	req.Host = v.Host()
+	req.URL.Host = v.Host()
 
 	return nil
 }

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -203,23 +203,33 @@ func TestDefaultClient_Retry(t *testing.T) {
 }
 
 func TestSetEndpointFromContext(t *testing.T) {
-	var (
-		ctx                = context.Background()
-		testReqEndpointEnv = "api"
-		testURL            = "https://www.example.net/test.txt"
-		req, _             = http.NewRequest("GET", testURL, nil)
-	)
+	ctx := context.Background()
+	zonedCtx := api.WithEndpoint(ctx, api.NewReqEndpoint("api", "ch-gva-2"))
+	environmentCtx := api.WithEndpoint(ctx, api.NewReqEndpoint("test", "ch-gva-2"))
 
-	// With empty context
-	err := setEndpointFromContext(ctx, req)
-	require.NoError(t, err)
-	require.Equal(t, testURL, req.URL.String())
-
-	// With augmented context
-	reqEndpoint := api.NewReqEndpoint(testReqEndpointEnv, "")
-	err = setEndpointFromContext(api.WithEndpoint(ctx, reqEndpoint), req)
-	require.NoError(t, err)
-	require.Equal(t, reqEndpoint.Host(), req.URL.Host)
+	for _, tt := range []struct {
+		name     string
+		ctx      context.Context
+		url      string
+		wantHost string
+	}{
+		{name: "without endpoint context", ctx: ctx, url: "https://api.exoscale.com/v2/ssh-key", wantHost: "api.exoscale.com"},
+		{name: "default endpoint", ctx: zonedCtx, url: "https://api.exoscale.com/v2/ssh-key", wantHost: "api-ch-gva-2.exoscale.com"},
+		{name: "default endpoint with environment", ctx: environmentCtx, url: "https://api.exoscale.com/v2/ssh-key", wantHost: "test-ch-gva-2.exoscale.com"},
+		{name: "environment endpoint", ctx: environmentCtx, url: "https://test.exoscale.com/v2/ssh-key", wantHost: "test-ch-gva-2.exoscale.com"},
+		{name: "custom hostname", ctx: zonedCtx, url: "https://gateway.internal:8443/v2/ssh-key", wantHost: "gateway.internal:8443"},
+		{name: "custom IPv4", ctx: zonedCtx, url: "http://127.0.0.1:8080/v2/ssh-key", wantHost: "127.0.0.1:8080"},
+		{name: "custom IPv6", ctx: zonedCtx, url: "http://[::1]/v2/ssh-key", wantHost: "[::1]"},
+		{name: "custom scheme", ctx: zonedCtx, url: "http://api.exoscale.com/v2/ssh-key", wantHost: "api.exoscale.com"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.url, nil)
+			require.NoError(t, err)
+			require.NoError(t, setEndpointFromContext(tt.ctx, req))
+			require.Equal(t, tt.wantHost, req.URL.Host)
+			require.Equal(t, tt.wantHost, req.Host)
+		})
+	}
 }
 
 func TestNewClient(t *testing.T) {


### PR DESCRIPTION
# Description

Preserve custom v2 API endpoints instead of rewriting hostname endpoints to zonal Exoscale hosts. Default and environment endpoints keep their zonal routing.

Stacked on #807 and related to [terraform-provider-exoscale#573](https://github.com/exoscale/terraform-provider-exoscale/issues/573).

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
