### PR TITLE
fix: check http error for metadata package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+----------
+- v3: fix: check http error for metadata package - #812
+
 3.1.47
 ----------
 

--- a/v3/metadata/metadata.go
+++ b/v3/metadata/metadata.go
@@ -105,6 +105,10 @@ func httpGet(ctx context.Context, url string) (string, error) {
 		return "", err
 	}
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("bad http status, got: %d with body: %s", resp.StatusCode, string(body))
+	}
+
 	return string(body), nil
 }
 


### PR DESCRIPTION
# Description
All the http call made in the metadata package do not check the http status code from the response

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
