### PR TITLE
Fix error handling compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ change: delete unused return values vpc delete endpoints
 - v3 generator: fix response suffix and number parsing (#802)
 - v3: regenerate API spec - add DBaaS ClickHouse RBAC and Impact Report/Estimate endpoints (#800)
 
+- Fix error handling compatibility (#813)
+
 3.1.43
 ------
 

--- a/v3/errors.go
+++ b/v3/errors.go
@@ -118,7 +118,9 @@ type APIErrorEntry struct {
 	Location string
 }
 
-func (e *APIError) Error() string { return e.sentinel.Error() }
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.sentinel.Error(), e.Message)
+}
 func (e *APIError) Unwrap() error { return e.sentinel }
 
 func handleHTTPErrorResp(resp *http.Response) error {


### PR DESCRIPTION
# Description
Re-applies https://github.com/exoscale/egoscale/pull/798 after it got accidentally reverted in https://github.com/exoscale/egoscale/pull/766

Fixes issue in terraform-provider related to error message parsing.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
