### PR TITLE
lint: ignore deprecated v1 assignments

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -550,16 +550,6 @@ func TestClientList(t *testing.T) {
 	}}`
 
 	for _, tt := range lsTests() {
-		end := len(tt.name)
-		switch {
-		case strings.HasSuffix(tt.name, "ses"):
-			end -= 2 // nolint: ineffassign
-		case strings.HasSuffix(tt.name, "jobs"):
-			//lint:ignore SA4011 egoscale v1 is deprecated no need to fix linting issues
-			break
-		default:
-			end-- // nolint: ineffassign
-		}
 		responses := make([]response, len(tt.listables))
 		for i := range tt.listables {
 			responses[i] = response{200, jsonContentType, fmt.Sprintf(body, tt.name, tt.fieldName)}
@@ -592,6 +582,16 @@ func TestClientPaginate(t *testing.T) {
 	}}`
 
 	for _, tt := range lsTests() {
+		end := len(tt.name)
+		switch {
+		case strings.HasSuffix(tt.name, "ses"):
+			end -= 2 // nolint: ineffassign
+		case strings.HasSuffix(tt.name, "jobs"):
+			//lint:ignore SA4011 egoscale v1 is deprecated no need to fix linting issues
+			break
+		default:
+			end-- // nolint: ineffassign
+		}
 		responses := make([]response, len(tt.listables))
 		for i := range tt.listables {
 			responses[i] = response{200, jsonContentType, fmt.Sprintf(body, tt.name, tt.fieldName)}

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,4 @@
+//lint:file-ignore SA4006 egoscale v1 is deprecated
 package egoscale
 
 import (
@@ -549,6 +550,16 @@ func TestClientList(t *testing.T) {
 	}}`
 
 	for _, tt := range lsTests() {
+		end := len(tt.name)
+		switch {
+		case strings.HasSuffix(tt.name, "ses"):
+			end -= 2 // nolint: ineffassign
+		case strings.HasSuffix(tt.name, "jobs"):
+			//lint:ignore SA4011 egoscale v1 is deprecated no need to fix linting issues
+			break
+		default:
+			end-- // nolint: ineffassign
+		}
 		responses := make([]response, len(tt.listables))
 		for i := range tt.listables {
 			responses[i] = response{200, jsonContentType, fmt.Sprintf(body, tt.name, tt.fieldName)}

--- a/client_test.go
+++ b/client_test.go
@@ -581,16 +581,6 @@ func TestClientPaginate(t *testing.T) {
 	}}`
 
 	for _, tt := range lsTests() {
-		end := len(tt.name)
-		switch {
-		case strings.HasSuffix(tt.name, "ses"):
-			end -= 2 // nolint: ineffassign
-		case strings.HasSuffix(tt.name, "jobs"):
-			//lint:ignore SA4011 egoscale v1 is deprecated no need to fix linting issues
-			break
-		default:
-			end-- // nolint: ineffassign
-		}
 		responses := make([]response, len(tt.listables))
 		for i := range tt.listables {
 			responses[i] = response{200, jsonContentType, fmt.Sprintf(body, tt.name, tt.fieldName)}


### PR DESCRIPTION
# Description

Ignore `SA4006` in the deprecated v1 client test while keeping Staticcheck enabled for v2. This leaves the dead v1 code unchanged and unblocks CI for #806.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
